### PR TITLE
develops model pattern to be more generic and reduce redundant code

### DIFF
--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -60,6 +60,10 @@ export type DeepPartial<T> = {
       : T[P];
 };
 
+export type Optional<T, P extends keyof T> = Omit<T, P> & {
+  [P in keyof T]?: T[P] | undefined;
+};
+
 export type ValueOf<T> = T[keyof T];
 
 export const assign = <T>(target: T, source: any) => {

--- a/src/server/lib/postgres/database.ts
+++ b/src/server/lib/postgres/database.ts
@@ -36,7 +36,7 @@ export interface UpsertOptions {
 
 export function buildCreateTable(
   tableName: string,
-  schema: Schema<Record<string, unknown>>,
+  schema: Schema,
   constraints: Constraints = [],
 ): string {
   const columnDefs = Object.entries(schema).map(

--- a/src/server/lib/postgres/repositories/accounts.ts
+++ b/src/server/lib/postgres/repositories/accounts.ts
@@ -72,7 +72,7 @@ export const upsertAccounts = async (
 
   for (const account of accounts) {
     try {
-      const row = AccountModel.toRow(account, user.user_id);
+      const row = AccountModel.fromJSON(account, user.user_id);
       await accountsTable.upsert(row);
       results.push(successResult(account.account_id, 1));
     } catch (error) {
@@ -92,7 +92,7 @@ export const updateAccounts = async (
 
   for (const account of accounts) {
     try {
-      const row = AccountModel.toRow(account, user.user_id);
+      const row = AccountModel.fromJSON(account, user.user_id);
       delete row.account_id;
       delete row.user_id;
 

--- a/src/server/lib/postgres/repositories/budgets.ts
+++ b/src/server/lib/postgres/repositories/budgets.ts
@@ -40,7 +40,7 @@ export const createBudget = async (
   data: Partial<JSONBudget>,
 ): Promise<JSONBudget | null> => {
   try {
-    const row = BudgetModel.toRow(
+    const row = BudgetModel.fromJSON(
       {
         name: data.name || "New Budget",
         iso_currency_code: data.iso_currency_code || "USD",
@@ -119,7 +119,7 @@ export const createSection = async (
   data: Partial<JSONSection>,
 ): Promise<JSONSection | null> => {
   try {
-    const row = SectionModel.toRow(
+    const row = SectionModel.fromJSON(
       {
         budget_id: data.budget_id,
         name: data.name || "New Section",
@@ -194,7 +194,7 @@ export const createCategory = async (
   data: Partial<JSONCategory>,
 ): Promise<JSONCategory | null> => {
   try {
-    const row = CategoryModel.toRow(
+    const row = CategoryModel.fromJSON(
       {
         section_id: data.section_id,
         name: data.name || "New Category",

--- a/src/server/lib/postgres/repositories/holdings.ts
+++ b/src/server/lib/postgres/repositories/holdings.ts
@@ -60,7 +60,7 @@ export const upsertHoldings = async (
 
   for (const holding of holdings) {
     try {
-      const row = HoldingModel.toRow(holding, user.user_id);
+      const row = HoldingModel.fromJSON(holding, user.user_id);
       const holdingId =
         (row.holding_id as string) || `${holding.account_id}-${holding.security_id}`;
       await holdingsTable.upsert(row);
@@ -84,7 +84,7 @@ export const updateHoldings = async (
   for (const holding of holdings) {
     const holdingId = holding.holding_id || `${holding.account_id}-${holding.security_id}`;
     try {
-      const row = HoldingModel.toRow(holding, user.user_id);
+      const row = HoldingModel.fromJSON(holding, user.user_id);
       delete row.holding_id;
       delete row.user_id;
 

--- a/src/server/lib/postgres/repositories/institutions.ts
+++ b/src/server/lib/postgres/repositories/institutions.ts
@@ -31,7 +31,7 @@ export const upsertInstitutions = async (
 
   for (const institution of institutions) {
     try {
-      const row = InstitutionModel.toRow(institution);
+      const row = InstitutionModel.fromJSON(institution);
       await institutionsTable.upsert(row);
       results.push(successResult(institution.institution_id, 1));
     } catch (error) {

--- a/src/server/lib/postgres/repositories/investment_transactions.ts
+++ b/src/server/lib/postgres/repositories/investment_transactions.ts
@@ -1,7 +1,7 @@
 import { JSONInvestmentTransaction } from "common";
 import {
   MaskedUser,
-  InvestmentTransactionModel,
+  InvTxModel,
   investmentTransactionsTable,
   INVESTMENT_TRANSACTION_ID,
   ACCOUNT_ID,
@@ -45,7 +45,7 @@ export const getInvestmentTransactions = async (
     offset: options.offset,
   });
   const result = await pool.query<Record<string, unknown>>(sql, values);
-  return result.rows.map((row) => new InvestmentTransactionModel(row).toJSON());
+  return result.rows.map((row) => new InvTxModel(row).toJSON());
 };
 
 export const getInvestmentTransaction = async (
@@ -75,7 +75,7 @@ export const upsertInvestmentTransactions = async (
 
   for (const tx of transactions) {
     try {
-      const row = InvestmentTransactionModel.toRow(tx, user.user_id);
+      const row = InvTxModel.fromJSON(tx, user.user_id);
       await investmentTransactionsTable.upsert(row);
       results.push(successResult(tx.investment_transaction_id, 1));
     } catch (error) {
@@ -98,7 +98,7 @@ export const updateInvestmentTransactions = async (
 
   for (const tx of transactions) {
     try {
-      const row = InvestmentTransactionModel.toRow(tx, user.user_id);
+      const row = InvTxModel.fromJSON(tx, user.user_id);
       delete row.investment_transaction_id;
       delete row.user_id;
 

--- a/src/server/lib/postgres/repositories/items.ts
+++ b/src/server/lib/postgres/repositories/items.ts
@@ -88,7 +88,7 @@ export const upsertItems = async (
 
   for (const item of items) {
     try {
-      const row = ItemModel.toRow(item, user.user_id);
+      const row = ItemModel.fromJSON(item, user.user_id);
       if (upsert) {
         await itemsTable.upsert(row);
         results.push(successResult(item.item_id, 1));

--- a/src/server/lib/postgres/repositories/securities.ts
+++ b/src/server/lib/postgres/repositories/securities.ts
@@ -40,7 +40,7 @@ export const upsertSecurities = async (securities: JSONSecurity[]): Promise<Upse
 
   for (const security of securities) {
     try {
-      const row = SecurityModel.toRow(security);
+      const row = SecurityModel.fromJSON(security);
       await securitiesTable.upsert(row);
       results.push(successResult(security.security_id, 1));
     } catch (error) {

--- a/src/server/lib/postgres/repositories/split_transactions.ts
+++ b/src/server/lib/postgres/repositories/split_transactions.ts
@@ -67,7 +67,7 @@ export const upsertSplitTransactions = async (
 
   for (const tx of transactions) {
     try {
-      const row = SplitTransactionModel.toRow(tx, user.user_id);
+      const row = SplitTransactionModel.fromJSON(tx, user.user_id);
       const result = await splitTransactionsTable.upsert(row);
       const id = result ? (result.split_transaction_id as string) : tx.split_transaction_id;
       results.push(successResult(id, 1));
@@ -88,7 +88,7 @@ export const updateSplitTransactions = async (
 
   for (const tx of transactions) {
     try {
-      const row = SplitTransactionModel.toRow(tx, user.user_id);
+      const row = SplitTransactionModel.fromJSON(tx, user.user_id);
       delete row.split_transaction_id;
       delete row.user_id;
 
@@ -133,7 +133,7 @@ export const createSplitTransaction = async (
   user: MaskedUser,
   input: { transaction_id: string; account_id: string },
 ): Promise<JSONSplitTransaction> => {
-  const row = SplitTransactionModel.toRow(
+  const row = SplitTransactionModel.fromJSON(
     {
       transaction_id: input.transaction_id,
       account_id: input.account_id,

--- a/src/server/lib/postgres/repositories/transactions.ts
+++ b/src/server/lib/postgres/repositories/transactions.ts
@@ -2,7 +2,7 @@ import { JSONTransaction, JSONInvestmentTransaction } from "common";
 import {
   MaskedUser,
   TransactionModel,
-  InvestmentTransactionModel,
+  InvTxModel,
   transactionsTable,
   splitTransactionsTable,
   TRANSACTION_ID,
@@ -85,9 +85,7 @@ export const searchTransactions = async (
     offset: options.offset,
   });
   const result = await pool.query<Record<string, unknown>>(sql, values);
-  const investment_transactions = result.rows.map((row) =>
-    new InvestmentTransactionModel(row).toJSON(),
-  );
+  const investment_transactions = result.rows.map((row) => new InvTxModel(row).toJSON());
 
   return { transactions, investment_transactions };
 };
@@ -110,7 +108,7 @@ export const upsertTransactions = async (
 
   for (const tx of transactions) {
     try {
-      const row = TransactionModel.toRow(tx, user.user_id);
+      const row = TransactionModel.fromJSON(tx, user.user_id);
       await transactionsTable.upsert(row);
       results.push(successResult(tx.transaction_id, 1));
     } catch (error) {
@@ -130,7 +128,7 @@ export const updateTransactions = async (
 
   for (const tx of transactions) {
     try {
-      const row = TransactionModel.toRow(tx, user.user_id);
+      const row = TransactionModel.fromJSON(tx, user.user_id);
       delete row.transaction_id;
       delete row.user_id;
 
@@ -212,9 +210,7 @@ export const searchTransactionsByAccountId = async (
 
   return {
     transactions: txResult.rows.map((row) => new TransactionModel(row).toJSON()),
-    investment_transactions: invResult.rows.map((row) =>
-      new InvestmentTransactionModel(row).toJSON(),
-    ),
+    investment_transactions: invResult.rows.map((row) => new InvTxModel(row).toJSON()),
   };
 };
 


### PR DESCRIPTION
## Background

Previously we refactored Postgres data model to streamline type assertion and conversion between DB data, runtime data and API data types. This PR develops the model pattern to further extend the modeling strategy.

## Changes

1. Changes the abstract `Model` class to take over the initialization of the data by owning type assertion and data assignment.

2. Changes individual model definitions to incorporate with the parent model changes and add stricter association between schema, model and row types