### PR TITLE
feat: add test coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dev-client": "vite",
     "dev-server": "bun --watch ./src/server/start.ts",
     "test": "bun test",
+    "test:coverage": "bun test --coverage",
     "preview": "vite preview"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Adds `test:coverage` npm script using Bun's built-in coverage support.

## Changes
- Added `"test:coverage": "bun test --coverage"` to package.json scripts

## Usage
```bash
bun run test:coverage
```

Output shows per-file function/line coverage with uncovered line numbers.

## Current coverage
- **42.82% functions**
- **75.78% lines**

Relates to #13 (CI integration to follow in separate PR)