### PR TITLE
ci: fix codecov rate limiting for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
       - name: Run tests with coverage
         run: bun run test:coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info
-          # Token required for reliable uploads - tokenless hits rate limits
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          # Don't fail CI for fork PRs (secrets not available)
+          fail_ci_if_error: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           verbose: true
 
   build:


### PR DESCRIPTION
Same fix as hoiekim/inbox PR #11 (commit a8d5b8a):

- Upgrade to codecov-action@v5
- Only fail CI on codecov errors for non-fork PRs (secrets unavailable for fork PRs)

Fork PRs can't access repository secrets, so codecov falls back to tokenless upload which gets rate limited.