### PR TITLE
ci: add ESLint linting step to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           restore-keys: bun-
       - name: Install dependencies
         run: bun install
+      - name: Lint
+        run: bun run lint
       - name: Run tests with coverage
         run: bun run test:coverage
 


### PR DESCRIPTION
Adds ESLint check to the CI workflow to catch code quality issues before tests run.

## Dependencies
- ⚠️ Requires #39 to be merged first (ESLint setup)

## Changes
- Added `bun run lint` step to CI after dependency installation
- Runs before tests to fail fast on lint errors

## Notes
- Currently ESLint is configured with warnings only (~100 existing warnings)
- Warnings are visible in CI output but don't block PRs
- Issue #41 tracks upgrading warnings to errors

Closes #47