### PR TITLE
fix: add BodyInit cast for call.post body parameter

### DIFF
--- a/src/client/lib/call.ts
+++ b/src/client/lib/call.ts
@@ -19,7 +19,7 @@ const call = async <T = unknown>(path: string, options?: RequestInit) => {
 };
 
 call.get = <T>(path: string) => call<T>(path);
-call.post = <T>(path: string, body: unknown) => call<T>(path, { method: "POST", body });
+call.post = <T>(path: string, body: unknown) => call<T>(path, { method: "POST", body: body as BodyInit });
 call.delete = <T>(path: string) => call<T>(path, { method: "DELETE" });
 
 export { call };


### PR DESCRIPTION
## Problem

CI failing with TypeScript error:
```
src/client/lib/call.ts(22,81): error TS2322: Type 'unknown' is not assignable to type 'BodyInit | null | undefined'.
```

## Fix

Add explicit `as BodyInit` cast. The body gets `JSON.stringify`'d inside `call()` anyway, so this cast is safe.

## Testing

- `bun run --bun tsc --noEmit` passes
- `bun test` passes (31 tests)