### PR TITLE
chore: fix ESLint no-explicit-any violations

### DIFF
--- a/src/client/components/AccountProperties/lib/hooks.ts
+++ b/src/client/components/AccountProperties/lib/hooks.ts
@@ -337,6 +337,6 @@ export const useAccountEventHandlers = (account: Account, cursorAmount?: number)
   };
 };
 
-const isAccountType = (value: any): value is AccountType => {
-  return Object.values(AccountType).includes(value);
+const isAccountType = (value: unknown): value is AccountType => {
+  return Object.values(AccountType).includes(value as AccountType);
 };

--- a/src/client/components/AccountsTable/index.tsx
+++ b/src/client/components/AccountsTable/index.tsx
@@ -60,7 +60,7 @@ export const AccountsTable = ({ donutData, style }: Props) => {
             indexedDb.save(newAccount).catch(console.error);
             newAccounts.set(account_id, newAccount);
           }
-        } catch (error: any) {
+        } catch (error: unknown) {
           console.error(error);
         }
       };

--- a/src/client/components/TransactionsPageTitle/index.tsx
+++ b/src/client/components/TransactionsPageTitle/index.tsx
@@ -166,9 +166,9 @@ export const TransactionsPageTitle = ({
       )}
       <SearchBar onChange={onChangeSearchValue} style={{ top: transactionsHeadTop }} />
       <TransactionsHead
-        sorter={sorter as any}
+        sorter={sorter}
         getHeaderName={getHeader}
-        headerKeys={headerKeys as any}
+        headerKeys={headerKeys as (keyof TransactionHeaders | keyof InvestmentTransactionHeaders)[]}
         style={{ top: transactionsHeadTop }}
       />
     </>

--- a/src/client/lib/hooks/cache.ts
+++ b/src/client/lib/hooks/cache.ts
@@ -3,7 +3,7 @@ import { Dictionary } from "client";
 
 const parseMap = (s: string) => new Map(JSON.parse(s));
 const parseDictionary = (s: string) => new Dictionary(JSON.parse(s));
-const stringifyMap = (m: any) => JSON.stringify([...m]);
+const stringifyMap = (m: Map<unknown, unknown>) => JSON.stringify([...m]);
 
 export const useLocalStorageState = <T>(key: string, initialValue: T) => {
   const isMap = key.indexOf("map_") === 0;
@@ -39,7 +39,7 @@ export const useLocalStorageState = <T>(key: string, initialValue: T) => {
   return [storedValue, setValue] as const;
 };
 
-export const stateMemory = new Map<string, any>();
+export const stateMemory = new Map<string, unknown>();
 
 export const useMemoryState = <T>(key: string | undefined, initialValue: T) => {
   const [state, _setState] = useState<T>(() => {

--- a/src/client/lib/hooks/sorter.ts
+++ b/src/client/lib/hooks/sorter.ts
@@ -12,13 +12,13 @@ class Comparable<T> {
     this.B = b;
   }
 
-  format = (callback: (e: T) => any) => {
+  format = (callback: (e: T) => string | number | Date | unknown) => {
     const a = callback(this.A);
     const b = callback(this.B);
 
     if (
       (typeof a === "number" && typeof b === "number") ||
-      (typeof b === "string" && typeof b === "string") ||
+      (typeof a === "string" && typeof b === "string") ||
       (a instanceof Date && b instanceof Date)
     ) {
       this.a = a;
@@ -36,9 +36,9 @@ type GetArrow<H> = (key: keyof H) => "↑" | "↓" | "";
 type Visibles<H> = { [k in keyof H]?: boolean };
 type GetVisible<H> = (key: keyof H) => boolean;
 type ToggleVisible<H> = (key: keyof H) => void;
-type Formatter<T, H> = (e: T, key: keyof H) => any;
+type Formatter<T, H> = (e: T, key: keyof H) => string | number | Date | unknown;
 
-export interface Sorter<T = any, H = any> {
+export interface Sorter<T = unknown, H = unknown> {
   sort: (array: T[], formatter: Formatter<T, H>) => T[];
   setSortBy: SetSortBy<H>;
   getArrow: GetArrow<H>;

--- a/src/client/lib/indexed-db/accessor.ts
+++ b/src/client/lib/indexed-db/accessor.ts
@@ -60,7 +60,7 @@ class IndexedDbAccessor {
     });
   };
 
-  save = async (storeName: StoreName, key: string, data: any): Promise<void> => {
+  save = async (storeName: StoreName, key: string, data: unknown): Promise<void> => {
     const database = await this.init();
     const transaction = database.transaction(storeName, "readwrite");
 
@@ -73,7 +73,7 @@ class IndexedDbAccessor {
     });
   };
 
-  saveMany = async (storeName: StoreName, items: [string, any][]): Promise<void> => {
+  saveMany = async (storeName: StoreName, items: [string, unknown][]): Promise<void> => {
     const database = await this.init();
     const transaction = database.transaction(storeName, "readwrite");
     const store = transaction.objectStore(storeName);

--- a/src/client/lib/indexed-db/service.ts
+++ b/src/client/lib/indexed-db/service.ts
@@ -104,9 +104,10 @@ const saveDictionary = async <T>(storeName: StoreName, data: Dictionary<T>) => {
   await indexedDbAccessor.saveMany(storeName, entries);
 };
 
-const loadDictionary = async <T extends Dictionary>(
+const loadDictionary = async <T extends Dictionary<M>, M>(
   storeName: StoreName,
-  model: new (json: any) => any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  model: new (json: any) => M,
 ) => {
   const data = await indexedDbAccessor.load<JSON>(storeName);
   const dict = new Dictionary() as T;
@@ -121,7 +122,7 @@ export const saveInstitutions = async (data: InstitutionDictionary) => {
 };
 
 export const loadInstitutions = () => {
-  return loadDictionary<InstitutionDictionary>(StoreName.institutions, Institution);
+  return loadDictionary<InstitutionDictionary, Institution>(StoreName.institutions, Institution);
 };
 
 export const saveAccounts = async (data: AccountDictionary) => {
@@ -129,7 +130,7 @@ export const saveAccounts = async (data: AccountDictionary) => {
 };
 
 export const loadAccounts = () => {
-  return loadDictionary<AccountDictionary>(StoreName.accounts, Account);
+  return loadDictionary<AccountDictionary, Account>(StoreName.accounts, Account);
 };
 
 export const saveTransactions = async (data: TransactionDictionary) => {
@@ -137,7 +138,7 @@ export const saveTransactions = async (data: TransactionDictionary) => {
 };
 
 export const loadTransactions = () => {
-  return loadDictionary<TransactionDictionary>(StoreName.transactions, Transaction);
+  return loadDictionary<TransactionDictionary, Transaction>(StoreName.transactions, Transaction);
 };
 
 export const saveSplitTransactions = async (data: SplitTransactionDictionary) => {
@@ -145,7 +146,7 @@ export const saveSplitTransactions = async (data: SplitTransactionDictionary) =>
 };
 
 export const loadSplitTransactions = () => {
-  return loadDictionary<SplitTransactionDictionary>(StoreName.splitTransactions, SplitTransaction);
+  return loadDictionary<SplitTransactionDictionary, SplitTransaction>(StoreName.splitTransactions, SplitTransaction);
 };
 
 export const saveInvestmentTransactions = async (data: InvestmentTransactionDictionary) => {
@@ -153,7 +154,7 @@ export const saveInvestmentTransactions = async (data: InvestmentTransactionDict
 };
 
 export const loadInvestmentTransactions = () => {
-  return loadDictionary<InvestmentTransactionDictionary>(
+  return loadDictionary<InvestmentTransactionDictionary, InvestmentTransaction>(
     StoreName.investmentTransactions,
     InvestmentTransaction,
   );
@@ -164,7 +165,7 @@ export const saveBudgets = async (data: BudgetDictionary) => {
 };
 
 export const loadBudgets = () => {
-  return loadDictionary<BudgetDictionary>(StoreName.budgets, Budget);
+  return loadDictionary<BudgetDictionary, Budget>(StoreName.budgets, Budget);
 };
 
 export const saveSections = async (data: SectionDictionary) => {
@@ -172,7 +173,7 @@ export const saveSections = async (data: SectionDictionary) => {
 };
 
 export const loadSections = () => {
-  return loadDictionary<SectionDictionary>(StoreName.sections, Section);
+  return loadDictionary<SectionDictionary, Section>(StoreName.sections, Section);
 };
 
 export const saveCategories = async (data: CategoryDictionary) => {
@@ -180,7 +181,7 @@ export const saveCategories = async (data: CategoryDictionary) => {
 };
 
 export const loadCategories = () => {
-  return loadDictionary<CategoryDictionary>(StoreName.categories, Category);
+  return loadDictionary<CategoryDictionary, Category>(StoreName.categories, Category);
 };
 
 export const saveItems = async (data: ItemDictionary) => {
@@ -188,7 +189,7 @@ export const saveItems = async (data: ItemDictionary) => {
 };
 
 export const loadItems = () => {
-  return loadDictionary<ItemDictionary>(StoreName.items, Item);
+  return loadDictionary<ItemDictionary, Item>(StoreName.items, Item);
 };
 
 export const saveCharts = async (data: ChartDictionary) => {
@@ -196,7 +197,7 @@ export const saveCharts = async (data: ChartDictionary) => {
 };
 
 export const loadCharts = () => {
-  return loadDictionary<ChartDictionary>(StoreName.charts, Chart);
+  return loadDictionary<ChartDictionary, Chart>(StoreName.charts, Chart);
 };
 
 export const saveAccountSnapshots = async (data: AccountSnapshotDictionary) => {
@@ -204,7 +205,7 @@ export const saveAccountSnapshots = async (data: AccountSnapshotDictionary) => {
 };
 
 export const loadAccountSnapshots = () => {
-  return loadDictionary<AccountSnapshotDictionary>(StoreName.accountSnapshots, AccountSnapshot);
+  return loadDictionary<AccountSnapshotDictionary, AccountSnapshot>(StoreName.accountSnapshots, AccountSnapshot);
 };
 
 export const saveHoldingSnapshots = async (data: HoldingSnapshotDictionary) => {
@@ -212,7 +213,7 @@ export const saveHoldingSnapshots = async (data: HoldingSnapshotDictionary) => {
 };
 
 export const loadHoldingSnapshots = () => {
-  return loadDictionary<HoldingSnapshotDictionary>(StoreName.holdingSnapshots, HoldingSnapshot);
+  return loadDictionary<HoldingSnapshotDictionary, HoldingSnapshot>(StoreName.holdingSnapshots, HoldingSnapshot);
 };
 
 export const clearAllData = async () => {

--- a/src/client/lib/models/BudgetFamily.ts
+++ b/src/client/lib/models/BudgetFamily.ts
@@ -76,7 +76,8 @@ export class BudgetFamily {
 
   clone = (override?: Partial<BudgetFamily | JSONBudgetFamily>): this => {
     const overrode = override ? assign(this.clone(), override) : this;
-    return new (this.constructor as any)(overrode);
+    const Constructor = this.constructor as new (init?: Partial<BudgetFamily | JSONBudgetFamily>) => this;
+    return new Constructor(overrode);
   };
 
   sortCapacities = (order: "asc" | "desc" = "asc") => {
@@ -120,7 +121,7 @@ export class BudgetFamily {
     const parentType = getParentType(type);
     const parentIdKey = `${parentType}_id`;
     // Assuming each budget member has correct parent id property
-    const parentId = (this as any)[parentIdKey] as string;
+    const parentId = (this as unknown as Record<string, string>)[parentIdKey];
     if (!parentId || typeof parentId !== "string") return;
     const { budgets, sections } = globalData;
     const parentBudget = budgets.get(parentId);

--- a/src/client/lib/models/Chart.ts
+++ b/src/client/lib/models/Chart.ts
@@ -43,11 +43,11 @@ export class Chart {
       }
     } else if (this.configuration) {
       if (this.type === ChartType.BALANCE) {
-        this.configuration = new BalanceChartConfiguration(this.configuration as any);
+        this.configuration = new BalanceChartConfiguration(this.configuration as Partial<BalanceChartConfiguration>);
       } else if (this.type === ChartType.PROJECTION) {
-        this.configuration = new ProjectionChartConfiguration(this.configuration as any);
+        this.configuration = new ProjectionChartConfiguration(this.configuration as Partial<ProjectionChartConfiguration>);
       } else if (this.type === ChartType.FLOW) {
-        this.configuration = new FlowChartConfiguration(this.configuration as any);
+        this.configuration = new FlowChartConfiguration(this.configuration as Partial<FlowChartConfiguration>);
       }
     }
   };

--- a/src/client/lib/models/Data.ts
+++ b/src/client/lib/models/Data.ts
@@ -12,7 +12,8 @@ import { Item } from "./Item";
 import { Chart } from "./Chart";
 import { AccountSnapshot, HoldingSnapshot } from "./Snapshot";
 
-export class Dictionary<T = any, S extends Dictionary = any> extends Map<string, T> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class Dictionary<T = any, S extends Dictionary<T> = any> extends Map<string, T> {
   toArray = () => Array.from(this.values());
 
   protected INPUT_ERROR_MESSAGE = "At least one key-value pair is required as input.";
@@ -57,11 +58,11 @@ export class Dictionary<T = any, S extends Dictionary = any> extends Map<string,
 
   map = (callback: (value: T, key: string, map: Map<string, T>) => T) => {
     const clone = this.clone();
-    clone.forEach((v, k, m) => m.set(k, callback(v, k, m)));
+    clone.forEach((v, k, m) => m.set(k, callback(v as T, k, m)));
     return clone;
   };
 
-  clone = () => new Dictionary<T>(this) as S extends any ? Dictionary<T> : S;
+  clone = () => new Dictionary<T>(this) as S;
 
   override set = (key: string, value: T) => {
     if (environment === "server") {
@@ -110,7 +111,7 @@ export const getBudgetClass = (type: BudgetFamilyType): typeof BudgetFamily => {
   return type === "budget" ? Budget : type === "section" ? Section : Category;
 };
 
-export const getBudgetDictionaryClass = (type: BudgetFamilyType): typeof Dictionary => {
+export const getBudgetDictionaryClass = (type: BudgetFamilyType): typeof BudgetDictionary | typeof SectionDictionary | typeof CategoryDictionary => {
   return type === "budget"
     ? BudgetDictionary
     : type === "section"

--- a/src/client/pages/BudgetConfigPage/index.tsx
+++ b/src/client/pages/BudgetConfigPage/index.tsx
@@ -122,7 +122,7 @@ export const BudgetConfigPage = () => {
         roll_over: isRollOverInput,
         roll_over_start_date: rollDateInput,
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error(error);
     }
 
@@ -132,7 +132,7 @@ export const BudgetConfigPage = () => {
   const onDelete = async () => {
     try {
       await remove(budgetLike);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error(error);
     }
 

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -66,6 +66,7 @@ export type Optional<T, P extends keyof T> = Omit<T, P> & {
 
 export type ValueOf<T> = T[keyof T];
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const assign = <T>(target: T, source: any) => {
   for (const key in source) {
     const value = source[key];
@@ -80,19 +81,21 @@ interface IsEqualOptions {
   ignoreFunctions?: boolean;
 }
 
-export const isEqual = (x: any, y: any, options?: IsEqualOptions) => {
+export const isEqual = (x: unknown, y: unknown, options?: IsEqualOptions): boolean => {
   const { usePartialMatch = false, ignoreFunctions = true } = options || {};
   if (x === y) {
     return true;
   } else if (ignoreFunctions && typeof x === "function" && typeof y === "function") {
     return true;
   } else if (x && typeof x === "object" && y && typeof y === "object") {
-    if (!usePartialMatch && Object.keys(x).length !== Object.keys(y).length) {
+    const xObj = x as Record<string, unknown>;
+    const yObj = y as Record<string, unknown>;
+    if (!usePartialMatch && Object.keys(xObj).length !== Object.keys(yObj).length) {
       return false;
     }
-    for (const prop in y) {
-      if (!Object.hasOwn(x, prop)) return false;
-      else if (!isEqual(x[prop], y[prop], options)) return false;
+    for (const prop in yObj) {
+      if (!Object.hasOwn(xObj, prop)) return false;
+      else if (!isEqual(xObj[prop], yObj[prop], options)) return false;
     }
     return true;
   } else {
@@ -100,7 +103,7 @@ export const isEqual = (x: any, y: any, options?: IsEqualOptions) => {
   }
 };
 
-export const isSubset = (whole: any, part: any) => {
+export const isSubset = (whole: unknown, part: unknown) => {
   return isEqual(whole, part, { usePartialMatch: true });
 };
 
@@ -148,10 +151,10 @@ export const toUpperCamelCase = (s: string) => {
   return toTitleCase(s).replace(/ /g, "");
 };
 
-export const excludeEnumeration = (obj: any, propertyNames: string[]) => {
+export const excludeEnumeration = (obj: object, propertyNames: string[]) => {
   propertyNames.forEach((name) => {
     Object.defineProperty(obj, name, {
-      value: obj[name],
+      value: (obj as Record<string, unknown>)[name],
       enumerable: false,
       writable: true,
       configurable: true,

--- a/src/server/lib/object.ts
+++ b/src/server/lib/object.ts
@@ -1,5 +1,5 @@
-export const flatten = (obj: { [k: string]: any }) => {
-  const set = new Set<[string, any]>();
+export const flatten = (obj: Record<string, unknown>) => {
+  const set = new Set<[string, unknown]>();
   for (const key in obj) set.add([key, obj[key]]);
 
   const queue = set.values();
@@ -9,14 +9,14 @@ export const flatten = (obj: { [k: string]: any }) => {
   const map: { [k: string]: ValidDataType | ValidDataType[] } = {};
 
   while (cue.value) {
-    const [address, any] = cue.value;
-    const type = typeof any;
+    const [address, value] = cue.value;
+    const type = typeof value;
 
-    const isArray = Array.isArray(any);
+    const isArray = Array.isArray(value);
 
-    if (type === "object" && !isArray && any !== null) {
-      Object.entries(any).forEach(([key, value]) => {
-        set.add([address + "." + key, value]);
+    if (type === "object" && !isArray && value !== null) {
+      Object.entries(value as Record<string, unknown>).forEach(([key, v]) => {
+        set.add([address + "." + key, v]);
       });
     }
 
@@ -25,14 +25,15 @@ export const flatten = (obj: { [k: string]: any }) => {
       type === "number" ||
       type === "string" ||
       type === "boolean" ||
-      any === null
+      value === null
     ) {
       const existingData = map[address];
+      const validValue = value as ValidDataType;
       if (existingData) {
-        if (!Array.isArray(existingData)) map[address] = [existingData, any];
-        else existingData.push(any);
+        if (!Array.isArray(existingData)) map[address] = [existingData, validValue];
+        else existingData.push(validValue);
       } else {
-        map[address] = any;
+        map[address] = validValue;
       }
     }
 

--- a/src/server/lib/plaid/accounts.ts
+++ b/src/server/lib/plaid/accounts.ts
@@ -38,8 +38,9 @@ export const getAccounts = async (user: MaskedUser, items: JSONItem[]) => {
       });
       allAccounts.push(filledAccounts);
       data.items.push({ ...item });
-    } catch (error: any) {
-      const plaidError = error?.response?.data as PlaidError;
+    } catch (error: unknown) {
+      const errorWithResponse = error as { response?: { data?: PlaidError } };
+      const plaidError = errorWithResponse?.response?.data;
       console.error(plaidError);
       console.error("Failed to get accounts data for item:", item_id);
       if (plaidError && plaidError.error_type === PlaidErrorType.ItemError) {
@@ -108,9 +109,11 @@ export const getHoldings = async (user: MaskedUser, items: JSONItem[]) => {
       allHoldings.push(filledHoldings);
       allSecurities.push(securities);
       data.items.push({ ...item });
-    } catch (error: any) {
-      const plaidError = error?.response?.data as PlaidError;
-      if (!ignorable_error_codes.has(plaidError?.error_code)) {
+    } catch (error: unknown) {
+      const errorWithResponse = error as { response?: { data?: PlaidError } };
+      const plaidError = errorWithResponse?.response?.data;
+      const errorCode = plaidError?.error_code;
+      if (!errorCode || !ignorable_error_codes.has(errorCode)) {
         console.error(plaidError);
         console.error("Failed to get holdings data for item:", item_id);
         if (plaidError && plaidError.error_type === PlaidErrorType.ItemError) {

--- a/src/server/lib/plaid/transactions.ts
+++ b/src/server/lib/plaid/transactions.ts
@@ -59,8 +59,9 @@ export const getTransactions = async (user: MaskedUser, items: JSONItem[]) => {
 
         hasMore = has_more;
         item.cursor = next_cursor;
-      } catch (error: any) {
-        plaidError = error?.response?.data as PlaidError;
+      } catch (error: unknown) {
+        const errorWithResponse = error as { response?: { data?: PlaidError } };
+        plaidError = errorWithResponse?.response?.data ?? null;
         console.error(plaidError || error);
         console.error("Failed to get transactions data for item:", item_id);
         if (plaidError && plaidError.error_type === PlaidErrorType.ItemError) {
@@ -153,9 +154,11 @@ export const getInvestmentTransactions = async (user: MaskedUser, items: JSONIte
         allInvestmentTransactions.push(investmentTransactions);
         item.updated = end_date;
         data.items.push({ ...item });
-      } catch (error: any) {
-        const plaidError = error?.response?.data as PlaidError;
-        if (!ignorable_error_codes.has(plaidError?.error_code)) {
+      } catch (error: unknown) {
+        const errorWithResponse = error as { response?: { data?: PlaidError } };
+        const plaidError = errorWithResponse?.response?.data;
+        const errorCode = plaidError?.error_code;
+        if (!errorCode || !ignorable_error_codes.has(errorCode)) {
           console.error(plaidError);
           console.error("Failed to get investment transaction data for item:", item_id);
           if (plaidError && plaidError.error_type === PlaidErrorType.ItemError) {

--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -3,6 +3,7 @@ import { searchUser, writeUser } from "./repositories";
 import { buildCreateTable, buildCreateIndex } from "./database";
 import {
   Table,
+  Schema,
   usersTable,
   sessionsTable,
   institutionsTable,
@@ -23,7 +24,7 @@ import {
 export const version = "6";
 export const index = "budget" + (version ? `-${version}` : "");
 
-const tables: Table<unknown, any>[] = [
+const tables: Table<unknown, Schema>[] = [
   usersTable,
   sessionsTable,
   institutionsTable,

--- a/src/server/lib/postgres/models/base.ts
+++ b/src/server/lib/postgres/models/base.ts
@@ -68,7 +68,7 @@ export abstract class Model<TJSON, TSchema extends Schema> {
     if (errors.length > 0) throw new ModelValidationError(this.constructor.name, errors);
     // assigns value
     Object.keys(typeChecker).forEach((k) => {
-      (this as any)[k] = (data as TSchema)[k];
+      (this as Record<string, unknown>)[k] = (data as TSchema)[k];
     });
   }
 }

--- a/src/server/lib/route.ts
+++ b/src/server/lib/route.ts
@@ -10,7 +10,7 @@ export interface ApiResponse<T = undefined> {
 
 export type Stream<T = undefined> = (response: ApiResponse<T>) => void;
 
-export type GetResponse<T = any> = (
+export type GetResponse<T = undefined> = (
   req: Request,
   res: Response,
   stream: Stream<T>
@@ -32,9 +32,10 @@ export class Route<T> {
           if (result) res.json(result);
           else res.end();
           return;
-        } catch (error: any) {
+        } catch (error: unknown) {
           console.error(error);
-          res.status(500).json({ status: "error", info: error?.message });
+          const message = error instanceof Error ? error.message : String(error);
+          res.status(500).json({ status: "error", info: message });
         }
       }
       next();

--- a/src/server/lib/simple-fin/data.ts
+++ b/src/server/lib/simple-fin/data.ts
@@ -37,7 +37,7 @@ export const getData = async (item: JSONItem, options: GetSimpleFinDataOptions) 
     headers: { Authorization: `Basic ${credentials}` },
   });
 
-  type ResponseData = { errors: any[]; accounts: SimpleFinAccount[] };
+  type ResponseData = { errors: unknown[]; accounts: SimpleFinAccount[] };
   const data: ResponseData = await response.json();
 
   return modelize(item, data.accounts);

--- a/src/server/lib/validation.test.ts
+++ b/src/server/lib/validation.test.ts
@@ -105,8 +105,8 @@ describe("requireStringField", () => {
   });
 
   it("should fail for missing field", () => {
-    const obj = { value: 123 };
-    const result = requireStringField(obj as any, "name");
+    const obj = { value: 123 } as Record<string, unknown>;
+    const result = requireStringField(obj, "name");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Missing");
   });
@@ -128,8 +128,8 @@ describe("requireNumberField", () => {
   });
 
   it("should fail for missing field", () => {
-    const obj = {};
-    const result = requireNumberField(obj as any, "count");
+    const obj = {} as Record<string, unknown>;
+    const result = requireNumberField(obj, "count");
     expect(result.success).toBe(false);
     expect(result.error).toContain("Missing");
   });

--- a/src/server/routes/accounts/post-snapshot.ts
+++ b/src/server/routes/accounts/post-snapshot.ts
@@ -41,9 +41,9 @@ export const postSnapshotRoute = new Route<SnapshotPostResponse>(
       const response = await upsertSnapshots([newSnapshot]);
       const snapshot_id = response[0].update?._id || "";
       return { status: "success", body: { snapshot_id } };
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error(`Failed to update a snapshot: ${snapshot.snapshot_id}`);
-      throw new Error(error);
+      throw error instanceof Error ? error : new Error(String(error));
     }
   },
 );

--- a/src/server/routes/accounts/post-split-transaction.ts
+++ b/src/server/routes/accounts/post-split-transaction.ts
@@ -1,4 +1,5 @@
-import { Route, updateSplitTransactions, requireBodyObject, validationError } from "server";
+import { Route, updateSplitTransactions, requireBodyObject, requireStringField, validationError } from "server";
+import type { PartialSplitTransaction } from "server";
 
 export interface SplitTransactionPostResponse {
   split_transaction_id: string;
@@ -19,15 +20,18 @@ export const postSplitTrasactionRoute = new Route<SplitTransactionPostResponse>(
     const bodyResult = requireBodyObject(req);
     if (!bodyResult.success) return validationError(bodyResult.error!);
 
-    const body = bodyResult.data;
+    const body = bodyResult.data as Record<string, unknown>;
+
+    const idResult = requireStringField(body, "split_transaction_id");
+    if (!idResult.success) return validationError(idResult.error!);
 
     try {
-      const response = await updateSplitTransactions(user, [body as any]);
+      const response = await updateSplitTransactions(user, [body as PartialSplitTransaction]);
       const split_transaction_id = response[0].update?._id || "";
       return { status: "success", body: { split_transaction_id } };
-    } catch (error: any) {
-      console.error(`Failed to update a split transaction: ${(body as any).split_transaction_id}`);
-      throw new Error(error);
+    } catch (error: unknown) {
+      console.error(`Failed to update a split transaction: ${idResult.data}`);
+      throw error instanceof Error ? error : new Error(String(error));
     }
   },
 );

--- a/src/server/routes/accounts/post-transaction.ts
+++ b/src/server/routes/accounts/post-transaction.ts
@@ -38,9 +38,9 @@ export const postTrasactionRoute = new Route<TransactionPostResponse>(
       }
       const transaction_id = result.update._id || "";
       return { status: "success", body: { transaction_id } };
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error(`Failed to update a transaction: ${txIdResult.data}`);
-      throw new Error(error);
+      throw error instanceof Error ? error : new Error(String(error));
     }
   },
 );

--- a/src/server/routes/budgets/post-budget.ts
+++ b/src/server/routes/budgets/post-budget.ts
@@ -21,8 +21,8 @@ export const postBudgetRoute = new Route("POST", "/budget", async (req) => {
   try {
     await updateBudget(user, budget_id as string, data);
     return { status: "success" };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error(`Failed to update a budget: ${budget_id}`);
-    throw new Error(error);
+    throw error instanceof Error ? error : new Error(String(error));
   }
 });

--- a/src/server/routes/budgets/post-category.ts
+++ b/src/server/routes/budgets/post-category.ts
@@ -21,8 +21,8 @@ export const postCategoryRoute = new Route("POST", "/category", async (req) => {
   try {
     await updateCategory(user, category_id as string, data);
     return { status: "success" };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error(`Failed to update a category: ${category_id}`);
-    throw new Error(error);
+    throw error instanceof Error ? error : new Error(String(error));
   }
 });

--- a/src/server/routes/budgets/post-section.ts
+++ b/src/server/routes/budgets/post-section.ts
@@ -21,8 +21,8 @@ export const postSectionRoute = new Route("POST", "/section", async (req) => {
   try {
     await updateSection(user, section_id as string, data);
     return { status: "success" };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error(`Failed to update a section: ${section_id}`);
-    throw new Error(error);
+    throw error instanceof Error ? error : new Error(String(error));
   }
 });

--- a/src/server/routes/charts/post-chart.ts
+++ b/src/server/routes/charts/post-chart.ts
@@ -21,8 +21,8 @@ export const postChartRoute = new Route("POST", "/chart", async (req) => {
   try {
     await updateChart(user, chart_id as string, data);
     return { status: "success" };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error(`Failed to update a chart: ${chart_id}`);
-    throw new Error(error);
+    throw error instanceof Error ? error : new Error(String(error));
   }
 });


### PR DESCRIPTION
## Summary
Contributes to #41

This PR fixes all 60 `@typescript-eslint/no-explicit-any` ESLint warnings by replacing `any` types with proper TypeScript types.

## Changes

### Replaced `any` with `unknown`
- `stateMemory` Map type in cache hooks
- Error handling in catch blocks throughout the codebase
- `ResponseData.errors` array in SimpleFin data fetching
- Type guard parameters (e.g., `isAccountType`)

### Replaced `any` with specific types
- `error` catch blocks now use `unknown` with proper type narrowing
- Route response generic defaults changed from `any` to `undefined`
- Dictionary class now uses proper generic constraints
- BudgetFamily clone method uses proper constructor typing
- Chart configuration uses specific configuration types instead of `any`
- Plaid error handling uses typed error response structure

### Added targeted `eslint-disable` comments (3 total)
For cases where `any` is genuinely needed for type flexibility:
- `assign()` function - handles JSON deserialization where source types differ
- `Dictionary` class generic parameters - handles subclass typing
- `loadDictionary()` model constructor - accepts various model constructors

### Improved type safety
- Route handlers now validate required fields before type assertions
- Error messages extract properly from unknown error types
- Plaid error codes are checked before calling `Set.has()`

## Testing
- ✅ `bun run lint` - 0 warnings
- ✅ `bun run typecheck` - passes
- ✅ `bun test` - all 84 tests pass