### PR TITLE
fix: add missing type argument to loadSecuritySnapshots

### DIFF
--- a/src/client/lib/indexed-db/service.ts
+++ b/src/client/lib/indexed-db/service.ts
@@ -223,7 +223,7 @@ export const saveSecuritySnapshots = async (data: SecuritySnapshotDictionary) =>
 };
 
 export const loadSecuritySnapshots = () => {
-  return loadDictionary<SecuritySnapshotDictionary>(StoreName.securitySnapshots, SecuritySnapshot);
+  return loadDictionary<SecuritySnapshotDictionary, SecuritySnapshot>(StoreName.securitySnapshots, SecuritySnapshot);
 };
 
 export const clearAllData = async () => {


### PR DESCRIPTION
## Summary
Fixes TypeScript compilation error in `loadSecuritySnapshots`.

## Problem
The `loadDictionary` function requires two type arguments:
```typescript
const loadDictionary = async <T extends Dictionary<M>, M>(...)
```

But `loadSecuritySnapshots` was only passing one:
```typescript
return loadDictionary<SecuritySnapshotDictionary>(StoreName.securitySnapshots, SecuritySnapshot);
```

## Solution
Add the missing `SecuritySnapshot` type argument to match the function signature and all other usages in the file.

## Self-Review

### Checked:
- [x] Verified all other `loadDictionary` calls have two type arguments
- [x] TypeScript now compiles successfully
- [x] This is a type-only change with no runtime impact

### E2E Testing:
- TypeScript compilation passes
- No functional changes to test

### Confidence: High