### PR TITLE
fix: preserve MAX_FLOAT in yearly capacity calculation

### DIFF
--- a/src/client/lib/models/Capacity.ts
+++ b/src/client/lib/models/Capacity.ts
@@ -20,6 +20,10 @@ export class Capacity {
   capacity_id!: string;
 
   get year() {
+    // Preserve MAX_FLOAT for infinite capacities to avoid overflow
+    if (this.isInfinite) {
+      return this.month > 0 ? MAX_FLOAT : -MAX_FLOAT;
+    }
     return this.month * 12;
   }
 


### PR DESCRIPTION
## Problem
Yearly budget view showed scientific notation overflow for Non-budgeted and Transfers (e.g., `$ 4.0833882804e+39`).

## Root Cause
Non-budgeted and Transfers use `MAX_FLOAT` (3.402823567e38) as a sentinel value for "unlimited" capacity. The `year` getter in the Capacity class was simply returning `month * 12`, causing `MAX_FLOAT * 12 = 4.08e39` overflow.

The `isInfinite` check in `LabeledBar` compared against `MAX_FLOAT`, but the overflowed value didn't match, so the scientific notation was displayed instead of being treated as infinite.

## Fix
The `year` getter now checks `isInfinite` and preserves `MAX_FLOAT` with the appropriate sign, ensuring infinite capacities remain infinite in yearly view.

## Testing
- [x] TypeScript compiles (`bun run typecheck`)
- [x] All tests pass (`bun test`)
- [x] E2E tested: Started app locally, navigated to Budgets in yearly view (2026), verified Non-budgeted and Transfers show only "$ 0 spent" without overflow values

Closes #108