### PR TITLE
fix(dashboard): use getAccountBalance for investment accounts

### DIFF
--- a/src/client/components/BalanceChartRow/index.tsx
+++ b/src/client/components/BalanceChartRow/index.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, MouseEventHandler, SetStateAction } from "react";
 import { AccountType } from "plaid";
 import { numberToCommaString, toTitleCase } from "common";
-import { BalanceChart, useAppContext, useReorder } from "client";
+import { BalanceChart, getAccountBalance, useAppContext, useReorder } from "client";
 import { ChevronDownIcon, ChevronUpIcon, QuestionIcon } from "client/components";
 import { ColumnData, StackData, Stacks } from "./Stacks";
 import "./index.css";
@@ -42,7 +42,7 @@ export const BalanceChartRow = ({
 
   accounts.forEach((a) => {
     if (a.hide) return;
-    const stack = { type: a.type, name: a.custom_name || a.name, amount: a.balances.current || 0 };
+    const stack = { type: a.type, name: a.custom_name || a.name, amount: getAccountBalance(a) };
     if (!configuration.account_ids.includes(a.id)) return;
     if (a.type === AccountType.Depository) column1.push(stack);
     else if (a.type === AccountType.Investment) column1.push(stack);


### PR DESCRIPTION
## Summary
BalanceChartRow was using `a.balances.current || 0` directly, which returns incorrect values for investment accounts. Investment accounts should use holdings value (sum of securities) instead of `balances.current`.

## Changes
- Import `getAccountBalance` from client
- Replace `a.balances.current || 0` with `getAccountBalance(a)`

## Testing
- TypeScript compiles successfully
- All existing tests pass
- The fix uses the same helper function already used in AccountsPage, ensuring consistent behavior

## Root Cause
The Dashboard's BalanceChartRow component was accessing `balances.current` directly, while the Accounts page uses `getAccountBalance()` which correctly handles investment accounts by returning holdings value when available.

Closes #105