### PR TITLE
security: ignore .env files by default in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@
 
 # misc
 .DS_Store
+.env
 .env.*
-!.env
 !.env.example
 
 npm-debug.log*


### PR DESCRIPTION
## Problem

The `.gitignore` had:
```
.env.*
!.env
!.env.example
```

The `!.env` line explicitly **un-ignores** `.env`, meaning real environment files containing secrets can be accidentally committed to the public repo. This exact pattern caused an incident in the inbox repo.

## Fix

```
.env
.env.*
!.env.example
```

All `.env` files are now ignored by default. Only `.env.example` (template with no secrets) is tracked.

## E2E Testing
- Verified `git check-ignore -v .env` now correctly reports the file as ignored
- `.env.example` still tracked (no change)
- No functional code changes

Closes #124