### PR TITLE
fix: return structured error when Plaid not configured on /api/link-token

### DIFF
--- a/src/server/lib/plaid/index.ts
+++ b/src/server/lib/plaid/index.ts
@@ -6,4 +6,5 @@ export * from "./accounts";
 export * from "./transactions";
 export * from "./institutions";
 export * from "./tokens";
+export * from "./util";
 export * from "./webhook";

--- a/src/server/lib/plaid/util.ts
+++ b/src/server/lib/plaid/util.ts
@@ -4,11 +4,12 @@ import { MaskedUser, logger } from "server";
 const { PLAID_CLIENT_ID, PLAID_SECRET_PRODUCTION, PLAID_SECRET_DEVELOPMENT, PLAID_SECRET_SANDBOX } =
   process.env;
 
-if (
-  !PLAID_CLIENT_ID ||
-  !(PLAID_SECRET_PRODUCTION || PLAID_SECRET_DEVELOPMENT) ||
-  !PLAID_SECRET_SANDBOX
-) {
+export const isPlaidConfigured =
+  !!PLAID_CLIENT_ID &&
+  !!(PLAID_SECRET_PRODUCTION || PLAID_SECRET_DEVELOPMENT) &&
+  !!PLAID_SECRET_SANDBOX;
+
+if (!isPlaidConfigured) {
   logger.warn("Plaid is not configured. Check env vars.");
 }
 

--- a/src/server/routes/users/get-link-token.ts
+++ b/src/server/routes/users/get-link-token.ts
@@ -14,6 +14,13 @@ export const getLinkTokenRoute = new Route<LinkTokenGetResponse>(
       };
     }
 
+    if (!plaid.isPlaidConfigured) {
+      return {
+        status: "failed",
+        message: "Plaid integration is not configured on this server.",
+      };
+    }
+
     const accessTokenResult = optionalQueryString(req, "access_token");
     if (!accessTokenResult.success) return validationError(accessTokenResult.error!);
 


### PR DESCRIPTION
## Problem

`/api/link-token` returned 500 when Plaid environment variables weren't configured. The Plaid client was constructed with `undefined` credentials and threw an opaque network/auth error, surfacing as an internal server error.

## Fix

Export `isPlaidConfigured` from `src/server/lib/plaid/util.ts` — reusing the same boolean condition already used for the startup warning log. The route checks this flag before attempting the API call and returns a clear error response.

```
{ status: "failed", message: "Plaid integration is not configured on this server." }
```

## Testing

- `npx tsc --noEmit` — clean
- When Plaid env vars are unset: endpoint returns `{ status: "failed", message: "Plaid integration is not configured on this server." }` instead of 500

Closes #121