### PR TITLE
security/reliability: reduce JSON body limit and add process error handlers

### DIFF
--- a/src/server/lib/postgres/client.ts
+++ b/src/server/lib/postgres/client.ts
@@ -48,6 +48,20 @@ process.on("SIGTERM", async () => {
   process.exit(0);
 });
 
+process.on("unhandledRejection", (reason) => {
+  console.error("Unhandled promise rejection:", reason);
+});
+
+process.on("uncaughtException", async (error) => {
+  console.error("Uncaught exception:", error);
+  try {
+    await pool.end();
+  } catch (e) {
+    // ignore pool shutdown errors during crash
+  }
+  process.exit(1);
+});
+
 /**
  * Execute a function within a database transaction.
  * Automatically handles BEGIN, COMMIT, and ROLLBACK.

--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -21,7 +21,7 @@ if (process.env.NODE_ENV === "production") {
 // Parse JSON and store raw body for webhook verification
 app.use(
   express.json({
-    limit: "50mb",
+    limit: "1mb",
     verify: (req, _res, buf) => {
       // Store raw body for Plaid webhook verification
       if (req.url === "/plaid-hook") {


### PR DESCRIPTION
## Changes

### Reduce JSON body size limit — Closes #128
`start.ts`: Changed `express.json({ limit: "50mb" })` to `limit: "1mb"`.

For a personal budget app, no legitimate JSON request should be near 50MB. The largest payloads (Plaid transaction syncs) are typically <1MB even for large accounts. The 50MB limit exposes the server to memory exhaustion via large payloads.

Note: The per-route `rawBody` extraction for Plaid webhook verification is unaffected — Plaid webhook bodies are tiny.

### Add process-level error handlers — Closes #129
`postgres/client.ts`: Added `unhandledRejection` and `uncaughtException` handlers alongside the existing SIGINT/SIGTERM handlers:

- **`unhandledRejection`**: Logs without crashing (non-fatal)
- **`uncaughtException`**: Logs, closes DB pool, exits with code 1

Without these, unhandled rejections in Node.js/Bun v15+ cause silent crashes with no cleanup of DB connections or in-flight syncs.

## Testing
- Server starts normally
- Existing SIGINT/SIGTERM graceful shutdown unaffected
- JSON limit: all current API payloads are well under 1MB