### PR TITLE
fix: budget sync-with-children zeros out all amounts

### DIFF
--- a/src/client/pages/BudgetConfigPage/lib/hooks.ts
+++ b/src/client/pages/BudgetConfigPage/lib/hooks.ts
@@ -109,6 +109,17 @@ const getLimitedBudgetsToSync = <T extends BudgetFamily>(
 ) => {
   const toUpdateList = new Set<BudgetFamily>();
 
+  // Capture references to original objects BEFORE cloning so we can look up
+  // their original capacity IDs in capacityData. getBudgetsToUpdatePeriod
+  // deletes capacity_id and generates new UUIDs, which would result in
+  // capacityData.get() returning zero defaults for all totals.
+  const originalBudget: Budget =
+    original.type === "budget"
+      ? (original as unknown as Budget)
+      : original.type === "section"
+        ? (original.getParent()! as Budget)
+        : (original.getParent()?.getParent()! as Budget);
+
   const { budget, sections, categories } = getBudgetsToUpdatePeriod(original, updated);
   toUpdateList.add(budget);
   sections.forEach((c) => toUpdateList.add(c));
@@ -116,14 +127,21 @@ const getLimitedBudgetsToSync = <T extends BudgetFamily>(
 
   if (original.type === "budget") {
     for (const capacity of budget.capacities) {
-      capacity.month = capacityData.get(capacity.id).grand_children_total;
+      const date = capacity.active_from ? new LocalDate(capacity.active_from) : new LocalDate(0);
+      const originalCapacity = originalBudget.getActiveCapacity(date);
+      capacity.month = capacityData.get(originalCapacity.id).grand_children_total;
     }
   }
 
   if (original.type === "budget" || original.type === "section") {
+    const originalSections = originalBudget.getChildren() as Section[];
     for (const section of sections) {
+      const originalSection = originalSections.find((s) => s.id === section.id);
+      if (!originalSection) continue;
       for (const capacity of section.capacities) {
-        capacity.month = capacityData.get(capacity.id).children_total;
+        const date = capacity.active_from ? new LocalDate(capacity.active_from) : new LocalDate(0);
+        const originalCapacity = originalSection.getActiveCapacity(date);
+        capacity.month = capacityData.get(originalCapacity.id).children_total;
       }
     }
   }


### PR DESCRIPTION
## Problem

When using the 'sync with children' toggle and saving on the budget configuration page, all budget/section/category amounts are set to 0.

## Root Cause

In `getLimitedBudgetsToSync` in `hooks.ts`, the code looks up `capacityData.get(capacity.id)` to retrieve `grand_children_total` / `children_total`. However, `getBudgetsToUpdatePeriod` deletes `capacity_id` from every cloned capacity and a new UUID is auto-generated in the `Capacity` constructor.

Since these new UUIDs don't exist in `capacityData`, the `CapacityData.get()` override returns a default `CapacitySummary` with zeros for all totals, zeroing out every budget amount on save.

## Fix

Capture references to the original (pre-clone) budget and section objects before calling `getBudgetsToUpdatePeriod`. Then use their `getActiveCapacity()` method to look up the correct original `capacity_id` in `capacityData`.

## Testing

1. Open budget configuration page
2. Enable 'sync with children' toggle
3. Save
4. Verify budget/section/category amounts are preserved (not zeroed)

Closes #132