### PR TITLE
fix: handle empty capacities array to prevent app crash

### DIFF
--- a/src/client/lib/models/BudgetFamily.ts
+++ b/src/client/lib/models/BudgetFamily.ts
@@ -85,6 +85,7 @@ export class BudgetFamily {
   };
 
   getActiveCapacity = (date: Date) => {
+    if (!this.capacities.length) return new Capacity();
     const sorted = this.sortCapacities("desc");
     const validCapacity = sorted.find((capacity) => {
       const { active_from } = capacity;


### PR DESCRIPTION
## Summary

Fixes a crash where the app throws `TypeError: Cannot read properties of undefined (reading 'month')` when a budget has an empty `capacities` array in the database.

## Root Cause

`getActiveCapacity()` returns `sorted[sorted.length - 1]` when no valid capacity is found — but when `capacities` is empty, this evaluates to `sorted[-1]` which is `undefined`. Subsequent code then crashes accessing `capacity.month`.

The empty capacities can exist because:
- Subclass constructors (`Budget`, `Section`, `Category`) call `assign(this, init)` after `super(init)`, overwriting the default capacity that `BudgetFamily` adds
- Server-side create functions use `data.capacities || []`

## Fix

**Defensive guard in `getActiveCapacity()`**: Return a default `new Capacity()` when the capacities array is empty, before attempting to sort/find.

This is a single-line change that prevents the crash regardless of how the empty state was created.

## Testing

- Started dev server with 2 budgets having `capacities: []` in the DB
- Verified the budgets page loads without crash (previously showed error boundary)
- Verified Dashboard and Accounts pages load cleanly
- Zero console errors across all pages

Closes #211