### PR TITLE
security: regenerate session ID on login to prevent session fixation

### DIFF
--- a/src/server/routes/users/post-login.ts
+++ b/src/server/routes/users/post-login.ts
@@ -21,6 +21,12 @@ export const postLoginRoute = new Route<LoginPostResponse>("POST", "/login", asy
 
   if (pwMatches) {
     const maskedUser = maskUser(user);
+    await new Promise<void>((resolve, reject) => {
+      req.session.regenerate((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
     req.session.user = maskedUser;
     return { status: "success", body: maskedUser };
   }


### PR DESCRIPTION
## Summary

Fixes session fixation vulnerability in the login flow by calling `req.session.regenerate()` before assigning user data to the session.

## Problem

After successful authentication, the old code simply wrote to the existing session:
```typescript
req.session.user = maskedUser;
```

An attacker could pre-set a session cookie (via XSS or subdomain cookie injection), wait for the victim to log in, and then access the authenticated session using the known session ID.

## Fix

Call `req.session.regenerate()` after auth succeeds, before writing user data. This issues a new session ID and invalidates the old one:

```typescript
await new Promise<void>((resolve, reject) => {
  req.session.regenerate((err) => {
    if (err) reject(err);
    else resolve();
  });
});
req.session.user = maskedUser;
```

## Testing

- TypeScript compiles without errors
- Started dev server, logged in successfully — session is assigned and app functions normally
- Session ID changes on login (verified by inspecting cookies before/after)

Closes #140