### PR TITLE
security: run Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,10 @@ FROM oven/bun:1
 
 WORKDIR /app
 
-COPY --from=builder /app/build ./build
-COPY healthcheck.js ./healthcheck.js
+COPY --chown=bun:bun --from=builder /app/build ./build
+COPY --chown=bun:bun healthcheck.js ./healthcheck.js
+
+USER bun
 
 # Environment variables should be provided at runtime, not baked into the image.
 # Use: docker run --env-file .env ...


### PR DESCRIPTION
## Summary

Use the built-in `bun` user (uid 1000) from the `oven/bun:1` base image instead of creating a custom `appuser`.

## Problem

The Dockerfile had no `USER` directive, so the container ran as root. If any vulnerability (RCE, path traversal, etc.) was exploited, the attacker would have root access inside the container, maximizing the blast radius.

## Fix

```dockerfile
COPY --chown=bun:bun --from=builder /app/build ./build
COPY --chown=bun:bun healthcheck.js ./healthcheck.js

USER bun
```

The `oven/bun:1` base image ships with a built-in `bun` user (uid 1000) — this is the canonical approach per the official Bun Docker docs and works across all variants (debian, slim, alpine, distroless). Using it avoids an extra `RUN groupadd/useradd/chown` layer and removes the dependency on Debian-specific tools like `useradd`.

Files are chowned at COPY time via `--chown`, so no extra `RUN chown` layer is needed.

## Testing

- Dockerfile lints cleanly
- Build stage is unchanged (still runs as default user during build — tests/typecheck run fine)
- Runtime stage runs as `bun` (non-root); app files are owned by `bun:bun`

Closes #141