### PR TITLE
reliability: add GET /api/health endpoint for production monitoring

### DIFF
--- a/src/server/routes/health.ts
+++ b/src/server/routes/health.ts
@@ -1,0 +1,31 @@
+import { Route } from "server/lib/route";
+import { pool } from "server/lib/postgres/client";
+
+export type HealthGetResponse = {
+  healthy: boolean;
+  checks: Record<string, "ok" | "unhealthy">;
+  timestamp: number;
+};
+
+export const getHealthRoute = new Route<HealthGetResponse>(
+  "GET",
+  "/health",
+  async (_req, res) => {
+    const checks: Record<string, "ok" | "unhealthy"> = {};
+    let allHealthy = true;
+
+    try {
+      await pool.query("SELECT 1");
+      checks.database = "ok";
+    } catch {
+      checks.database = "unhealthy";
+      allHealthy = false;
+    }
+
+    if (!allHealthy) res.status(503);
+    return {
+      status: allHealthy ? "success" : "error",
+      body: { healthy: allHealthy, checks, timestamp: Date.now() },
+    };
+  }
+);

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -1,5 +1,6 @@
 export * from "./accounts";
 export * from "./budgets";
 export * from "./charts";
+export * from "./health";
 export * from "./users";
 export * from "./webhooks";


### PR DESCRIPTION
## Summary

Adds a `GET /api/health` endpoint that reports app health and database connectivity. No authentication required.

## Response Format

**200 OK (healthy):**
```json
{"status":"success","body":{"healthy":true,"checks":{"database":"ok"},"timestamp":1741500000000}}
```

**503 Service Unavailable (unhealthy):**
```json
{"status":"error","body":{"healthy":false,"checks":{"database":"unhealthy"},"timestamp":1741500000000}}
```

## Use Cases

- **Docker HEALTHCHECK**: `HEALTHCHECK CMD wget -q --spider http://localhost:3005/api/health || exit 1`
- **Load balancer probes**: Route only to healthy instances
- **Staging deployment validation** (see #117): Health check confirms app+DB are live before promoting image to production

## Testing

- TypeScript compiles without errors
- Endpoint returns 200 with `{ database: 'ok' }` when DB is connected
- Returns 503 when database is unavailable

Closes #142