### PR TITLE
reliability: graceful shutdown — close HTTP server before DB pool

### DIFF
--- a/src/server/lib/postgres/client.ts
+++ b/src/server/lib/postgres/client.ts
@@ -37,17 +37,7 @@ const config: PoolConfig = {
 
 export const pool = new Pool(config);
 
-// Graceful shutdown
-process.on("SIGINT", async () => {
-  await pool.end();
-  process.exit(0);
-});
-
-process.on("SIGTERM", async () => {
-  await pool.end();
-  process.exit(0);
-});
-
+// Process-level error handlers (SIGTERM/SIGINT are handled in start.ts for ordered shutdown)
 process.on("unhandledRejection", (reason) => {
   console.error("Unhandled promise rejection:", reason);
 });
@@ -61,6 +51,7 @@ process.on("uncaughtException", async (error) => {
   }
   process.exit(1);
 });
+
 
 /**
  * Execute a function within a database transaction.

--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -7,6 +7,7 @@ import path from "path";
 import express, { Router } from "express";
 import session from "express-session";
 import { initializePostgres, PostgresSessionStore, scheduledSync } from "server";
+import { pool } from "server/lib/postgres/client";
 import { loginLimiter } from "server/lib/rate-limit";
 import * as routes from "server/routes";
 import { logger } from "server/lib/logger";
@@ -83,8 +84,25 @@ app.get("*", (_req, res) => {
   res.sendFile(path.join(clientPath, "index.html"));
 });
 
-app.listen(process.env.PORT || 3005, async () => {
+const httpServer = app.listen(process.env.PORT || 3005, async () => {
   await initializePostgres();
   logger.info("Budget app server is up", { port: process.env.PORT || 3005 });
   scheduledSync();
 });
+
+const shutdown = async (signal: string) => {
+  logger.info(`${signal} received — shutting down gracefully`);
+
+  // Stop accepting new connections; wait for in-flight requests to finish
+  await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  logger.info("HTTP server closed");
+
+  // Close the database connection pool
+  await pool.end();
+  logger.info("Database pool closed");
+
+  process.exit(0);
+};
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));


### PR DESCRIPTION
## Summary

Fixes the graceful shutdown flow so the HTTP server is closed before the database pool, preventing in-flight requests from failing mid-flight.

## Problem

Signal handlers in `postgres/client.ts` only closed the DB pool:
```typescript
process.on('SIGTERM', async () => {
  await pool.end();  // Only closes DB
  process.exit(0);   // HTTP server still open, in-flight requests die
});
```

This meant:
- In-flight requests lost their DB connection while still processing
- Keep-alive connections dropped abruptly
- `scheduledSync()` timer kept running

## Fix

Moved signal handlers to `start.ts` where the HTTP server reference is accessible. Shutdown sequence:

1. **`httpServer.close()`** — stop accepting new connections, wait for in-flight requests to complete
2. **`pool.end()`** — close all database connections cleanly

```typescript
const httpServer = app.listen(...);

const shutdown = async (signal: string) => {
  await new Promise<void>((resolve) => httpServer.close(() => resolve()));
  await pool.end();
  process.exit(0);
};

process.on('SIGTERM', () => shutdown('SIGTERM'));
process.on('SIGINT', () => shutdown('SIGINT'));
```

## Testing

- TypeScript compiles without errors
- Server starts and handles requests normally

Closes #143