### PR TITLE
fix: use only current balance for investment accounts (prevent double-counting cash)

### DIFF
--- a/src/client/lib/hooks/calculation/accounts.test.ts
+++ b/src/client/lib/hooks/calculation/accounts.test.ts
@@ -22,13 +22,15 @@ describe("getAccountBalance", () => {
     expect(getAccountBalance(account)).toBe(500);
   });
 
-  test("should return current + available for investment accounts", () => {
+  test("should return only current for investment accounts (available is already included in current)", () => {
     const account = new Account({
       account_id: "acc1",
       type: AccountType.Investment,
       balances: { current: 1000, available: 500, limit: null, iso_currency_code: "USD", unofficial_currency_code: null },
     });
-    expect(getAccountBalance(account)).toBe(1500);
+    // Plaid's `available` for investment accounts represents the cash component
+    // which is already included in `current`. Adding both would double-count cash.
+    expect(getAccountBalance(account)).toBe(1000);
   });
 
   test("should return only current for crypto exchange accounts", () => {

--- a/src/client/lib/hooks/calculation/accounts.ts
+++ b/src/client/lib/hooks/calculation/accounts.ts
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { AccountSubtype, AccountType } from "plaid";
 import { getYearMonthString, LocalDate, ViewDate } from "common";
 import {
   Account,
@@ -18,16 +17,10 @@ import {
 } from "client";
 
 export const getAccountBalance = (account: Account) => {
-  const balanceCurrent = account.balances.current || 0;
-  const balanceAvailalbe = account.balances.available || 0;
-  let value = 0;
-  if (account.type === AccountType.Investment) {
-    if (account.subtype === AccountSubtype.CryptoExchange) value = balanceCurrent;
-    else value = balanceCurrent + balanceAvailalbe;
-  } else {
-    value = balanceCurrent;
-  }
-  return value;
+  // Use `current` for all account types. For investment accounts, Plaid's
+  // `available` represents the cash component which is already included in
+  // `current` — adding both would double-count cash/buying power.
+  return account.balances.current || 0;
 };
 
 const getBalanceDataFromTransactions = (


### PR DESCRIPTION
## Problem

`getAccountBalance()` added `balances.current + balances.available` for investment accounts. Per Plaid's API, `available` for investment accounts represents the cash/buying power component that is **already included** in `current`. This caused cash to be double-counted.

**Impact on JP Morgan brokerage:**
- Was showing: $90,199.78 (`current` $84,621.09 + `available` $5,578.69)
- Correct: $84,621.09
- Total accounts balance was inflated by $5,578.69

This also propagated to Dashboard charts (Total Balance, etc.) that call `getAccountBalance()`.

## Fix

Use only `balances.current` for all account types. Since both branches (Investment and non-Investment) previously returned `balanceCurrent` for the non-crypto case anyway, the function simplifies to a single line.

Also removes the now-unused `AccountSubtype` and `AccountType` imports.

## Testing

- 6 unit tests pass (updated test expectation from 1500 → 1000 for the investment account case)
- Verified against Plaid docs: investment account `current` = total value including cash positions

## E2E

- Confirmed `getAccountBalance` is the function used by `BalanceChartRow` and account totals
- Fix removes the $5,578.69 overcount from JP Morgan account (matching holdings snapshot total)

Closes #149