### PR TITLE
fix: guard undefined activeCapacity in BudgetConfigPage and BudgetFamily

### DIFF
--- a/src/client/lib/models/BudgetFamily.ts
+++ b/src/client/lib/models/BudgetFamily.ts
@@ -65,6 +65,7 @@ export class BudgetFamily {
       this.roll_over_start_date = new LocalDate(this.roll_over_start_date);
     }
     this.capacities = this.capacities.map((c) => new Capacity(c));
+    if (!this.capacities.length) this.capacities = [new Capacity()];
   };
 
   toJSON(): JSONBudgetFamily {
@@ -92,7 +93,7 @@ export class BudgetFamily {
       return new LocalDate(active_from || 0) <= date;
     });
 
-    return validCapacity || sorted[sorted.length - 1];
+    return validCapacity || sorted[sorted.length - 1] || new Capacity();
   };
 
   isChildrenSynced = (capacityData: CapacityData) => {

--- a/src/client/pages/BudgetConfigPage/index.tsx
+++ b/src/client/pages/BudgetConfigPage/index.tsx
@@ -61,6 +61,7 @@ export const BudgetConfigPage = () => {
     const { name, roll_over, roll_over_start_date: roll_date } = budgetLike;
 
     const activeCapacity = budgetLike.getActiveCapacity(viewDate.getEndDate());
+    if (!activeCapacity) return;
     const defaultInputs = activeCapacity.toInputs();
     const allDates = budgetLike && getAllCapaciyDates(budgetLike);
     const defaultCapInput = allDates?.map((d) => {
@@ -105,8 +106,9 @@ export const BudgetConfigPage = () => {
   const { save, remove } = useEventHandlers(isSyncedInput, isIncomeInput, isInfiniteInput);
 
   if (!budgetLike) return <></>;
+  if (!activeCapacity) return <></>;
 
-  const activeCapInput = activeCapacity!.toInputs().capacityInput;
+  const activeCapInput = activeCapacity.toInputs().capacityInput;
   const barCapacity = Capacity.fromInputs(activeCapInput, isIncomeInput, isInfiniteInput);
   const barCapacityValue = barCapacity[interval];
   const labeledRatio = isInfiniteInput ? undefined : sorted_amount! / barCapacityValue;


### PR DESCRIPTION
## Summary

Fixes a crash on BudgetConfigPage when navigating to a budget with no capacities (e.g. after saving, if the default-selected budget has an empty capacities array).

## Changes

**`BudgetFamily.ts`**
- `getActiveCapacity()`: now returns `new Capacity()` as a safe fallback instead of `undefined` when no valid capacity is found
- Constructor: initializes `capacities` with a default `Capacity` when the array is empty

**`BudgetConfigPage/index.tsx`**
- useEffect: adds early return guard if `getActiveCapacity` returns `undefined`  
- Render path: adds explicit `if (!activeCapacity) return <></>` guard before accessing `.toInputs()`
- Removes unsafe non-null assertion (`activeCapacity!`)

## Root Cause

After save, `router.back()` may navigate to a budget with no capacities. `budgetLike.getActiveCapacity(date)` returned `undefined`, which then crashed on `.toInputs()` (both in the useEffect and in the render path with the `!` assertion).

## Testing

- Navigate to BudgetConfigPage for a budget that has sections
- Save while another budget with no capacities exists in DB
- Verify no crash occurs on navigation

Closes #137