### PR TITLE
security: add CSP and security response headers

### DIFF
--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -47,6 +47,28 @@ app.use(
   }),
 );
 
+app.use((_req, res, next) => {
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('X-XSS-Protection', '1; mode=block');
+  res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+  res.setHeader(
+    'Content-Security-Policy',
+    [
+      "default-src 'self'",
+      "script-src 'self' https://cdn.plaid.com",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob:",
+      "connect-src 'self' https://*.plaid.com",
+      "frame-src https://cdn.plaid.com",
+      "font-src 'self' data:",
+      "object-src 'none'",
+      "base-uri 'self'",
+    ].join('; ')
+  );
+  next();
+});
+
 const router = Router();
 
 router.use((req, _res, next) => {


### PR DESCRIPTION
## Summary

Adds security response headers to all HTTP responses as defense-in-depth.

## Headers Added

| Header | Value | Purpose |
|--------|-------|---------|
| `Content-Security-Policy` | Restricts resource origins (Plaid-compatible) | XSS mitigation |
| `X-Content-Type-Options` | `nosniff` | Prevents MIME sniffing |
| `X-Frame-Options` | `DENY` | Clickjacking protection |
| `X-XSS-Protection` | `1; mode=block` | Legacy XSS filter |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Referrer leakage prevention |

## CSP Directives

The CSP allows Plaid Link which requires `cdn.plaid.com` for scripts and frames, and `*.plaid.com` for API connections:
- `script-src 'self' https://cdn.plaid.com`
- `connect-src 'self' https://*.plaid.com`
- `frame-src https://cdn.plaid.com`
- `style-src 'self' 'unsafe-inline'` (needed for React inline styles)

## Implementation

No new packages — implemented as a plain Express middleware in `start.ts`.

Closes #119