### PR TITLE
fix: update CSS selectors to match divs inside form wrapper on LoginPage

### DIFF
--- a/src/client/components/App/index.css
+++ b/src/client/components/App/index.css
@@ -112,7 +112,8 @@ div.LoginPage {
   padding-top: 100px;
 }
 
-div.LoginPage > div {
+div.LoginPage > div,
+div.LoginPage > form > div {
   text-align: center;
   margin: 10px 0;
 }


### PR DESCRIPTION
## Summary

Fixes broken login page styling caused by the form element wrapper added in commit `4ddf143`.

Closes #107

## Root Cause

The CSS selectors targeted `div.LoginPage > div` for centering and spacing, but the form element sits between them now:

```html
<!-- Before: CSS matched -->
<div class="LoginPage">
  <div>...</div>
</div>

<!-- After: CSS no longer matches direct children -->
<div class="LoginPage">
  <form>
    <div>...</div>
  </form>
</div>
```

## Fix

Added `div.LoginPage > form > div` to the existing CSS rule so both direct-child and form-child divs receive the same centering and spacing styles.

```css
/* Before */
div.LoginPage > div {
  text-align: center;
  margin: 10px 0;
}

/* After */
div.LoginPage > div,
div.LoginPage > form > div {
  text-align: center;
  margin: 10px 0;
}
```

## E2E Testing

- Navigated to login page locally
- Confirmed username/password fields and Login button are centered with correct spacing
- Login flow works end-to-end (form submits, redirects to budgets page)