### PR TITLE
fix: recover from IndexedDB VersionError after code rollback

### DIFF
--- a/src/client/lib/indexed-db/accessor.ts
+++ b/src/client/lib/indexed-db/accessor.ts
@@ -44,7 +44,22 @@ class IndexedDbAccessor {
 
       const request = indexedDB.open(this.dbName, this.dbVersion);
 
-      request.onerror = () => reject(request.error);
+      request.onerror = () => {
+        // When the stored DB version is higher than the requested version (e.g. after
+        // a code rollback), IndexedDB throws a VersionError.  Recover by deleting the
+        // stale database so the next init() call starts fresh at the current version.
+        if (request.error?.name === "VersionError") {
+          console.warn(
+            `[IndexedDB] VersionError: stored version is newer than ${this.dbVersion}. ` +
+              "Deleting database and retrying.",
+          );
+          const deleteRequest = indexedDB.deleteDatabase(this.dbName);
+          deleteRequest.onsuccess = () => this.init().then(resolve, reject);
+          deleteRequest.onerror = () => reject(deleteRequest.error);
+          return;
+        }
+        reject(request.error);
+      };
       request.onsuccess = () => {
         this.db = request.result;
         resolve(this.db);


### PR DESCRIPTION
## Summary

Handles the `VersionError` thrown by `indexedDB.open()` when the browser's stored DB version is higher than the version the current code requests.

Closes #115

## Root Cause

After a code rollback (or branch switch to an older version), `DB_VERSION` can be lower than what's stored in the browser. IndexedDB fires `request.onerror` with `VersionError` in this case. Previously the error propagated unhandled, breaking all client-side caching for the session.

## Fix

Detect `VersionError` in `request.onerror` and recover by:
1. Deleting the stale database (`indexedDB.deleteDatabase`)
2. Retrying `init()` which recreates the DB at the current version

This clears cached data (acceptable — the IndexedDB is a local performance cache; all data is re-fetched from the server) and restores normal app behaviour.

```typescript
request.onerror = () => {
  if (request.error?.name === 'VersionError') {
    const deleteRequest = indexedDB.deleteDatabase(this.dbName);
    deleteRequest.onsuccess = () => this.init().then(resolve, reject);
    deleteRequest.onerror = () => reject(deleteRequest.error);
    return;
  }
  reject(request.error);
};
```

## TypeScript

`bun run tsc --noEmit` — clean.

## E2E Testing

Tested scenario:
1. Used dev tools to manually set IndexedDB version to 3 (simulating a stale version)
2. Reloaded the app — previously threw `VersionError` in console
3. With fix applied: app auto-deletes the stale DB, reinitialises at version 2, and loads normally with data fetched fresh from the server