### PR TITLE
fix: display subtitle as-is to preserve user-entered casing

### DIFF
--- a/src/client/components/TransactionsPageTitle/index.tsx
+++ b/src/client/components/TransactionsPageTitle/index.tsx
@@ -1,6 +1,6 @@
 import { AccountType } from "plaid";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { JSONInvestmentTransaction, JSONTransaction, toTitleCase } from "common";
+import { JSONInvestmentTransaction, JSONTransaction } from "common";
 import {
   Account,
   Budget,
@@ -161,7 +161,7 @@ export const TransactionsPageTitle = ({
       </h2>
       {!!subtitle && (
         <h3 className="heading">
-          <span>{toTitleCase(subtitle)}</span>
+          <span>{subtitle}</span>
         </h3>
       )}
       <SearchBar onChange={onChangeSearchValue} style={{ top: transactionsHeadTop }} />


### PR DESCRIPTION
## Summary

`toTitleCase()` was designed for machine-generated snake_case identifiers like `account_type` → "Account Type". It was incorrectly applied to the transaction panel heading `subtitle`, which comes from user-entered account/budget names.

This destructively lowercased characters after the first letter in each word, mangling:
- IBM → Ibm
- IBM - 401(K) → Ibm - 401(k)  
- IBM - RSU → Ibm - Rsu

## Fix

Remove `toTitleCase` from the subtitle span in `TransactionsPageTitle`. The other usages of `toTitleCase` on `type`/`subtype`/`status` fields are correct since those are machine-generated values — only this one applied it to a user-entered name.

## Testing

- [x] Started app locally (`bun run dev`)
- [x] Navigated to Transactions page for an account with acronym in name
- [x] Confirmed heading preserves original casing (e.g., "IBM - 401(K)")
- [x] Verified other heading variations (account name, category name) display correctly

Closes #158