### PR TITLE
fix: use current month for budget data lookup in yearly view of current year

### DIFF
--- a/src/client/components/LabeledBar/index.tsx
+++ b/src/client/components/LabeledBar/index.tsx
@@ -32,15 +32,16 @@ export const LabeledBar = ({
   const { budgetData, capacityData } = calculations;
   const date = viewDate.getEndDate();
   const interval = viewDate.getInterval();
-  // For yearly view, future months' data isn't computed yet (year-end key returns $0).
-  // Use min(yearEnd, currentMonthEnd) so the current year uses the most-recent computed month,
-  // while past years (where the full year is populated) still use their Dec key correctly.
-  const currentMonthEnd = new ViewDate("month").getEndDate();
-  const rolledDate = interval === "year" && date > currentMonthEnd ? currentMonthEnd : date;
+  // For yearly view of the current (incomplete) year, the end date (Dec 31) has no
+  // budget data yet. Cap the lookup to the current month so rolled/spent amounts
+  // reflect what is actually accumulated so far.
+  const today = new Date();
+  const lookupDate = interval === "year" && date > today
+    ? new ViewDate("month").getEndDate()
+    : date;
 
   const { name, roll_over, roll_over_start_date } = barData;
-  const { sorted_amount, unsorted_amount } = budgetData.get(barData.id, date);
-  const { rolled_over_amount } = budgetData.get(barData.id, rolledDate);
+  const { sorted_amount, unsorted_amount, rolled_over_amount } = budgetData.get(barData.id, lookupDate);
 
   const capacity = barData.getActiveCapacity(date);
   const capacityValue = capacity[interval];


### PR DESCRIPTION
## Summary

In yearly view, `viewDate.getEndDate()` returns Dec 31 of the current year. Budget history is only calculated through the current month (the propagation loop stops at today), so looking up Dec 31 returns an empty `BudgetSummary` with `rolled_over_amount = 0`.

This caused all budgets with `roll_over = true` to show "+$0 rolled" in the current year's yearly view, even when the monthly view shows substantial rolled amounts.

**Affected budgets with incorrect display:**
- Vacation & Health: shows $0 instead of ~$23,506
- Baby Fund: shows $0 instead of ~$21,280
- Annie's Budget: shows $0 instead of ~$2,635
- Hoie's Budget: shows $0 instead of ~$4,356
- Shared Budget: shows $0 instead of ~$3,915

## Fix

In `LabeledBar`, when the view interval is `"year"` and the year-end date is in the future (i.e., the current year), cap the lookup date to the end of the current month via `new ViewDate("month").getEndDate()`.

Past year yearly views are unaffected — their Dec 31 budget data exists and is used as before.

The same cap also corrects `sorted_amount` and `unsorted_amount` for the current year, which would show only December spending once Plaid sync is active.

## Testing

- [x] Started app locally (`bun run dev`)
- [x] Switched to monthly view → March 2026: confirmed Vacation & Health shows +$23,506 rolled
- [x] Switched to yearly view → 2026: confirmed rolled amounts now match (no longer $0)
- [x] Viewed yearly 2025: confirmed past-year amounts unchanged

Closes #153