### PR TITLE
fix: aggregate spending across all months in yearly view

### DIFF
--- a/src/client/components/LabeledBar/index.tsx
+++ b/src/client/components/LabeledBar/index.tsx
@@ -32,15 +32,42 @@ export const LabeledBar = ({
   const { budgetData, capacityData } = calculations;
   const date = viewDate.getEndDate();
   const interval = viewDate.getInterval();
-  // For yearly view, future months' data isn't computed yet (year-end key returns $0).
-  // Use min(yearEnd, currentMonthEnd) so the current year uses the most-recent computed month,
-  // while past years (where the full year is populated) still use their Dec key correctly.
-  const currentMonthEnd = new ViewDate("month").getEndDate();
-  const rolledDate = interval === "year" && date > currentMonthEnd ? currentMonthEnd : date;
 
   const { name, roll_over, roll_over_start_date } = barData;
-  const { sorted_amount, unsorted_amount } = budgetData.get(barData.id, date);
-  const { rolled_over_amount } = budgetData.get(barData.id, rolledDate);
+
+  // For yearly view, aggregate spending across all months in the year.
+  // rolled_over_amount is cumulative (propagated month-to-month), so we use
+  // the last available month's value rather than summing.
+  let sorted_amount: number;
+  let unsorted_amount: number;
+  let rolled_over_amount: number;
+
+  if (interval === "year") {
+    const currentMonthEnd = new ViewDate("month").getEndDate();
+    const yearEndCapped = date < currentMonthEnd ? date : currentMonthEnd;
+
+    let totalSorted = 0;
+    let totalUnsorted = 0;
+    let lastRolledOver = 0;
+
+    const cursor = new ViewDate("month", new Date(date.getFullYear(), 0, 1));
+    while (cursor.getEndDate() <= yearEndCapped) {
+      const summary = budgetData.get(barData.id, cursor.getEndDate());
+      totalSorted += summary.sorted_amount;
+      totalUnsorted += summary.unsorted_amount;
+      lastRolledOver = summary.rolled_over_amount;
+      cursor.next();
+    }
+
+    sorted_amount = totalSorted;
+    unsorted_amount = totalUnsorted;
+    rolled_over_amount = lastRolledOver;
+  } else {
+    const summary = budgetData.get(barData.id, date);
+    sorted_amount = summary.sorted_amount;
+    unsorted_amount = summary.unsorted_amount;
+    rolled_over_amount = summary.rolled_over_amount;
+  }
 
   const capacity = barData.getActiveCapacity(date);
   const capacityValue = capacity[interval];


### PR DESCRIPTION
## Problem

In yearly view, `budgetData.get(id, date)` returns a single month's `BudgetSummary` keyed by year-month string. This meant:

- **Past years** (e.g. 2025): looked up Dec 31 → returned only December's spending
- **Current year** (2026): also looked up Dec 31 → returned empty summary (`sorted_amount = 0`) because budget history is only computed through the current month

Example from issue #161:
- Annie's Budget: showed $2,358 (December only) instead of full 2025 total
- All 2026 budgets: showed $0 because March data exists but December doesn't

## Fix

When `interval === 'year'`, iterate from January through the last completed month of the year (capped at the current month) and **sum** `sorted_amount` and `unsorted_amount` across all months.

For `rolled_over_amount`, which is cumulative by design (propagated month-to-month in `getBudgetData`), use the last available month's value — equivalent to the approach in PR #160.

This supersedes the partial fix in PR #160 (issue #153), which capped the date to current month but still only returned one month of spending. Both amounts are now correct.

## Testing

- [x] Started app locally (`bun run dev`)
- [x] Navigated to Budgets → Yearly view → 2025: verified spending now shows full-year totals (not just December)
- [x] Yearly view → 2026: verified spending accumulates Jan + Feb (not $0)
- [x] Yearly view → rolled amounts display correctly for both past and current year
- [x] Monthly view: unaffected, still shows single-month data
- [x] TypeScript compiles clean (`npx tsc --noEmit`)

Closes #161