### PR TITLE
fix: add useEffect cleanup for setTimeout timers in Graph/Line and Bar

### DIFF
--- a/src/client/components/Bar/index.tsx
+++ b/src/client/components/Bar/index.tsx
@@ -41,6 +41,7 @@ export const Bar = ({
   const totalRatio = ratio + unlabeledRatio;
 
   const barColorTransitionTimeout = useRef<Timeout>();
+  const barAlertStepTimeout = useRef<Timeout>();
 
   useEffect(() => {
     if (!transitioning) {
@@ -49,12 +50,17 @@ export const Bar = ({
         const newAlertLevel = noAlert ? 0 : Math.floor(totalRatio);
         if (newAlertLevel === 2) {
           setAlertLevel(1);
-          setTimeout(() => setAlertLevel(2), 500);
+          clearTimeout(barAlertStepTimeout.current);
+          barAlertStepTimeout.current = setTimeout(() => setAlertLevel(2), 500);
         } else {
           setAlertLevel(newAlertLevel);
         }
       }, 500);
     }
+    return () => {
+      clearTimeout(barColorTransitionTimeout.current);
+      clearTimeout(barAlertStepTimeout.current);
+    };
   }, [transitioning, noAlert, totalRatio, setAlertLevel]);
 
   const alertClasses = [];
@@ -99,6 +105,9 @@ export const Bar = ({
         });
       }
     }
+    return () => {
+      clearTimeout(barMovingTimeout.current);
+    };
   }, [
     ratio,
     unlabeledRatio,

--- a/src/client/components/Graph/Line.tsx
+++ b/src/client/components/Graph/Line.tsx
@@ -35,7 +35,11 @@ const Line = ({
   const offsetDebouncer = useDebounce();
 
   useEffect(() => {
+    let cancelled = false;
+
     const recurUntilRef = () => {
+      if (cancelled) return;
+
       const path = pathRef.current;
       if (!path) {
         setTimeout(recurUntilRef, 100);
@@ -66,6 +70,10 @@ const Line = ({
     };
 
     setTimeout(recurUntilRef, 100);
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     points,
     transitioning,


### PR DESCRIPTION
## Problem

Two components create `setTimeout` timers in `useEffect` hooks without returning cleanup functions. If a component unmounts before a timer fires, the callback runs against a detached component and attempts to update state.

### `Graph/Line.tsx`

The recursive `recurUntilRef` polling loop polls every 100ms until it can obtain a ref to the SVG path element. It never stops if the component unmounts mid-poll:

```ts
useEffect(() => {
  const recurUntilRef = () => {
    if (!path) {
      setTimeout(recurUntilRef, 100); // keeps running after unmount
      return;
    }
    // ...
  };
  setTimeout(recurUntilRef, 100);
}, [...]);
```

**Fix:** Add a `cancelled` flag set by the cleanup function. `recurUntilRef` checks it before scheduling the next tick.

### `Bar/index.tsx`

Two `useEffect` hooks use timer refs but neither clears them on unmount:

1. **barColorTransitionTimeout** – cleared on re-run but not on unmount
2. **barAlertStepTimeout** (was anonymous) – the two-step animation (`setAlertLevel(1)` → `setAlertLevel(2)`) used a completely untracked `setTimeout`
3. **barMovingTimeout** – set inside state updater callbacks but never cancelled on unmount

**Fix:** Return cleanup functions from both effects; add `barAlertStepTimeout` ref for the previously-anonymous nested timer.

## Testing

- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Started app, navigated to Budgets — graph lines animate correctly
- [x] Budget bars show alert colours at the correct thresholds
- [x] No `Warning: Can't perform a React state update on an unmounted component` in console after fast navigation

Closes #163