### PR TITLE
fix: getAccountBalance uses only current for investment accounts

### DIFF
--- a/src/client/lib/hooks/calculation/accounts.test.ts
+++ b/src/client/lib/hooks/calculation/accounts.test.ts
@@ -22,13 +22,14 @@ describe("getAccountBalance", () => {
     expect(getAccountBalance(account)).toBe(500);
   });
 
-  test("should return current + available for investment accounts", () => {
+  test("should return only current for investment accounts (available is already included in current)", () => {
     const account = new Account({
       account_id: "acc1",
       type: AccountType.Investment,
       balances: { current: 1000, available: 500, limit: null, iso_currency_code: "USD", unofficial_currency_code: null },
     });
-    expect(getAccountBalance(account)).toBe(1500);
+    // available (cash/buying power) is already counted in current — must not double-count
+    expect(getAccountBalance(account)).toBe(1000);
   });
 
   test("should return only current for crypto exchange accounts", () => {

--- a/src/client/lib/hooks/calculation/accounts.ts
+++ b/src/client/lib/hooks/calculation/accounts.ts
@@ -19,11 +19,12 @@ import {
 
 export const getAccountBalance = (account: Account) => {
   const balanceCurrent = account.balances.current || 0;
-  const balanceAvailalbe = account.balances.available || 0;
   let value = 0;
   if (account.type === AccountType.Investment) {
-    if (account.subtype === AccountSubtype.CryptoExchange) value = balanceCurrent;
-    else value = balanceCurrent + balanceAvailalbe;
+    // For investment accounts, `current` already includes cash/buying power.
+    // `available` represents the cash component which is already counted in `current`,
+    // so adding it would double-count. Use `current` only for all investment subtypes.
+    value = balanceCurrent;
   } else {
     value = balanceCurrent;
   }


### PR DESCRIPTION
## Problem
Plaid's `available` for investment accounts represents the cash/buying power component which is **already included** in `current`. Adding both values was double-counting the cash balance.

**Impact:** JP Morgan brokerage was inflated by $5,578.69 ($90,199.78 displayed vs $84,621.09 correct). Total accounts balance inflated by ~$5,579.

## Changes
- Remove `current + available` path for investment accounts — use only `current`
- Remove unused `balanceAvailalbe` variable (typo eliminated)
- Update unit test: assert `current` only for investment accounts

## Testing
- All 6 unit tests pass
- Logic verified against Plaid API docs: `available` for investment = cash already in `current`

Closes #149