### PR TITLE
fix: prevent app crash when budget has empty capacities array

### DIFF
--- a/src/client/lib/models/BudgetFamily.ts
+++ b/src/client/lib/models/BudgetFamily.ts
@@ -47,7 +47,6 @@ export class BudgetFamily {
   constructor(init?: Partial<BudgetFamily | JSONBudgetFamily>) {
     assign(this, init);
     this.fromJSON();
-    if (!this.capacities.length) this.capacities = [new Capacity()];
     excludeEnumeration(this, [
       "fromJSON",
       "toJSON",
@@ -65,6 +64,9 @@ export class BudgetFamily {
       this.roll_over_start_date = new LocalDate(this.roll_over_start_date);
     }
     this.capacities = this.capacities.map((c) => new Capacity(c));
+    // Ensure there is always at least one capacity.  Subclasses call assign() + fromJSON()
+    // after super(), which would overwrite the parent-constructor guard, so keep it here.
+    if (!this.capacities.length) this.capacities = [new Capacity()];
   };
 
   toJSON(): JSONBudgetFamily {

--- a/src/client/pages/BudgetConfigPage/index.tsx
+++ b/src/client/pages/BudgetConfigPage/index.tsx
@@ -104,9 +104,9 @@ export const BudgetConfigPage = () => {
 
   const { save, remove } = useEventHandlers(isSyncedInput, isIncomeInput, isInfiniteInput);
 
-  if (!budgetLike) return <></>;
+  if (!budgetLike || !activeCapacity) return <></>;
 
-  const activeCapInput = activeCapacity!.toInputs().capacityInput;
+  const activeCapInput = activeCapacity.toInputs().capacityInput;
   const barCapacity = Capacity.fromInputs(activeCapInput, isIncomeInput, isInfiniteInput);
   const barCapacityValue = barCapacity[interval];
   const labeledRatio = isInfiniteInput ? undefined : sorted_amount! / barCapacityValue;


### PR DESCRIPTION
## Problem
### Crash 1: Entire app crashes with empty capacities (#138)
Budget/Section/Category constructors call `super(init)` → `assign(this, init)` → `this.fromJSON()`. The empty-capacities guard in `BudgetFamily`'s constructor ran between the parent's `assign` and the subclass's second `assign`, so the subclass's `assign(this, init)` silently overwrote `capacities` back to `[]` and the guard was bypassed.

When `getActiveCapacity()` was called on an item with `capacities: []`, it returned `undefined`, causing `LabeledBar` to crash trying to read `undefined.month`.

### Crash 2: BudgetConfigPage crashes after save (#137)
After save, navigation could land on a budget with no capacities. `activeCapacity!` (non-null assertion on line 109) then crashed with `Cannot read properties of undefined (reading 'toInputs')`.

## Fix
1. Move the `if (!this.capacities.length)` guard from `BudgetFamily` constructor **into `fromJSON()`** — `fromJSON()` is always called last by all subclasses, so the guard can no longer be bypassed.
2. Guard `BudgetConfigPage` against `!activeCapacity` and remove the unsafe `!.toInputs()` non-null assertion.

## Testing
- TypeScript compiles cleanly
- App should no longer crash on budgets with `capacities: []` in the database
- BudgetConfigPage should show a blank page (graceful) instead of crashing when budget has no capacities

Closes #137
Closes #138