### PR TITLE
security: add user ownership check to all update/delete repository operations

### DIFF
--- a/src/server/lib/postgres/models/base.ts
+++ b/src/server/lib/postgres/models/base.ts
@@ -127,9 +127,11 @@ export abstract class Table<
     primaryKeyValue: ParamValue,
     data: QueryData,
     returning?: string[],
+    userId?: ParamValue,
   ): Promise<Record<string, unknown> | null> {
     const query = buildUpdate(this.name, this.primaryKey, primaryKeyValue, data, {
       returning: returning ?? [this.primaryKey],
+      additionalWhere: userId !== undefined ? { column: "user_id", value: userId } : undefined,
     });
     if (!query) return null;
     const result = await pool.query(query.sql, query.values);
@@ -145,8 +147,13 @@ export abstract class Table<
     return result.rows.length > 0 ? result.rows[0] : null;
   }
 
-  async softDelete(primaryKeyValue: ParamValue): Promise<boolean> {
-    const { sql, values } = buildSoftDelete(this.name, this.primaryKey, primaryKeyValue);
+  async softDelete(primaryKeyValue: ParamValue, userId?: ParamValue): Promise<boolean> {
+    const { sql, values } = buildSoftDelete(
+      this.name,
+      this.primaryKey,
+      primaryKeyValue,
+      userId !== undefined ? { column: "user_id", value: userId } : undefined,
+    );
     const result = await pool.query(sql, values);
     return result.rowCount !== null && result.rowCount > 0;
   }

--- a/src/server/lib/postgres/repositories/accounts.ts
+++ b/src/server/lib/postgres/repositories/accounts.ts
@@ -98,7 +98,7 @@ export const updateAccounts = async (
       delete row.account_id;
       delete row.user_id;
 
-      const updated = await accountsTable.update(account.account_id, row);
+      const updated = await accountsTable.update(account.account_id, row, undefined, user.user_id);
       results.push(
         updated ? successResult(account.account_id, 1) : noChangeResult(account.account_id),
       );

--- a/src/server/lib/postgres/repositories/budgets.ts
+++ b/src/server/lib/postgres/repositories/budgets.ts
@@ -75,7 +75,7 @@ export const updateBudget = async (
   if (data.capacities !== undefined) updates.capacities = JSON.stringify(data.capacities);
 
   if (Object.keys(updates).length === 0) return false;
-  const model = await budgetsTable.update(budget_id, updates);
+  const model = await budgetsTable.update(budget_id, updates, undefined, user.user_id);
   return model !== null;
 };
 
@@ -83,17 +83,15 @@ export const deleteBudget = async (user: MaskedUser, budget_id: string): Promise
   const sections = await sectionsTable.query({ [USER_ID]: user.user_id, [BUDGET_ID]: budget_id });
   const sectionIds = sections.map((s) => s.section_id);
 
-  if (sectionIds.length > 0) {
-    for (const sid of sectionIds) {
-      await categoriesTable.softDelete(sid);
-    }
+  for (const sid of sectionIds) {
+    await categoriesTable.bulkSoftDeleteByColumn(SECTION_ID, sid, user.user_id);
   }
 
   for (const sid of sectionIds) {
-    await sectionsTable.softDelete(sid);
+    await sectionsTable.softDelete(sid, user.user_id);
   }
 
-  return await budgetsTable.softDelete(budget_id);
+  return await budgetsTable.softDelete(budget_id, user.user_id);
 };
 
 export const deleteBudgets = async (
@@ -153,19 +151,13 @@ export const updateSection = async (
   if (data.capacities !== undefined) updates.capacities = JSON.stringify(data.capacities);
 
   if (Object.keys(updates).length === 0) return false;
-  const model = await sectionsTable.update(section_id, updates);
+  const model = await sectionsTable.update(section_id, updates, undefined, user.user_id);
   return model !== null;
 };
 
 export const deleteSection = async (user: MaskedUser, section_id: string): Promise<boolean> => {
-  const categories = await categoriesTable.query({
-    [USER_ID]: user.user_id,
-    [SECTION_ID]: section_id,
-  });
-  for (const cat of categories) {
-    await categoriesTable.softDelete(cat.category_id);
-  }
-  return await sectionsTable.softDelete(section_id);
+  await categoriesTable.bulkSoftDeleteByColumn(SECTION_ID, section_id, user.user_id);
+  return await sectionsTable.softDelete(section_id, user.user_id);
 };
 
 export const deleteSections = async (
@@ -228,12 +220,12 @@ export const updateCategory = async (
   if (data.capacities !== undefined) updates.capacities = JSON.stringify(data.capacities);
 
   if (Object.keys(updates).length === 0) return false;
-  const model = await categoriesTable.update(category_id, updates);
+  const model = await categoriesTable.update(category_id, updates, undefined, user.user_id);
   return model !== null;
 };
 
 export const deleteCategory = async (user: MaskedUser, category_id: string): Promise<boolean> => {
-  return await categoriesTable.softDelete(category_id);
+  return await categoriesTable.softDelete(category_id, user.user_id);
 };
 
 export const deleteCategories = async (
@@ -241,9 +233,6 @@ export const deleteCategories = async (
   category_ids: string[],
 ): Promise<{ deleted: number }> => {
   if (!category_ids.length) return { deleted: 0 };
-  let deleted = 0;
-  for (const id of category_ids) {
-    if (await categoriesTable.softDelete(id)) deleted++;
-  }
+  const deleted = await categoriesTable.bulkSoftDelete(category_ids, { user_id: user.user_id });
   return { deleted };
 };

--- a/src/server/lib/postgres/repositories/charts.ts
+++ b/src/server/lib/postgres/repositories/charts.ts
@@ -69,12 +69,12 @@ export const updateChart = async (
 
   if (Object.keys(updates).length === 0) return false;
 
-  const model = await chartsTable.update(chart_id, updates);
+  const model = await chartsTable.update(chart_id, updates, undefined, user.user_id);
   return model !== null;
 };
 
 export const deleteChart = async (user: MaskedUser, chart_id: string): Promise<boolean> => {
-  return await chartsTable.softDelete(chart_id);
+  return await chartsTable.softDelete(chart_id, user.user_id);
 };
 
 export const deleteCharts = async (
@@ -84,7 +84,7 @@ export const deleteCharts = async (
   if (!chart_ids.length) return { deleted: 0 };
   let deleted = 0;
   for (const id of chart_ids) {
-    if (await chartsTable.softDelete(id)) deleted++;
+    if (await chartsTable.softDelete(id, user.user_id)) deleted++;
   }
   return { deleted };
 };

--- a/src/server/lib/postgres/repositories/snapshots.ts
+++ b/src/server/lib/postgres/repositories/snapshots.ts
@@ -338,7 +338,7 @@ export const deleteSnapshotById = async (
   user: MaskedUser,
   snapshot_id: string,
 ): Promise<boolean> => {
-  return await snapshotsTable.softDelete(snapshot_id);
+  return await snapshotsTable.softDelete(snapshot_id, user.user_id);
 };
 
 export const aggregateAccountSnapshots = async (

--- a/src/server/lib/postgres/repositories/transactions.ts
+++ b/src/server/lib/postgres/repositories/transactions.ts
@@ -134,7 +134,7 @@ export const updateTransactions = async (
       delete row.transaction_id;
       delete row.user_id;
 
-      const updated = await transactionsTable.update(tx.transaction_id, row);
+      const updated = await transactionsTable.update(tx.transaction_id, row, undefined, user.user_id);
       results.push(
         updated ? successResult(tx.transaction_id, 1) : noChangeResult(tx.transaction_id),
       );


### PR DESCRIPTION
## Summary

Fixes IDOR vulnerability across all write operations that were missing user ownership scoping.

Closes #168

## Changes

Extended `Table.update()` and `Table.softDelete()` in the base class to accept an optional `userId` parameter. When provided, appends `AND user_id = $N` to the WHERE clause, ensuring the operation only affects rows owned by the authenticated user.

**Fixed repository functions (were missing user_id scope):**
- `updateTransactions` — `transactionsTable.update(..., user.user_id)`
- `updateChart` — `chartsTable.update(..., user.user_id)`
- `deleteChart` / `deleteCharts` — `chartsTable.softDelete(..., user.user_id)`
- `deleteSnapshotById` — `snapshotsTable.softDelete(..., user.user_id)`
- `updateAccounts` — `accountsTable.update(..., user.user_id)`
- `updateBudget` / `updateSection` / `updateCategory` — update + softDelete
- `deleteBudget` / `deleteSection` — full cascade with user_id

**Already correct (no change):**
- `deleteAccounts` → `bulkSoftDelete` with `{ user_id }` ✓
- `deleteTransactions` → `bulkSoftDelete` with `{ user_id }` ✓
- Upsert operations include `user_id` in insert data ✓

## Security Impact

Before: any authenticated user could modify/delete another user's transactions, charts, budgets, etc. by knowing (or guessing) their resource ID.

After: update and delete SQL queries include `AND user_id = $N`, so operations silently no-op if the requesting user doesn't own the resource.

## E2E Testing

- Started dev server (`bun run dev`)
- Logged in as the app user
- Updated a transaction — succeeded
- Updated a chart name — succeeded
- Deleted a chart — succeeded
- Confirmed TypeScript compiles clean