### PR TITLE
fix: hide "Unhide All" button when no accounts are hidden

### DIFF
--- a/src/client/components/AccountsTable/index.tsx
+++ b/src/client/components/AccountsTable/index.tsx
@@ -33,9 +33,13 @@ export const AccountsTable = ({ donutData, style }: Props) => {
   });
 
   const creditAccounts: ReactNode[] = [];
+  let hasHiddenAccounts = false;
 
   accounts.forEach((a) => {
-    if (a.hide) return;
+    if (a.hide) {
+      hasHiddenAccounts = true;
+      return;
+    }
     const element = <AccountRow key={a.account_id} account={a} />;
     if (a.type === AccountType.Credit) creditAccounts.push(element);
   });
@@ -80,7 +84,7 @@ export const AccountsTable = ({ donutData, style }: Props) => {
     <div className="AccountsTable" style={style}>
       {!!donutAccounts.length && <div className="rows">{donutAccounts}</div>}
       {!!creditAccounts.length && <div className="rows">{creditAccounts}</div>}
-      <div>{!!accounts.size && <button onClick={onClickUnhide}>Unhide&nbsp;All</button>}</div>
+      <div>{hasHiddenAccounts && <button onClick={onClickUnhide}>Unhide&nbsp;All</button>}</div>
       {!accounts.size && (
         <div className="placeholder">
           You don't have any connected accounts! Click this button to connect your accounts.


### PR DESCRIPTION
## Summary

Only show the "Unhide All" button on the Accounts page when at least one account has `hide=true`. Previously the button showed whenever any accounts existed, regardless of hidden status.

Closes #174

## Changes

- `src/client/components/AccountsTable/index.tsx`: Track `hasHiddenAccounts` flag during account iteration. Use it instead of `!!accounts.size` to conditionally render the button.

## E2E Testing

1. Started dev server (`bun run dev`)
2. Logged in as admin
3. Navigated to Accounts page
4. Verified "Unhide All" button is NOT visible (no hidden accounts)
5. Verified all 12 accounts and 4 credits still display correctly
6. Verified account totals: $1,066,685 and -$3,202.64 outstanding
7. Dashboard and Budgets pages still load correctly