### PR TITLE
fix: cap yearly view balance lookup to current month for current year

### DIFF
--- a/src/client/pages/AccountsPage/index.tsx
+++ b/src/client/pages/AccountsPage/index.tsx
@@ -1,6 +1,6 @@
 import { AccountType } from "plaid";
 import { useEffect, useMemo, useState } from "react";
-import { cap, currencyCodeToSymbol } from "common";
+import { cap, currencyCodeToSymbol, ViewDate } from "common";
 import { colors, getAccountBalance, ScreenType, useAppContext, useDebounce } from "client";
 import { AccountsDonut, AccountsTable, DonutData } from "client/components";
 import "./index.css";
@@ -30,7 +30,15 @@ export const AccountsPage = () => {
         return !hide && type !== AccountType.Credit && (balances.current || balances.available);
       });
 
-    const viewDateDate = viewDate.getEndDate();
+    // For yearly view of the current (incomplete) year, viewDate.getEndDate()
+    // returns Dec 31 which has no balance data yet. Cap the lookup to the
+    // current month so the donut reflects actual accumulated balances.
+    const endDate = viewDate.getEndDate();
+    const today = new Date();
+    const viewDateDate =
+      viewDate.getInterval() === "year" && endDate > today
+        ? new ViewDate("month").getEndDate()
+        : endDate;
 
     filteredAccounts.forEach((a, i) => {
       const balanceHistory = balanceData.get(a.id);


### PR DESCRIPTION
## Summary

Fixes the Accounts page donut showing **$0 total balance** in yearly view for the current year.

## Problem

In yearly view for 2026, `viewDate.getEndDate()` returns Dec 31, 2026 (a future date). `BalanceHistory.get()` looks up by year-month key ("2026-12") which has no data, returning `undefined` → 0. This caused:
- Donut: **$0** (should be ~$1,066,685)
- Change: **-$1,037,854 from last year** (implied balance dropped to zero)
- Individual account rows: correct current balances (inconsistent with donut)

## Fix

Cap the balance lookup date to the current month when the year-end is in the future, matching the pattern from PR #160 (budget data fix):

```tsx
const viewDateDate =
  viewDate.getInterval() === "year" && endDate > today
    ? new ViewDate("month").getEndDate()
    : endDate;
```

## E2E Testing

- **Yearly 2026**: Donut shows $1,066,685 (+$28,831 from last year) ✓
- **Yearly 2025**: Donut shows $1,037,854 (+$458,144 from last year) ✓ (past year unaffected)
- **Monthly Mar 2026**: Donut shows $1,066,685 (+$32,306 from last month) ✓ (monthly unaffected)
- No console errors in any view ✓

Closes #176