### PR TITLE
fix: add keyboard accessibility and aria-labels to interactive elements

### DIFF
--- a/src/client/components/AccountsTable/AccountRow.tsx
+++ b/src/client/components/AccountsTable/AccountRow.tsx
@@ -1,4 +1,5 @@
 import { AccountType } from "plaid";
+import { KeyboardEvent } from "react";
 import { ItemProvider } from "common";
 import { Account, useAppContext, useAccountGraph, PATH, NoLabel } from "client";
 import { InstitutionSpan, Graph } from "client/components";
@@ -27,11 +28,26 @@ const AccountRow = ({ account, color }: Props) => {
     router.go(PATH.ACCOUNT_DETAIL, { params });
   };
 
+  const onKeyDownAccount = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onClickAccount();
+    }
+  };
+
   const noLabel = new NoLabel();
+  const accountLabel = custom_name || name || "Account";
 
   if (showGraph && !!graphData.lines) {
     return (
-      <div className="AccountRow threeChildren" onClick={onClickAccount}>
+      <div
+        className="AccountRow threeChildren"
+        onClick={onClickAccount}
+        onKeyDown={onKeyDownAccount}
+        role="button"
+        tabIndex={0}
+        aria-label={accountLabel}
+      >
         <div className="accountTitle">
           <div className="colorTag colored" style={{ backgroundColor: color }} />
           <div className="textTag">
@@ -62,7 +78,14 @@ const AccountRow = ({ account, color }: Props) => {
   }
 
   return (
-    <div className="AccountRow twoChildren" onClick={onClickAccount}>
+    <div
+      className="AccountRow twoChildren"
+      onClick={onClickAccount}
+      onKeyDown={onKeyDownAccount}
+      role="button"
+      tabIndex={0}
+      aria-label={accountLabel}
+    >
       <div className="accountTitle">
         <div className="textTag">
           <div>{custom_name || name}</div>

--- a/src/client/components/BalanceChartProperties.tsx
+++ b/src/client/components/BalanceChartProperties.tsx
@@ -99,7 +99,7 @@ export const BalanceChartProperties = ({ chart, children }: BalanceChartProperti
       <div className="property">
         <div className="row keyValue">
           <span className="propertyName">Chart&nbsp;Name</span>
-          <input value={nameInput} onChange={onChangeName} />
+          <input value={nameInput} onChange={onChangeName} aria-label="Chart name" />
         </div>
         <div className="row keyValue">
           <span className="propertyName">Chart&nbsp;Type</span>

--- a/src/client/components/BalanceChartRow/index.tsx
+++ b/src/client/components/BalanceChartRow/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, MouseEventHandler, SetStateAction } from "react";
+import { Dispatch, KeyboardEvent, MouseEventHandler, SetStateAction } from "react";
 import { AccountType } from "plaid";
 import { numberToCommaString, toTitleCase } from "common";
 import { BalanceChart, getAccountBalance, useAppContext, useReorder } from "client";
@@ -84,7 +84,23 @@ export const BalanceChartRow = ({
       }
     };
     return (
-      <tr key={`${i}_${name}`} onClick={onClickOverspentBudget}>
+      <tr
+        key={`${i}_${name}`}
+        onClick={onClickOverspentBudget}
+        onKeyDown={
+          isOverspentBudget
+            ? (e: KeyboardEvent<HTMLTableRowElement>) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onClickOverspentBudget();
+                }
+              }
+            : undefined
+        }
+        role={isOverspentBudget ? "button" : undefined}
+        tabIndex={isOverspentBudget ? 0 : undefined}
+        aria-label={isOverspentBudget ? `Overspent budget: ${name}` : undefined}
+      >
         <td className="type">
           {toTitleCase(type)}
           {isOverspentBudget && (

--- a/src/client/components/BudgetProperties/CapacitiesInput/index.tsx
+++ b/src/client/components/BudgetProperties/CapacitiesInput/index.tsx
@@ -88,6 +88,7 @@ const CapacitiesInput = ({
                     type="date"
                     defaultValue={getDateString(active_from)}
                     onBlur={onChangeDate}
+                    aria-label="Capacity active from date"
                   />
                 </>
               ) : (

--- a/src/client/components/BudgetProperties/index.tsx
+++ b/src/client/components/BudgetProperties/index.tsx
@@ -96,6 +96,7 @@ export const BudgetProperties = ({
                   type="date"
                   value={getDateString(rollOverStartDateInput)}
                   onChange={onChangeRollDate}
+                  aria-label="Roll over start date"
                 />
               </div>
             </div>

--- a/src/client/components/ProjectionChartProperties.tsx
+++ b/src/client/components/ProjectionChartProperties.tsx
@@ -179,7 +179,7 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
       <div className="property">
         <div className="row keyValue">
           <span className="propertyName">Chart&nbsp;Name</span>
-          <input value={nameInput} onChange={onChangeName} />
+          <input value={nameInput} onChange={onChangeName} aria-label="Chart name" />
         </div>
         <div className="row keyValue">
           <span className="propertyName">Chart&nbsp;Type</span>
@@ -224,6 +224,7 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
             type="date"
             defaultValue={getDateString(initial_saving.amountAsOf)}
             onBlur={onBlurInitialSavingDate}
+            aria-label="Initial saving as of date"
           />
         </div>
         <div className="row keyValue">
@@ -271,6 +272,7 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
             type="date"
             defaultValue={getDateString(living_cost.amountAsOf)}
             onBlur={onBlurLivingCostDate}
+            aria-label="Living cost as of date"
           />
         </div>
         <div className="row keyValue">

--- a/src/client/components/ProjectionChartRow/index.tsx
+++ b/src/client/components/ProjectionChartRow/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, MouseEventHandler, SetStateAction, useMemo } from "react";
+import React, { Dispatch, KeyboardEvent, MouseEventHandler, SetStateAction, useMemo } from "react";
 import { getYearMonthString, numberToCommaString, ViewDate } from "common";
 import { useAccountGraph, useAppContext, useReorder, ProjectionChart } from "client";
 import { ChevronDownIcon, ChevronUpIcon, DateLabel, Graph, MoneyLabel } from "client/components";
@@ -71,9 +71,23 @@ export const ProjectionChartRow = ({
     useLengthFixer: false,
   });
 
+  const onKeyDownChart = (e: KeyboardEvent<HTMLDivElement>) => {
+    if ((e.key === "Enter" || e.key === " ") && onClick) {
+      e.preventDefault();
+      onClick(e as unknown as React.MouseEvent<HTMLDivElement>);
+    }
+  };
+
   if (!account_ids?.length) {
     return (
-      <div className="ProjectionChartRow" onClick={onClick}>
+      <div
+        className="ProjectionChartRow"
+        onClick={onClick}
+        onKeyDown={onClick ? onKeyDownChart : undefined}
+        role={onClick ? "button" : undefined}
+        tabIndex={onClick ? 0 : undefined}
+        aria-label={chart.name}
+      >
         {showTitle && <div className="title">{chart.name}</div>}
         <Graph height={200} input={{}} />
       </div>
@@ -149,6 +163,10 @@ export const ProjectionChartRow = ({
     <div
       className={classes.join(" ")}
       onClick={onClick}
+      onKeyDown={onClick ? onKeyDownChart : undefined}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      aria-label={chart.name}
       draggable={true}
       onDragStart={onDragStart}
       onDragEnter={onDragEnter}

--- a/src/client/components/SectionBar.tsx
+++ b/src/client/components/SectionBar.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useEffect, useRef } from "react";
+import { Dispatch, KeyboardEvent, SetStateAction, useEffect, useRef } from "react";
 import { NewCategoryGetResponse } from "server";
 import {
   Budget,
@@ -134,7 +134,19 @@ export const SectionBar = ({ section, onSetOrder }: Props) => {
   return (
     <div className="SectionBar">
       {isOpen ? (
-        <div className="openLabel" onClick={onClickInfo}>
+        <div
+          className="openLabel"
+          onClick={onClickInfo}
+          onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onClickInfo();
+            }
+          }}
+          role="button"
+          tabIndex={0}
+          aria-label={`Collapse ${section.name}`}
+        >
           <span>{section.name}</span>
         </div>
       ) : (

--- a/src/client/components/TransactionsPageTitle/index.tsx
+++ b/src/client/components/TransactionsPageTitle/index.tsx
@@ -1,5 +1,5 @@
 import { AccountType } from "plaid";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { KeyboardEvent, useCallback, useEffect, useRef, useState } from "react";
 import { JSONInvestmentTransaction, JSONTransaction, toTitleCase } from "common";
 import {
   Account,
@@ -151,9 +151,21 @@ export const TransactionsPageTitle = ({
         </button>
         {isSelecting && (
           <div ref={selectBoxRef} className="select" onMouseLeave={closeSelect}>
-            <div className="selectLabel" onClick={closeSelect}>
+            <div
+              className="selectLabel"
+              onClick={closeSelect}
+              onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
+                if (e.key === "Enter" || e.key === " " || e.key === "Escape") {
+                  e.preventDefault();
+                  closeSelect();
+                }
+              }}
+              role="button"
+              tabIndex={0}
+              aria-label="Close transaction type selector"
+            >
               <span>Select&nbsp;transaction&nbsp;type</span>
-              <button className="closeButton">✕</button>
+              <button className="closeButton" aria-hidden="true">✕</button>
             </div>
             <div className="options">{options}</div>
           </div>


### PR DESCRIPTION
## Summary

Implements WCAG 2.1 Level A compliance for keyboard navigation and screen reader support.

## Closes
- Closes #162 — Accessibility: interactive elements not keyboard-accessible
- Closes #164 — Form inputs missing labels for accessibility

## Changes

### Keyboard Accessibility (#162)

Added `role="button"`, `tabIndex={0}`, and `onKeyDown` (Enter/Space) to clickable non-interactive elements:

| File | Element | Change |
|------|---------|--------|
| `AccountsTable/AccountRow.tsx` | `<div className="AccountRow">` | role=button, tabIndex, onKeyDown, aria-label |
| `SectionBar.tsx` | `<div className="openLabel">` | role=button, tabIndex, onKeyDown |
| `ProjectionChartRow/index.tsx` | Both `<div className="ProjectionChartRow">` | role=button, tabIndex, onKeyDown (only when onClick provided) |
| `BalanceChartRow/index.tsx` | `<tr onClick>` | role=button, tabIndex, onKeyDown (only for overspent budget rows) |
| `TransactionsPageTitle/index.tsx` | `<div className="selectLabel">` | role=button, tabIndex, onKeyDown + Escape support |

### Form Labels (#164)

Added `aria-label` to unlabeled `<input>` elements:

| File | Input | aria-label |
|------|-------|------------|
| `ProjectionChartProperties.tsx` | Chart name, initial saving date, living cost date | Added |
| `BalanceChartProperties.tsx` | Chart name | Added |
| `BudgetProperties/index.tsx` | Roll over start date | Added |
| `BudgetProperties/CapacitiesInput/index.tsx` | Capacity active from date | Added |

Note: `NameInput` and `CapacityInput` already spread `...rest`, so they accept `aria-label` from callers — no internal changes needed.

## E2E Testing

- Started app locally, verified no console errors
- Tab navigation works on AccountRow — focus ring visible, Enter navigates to account detail
- Tab navigation works on SectionBar openLabel — Enter collapses/expands
- TransactionsPageTitle: Escape closes select dropdown via keyboard
- BalanceChartRow: only overspent budget rows are focusable (non-interactive rows have no tabIndex)
- Screen reader testing: VoiceOver announces AccountRow as "[Account name], button"

## Test Results

236 pass, 12 pre-existing failures (inferCostBasis/getHoldingsValueData, unrelated to these changes)