### PR TITLE
fix: Clamp to current month when switching from yearly to monthly view

### DIFF
--- a/src/common/utils/date.test.ts
+++ b/src/common/utils/date.test.ts
@@ -240,6 +240,34 @@ describe("ViewDate", () => {
     expect(view.getSpanFrom(new Date(2024, 5, 1))).toBe(0); // Same month
     expect(view.getSpanFrom(new Date(2024, 7, 1))).toBe(-2); // August -> June = -2 months
   });
+
+  describe("setInterval", () => {
+    it("should clamp to current month when switching from year to month for current/future year", () => {
+      // Create a yearly view far in the future (guaranteed to be future)
+      const futureYear = new Date().getFullYear() + 1;
+      const view = new ViewDate("year", new Date(futureYear, 5, 15));
+      // End date should be Dec 31 of futureYear
+      expect(view.getEndDate().getFullYear()).toBe(futureYear);
+      expect(view.getEndDate().getMonth()).toBe(11); // December
+
+      // Switch to month — should clamp to current month since Dec futureYear is future
+      view.setInterval("month");
+      const now = new Date();
+      expect(view.getEndDate().getMonth()).toBe(now.getMonth());
+      expect(view.getEndDate().getFullYear()).toBe(now.getFullYear());
+    });
+
+    it("should keep December when switching from past year to month", () => {
+      const view = new ViewDate("year", new Date(2020, 5, 15));
+      expect(view.getEndDate().getFullYear()).toBe(2020);
+      expect(view.getEndDate().getMonth()).toBe(11); // December
+
+      // Switch to month — Dec 2020 is in the past, should stay
+      view.setInterval("month");
+      expect(view.getEndDate().getMonth()).toBe(11); // December
+      expect(view.getEndDate().getFullYear()).toBe(2020);
+    });
+  });
 });
 
 describe("IsDate", () => {

--- a/src/common/utils/date.ts
+++ b/src/common/utils/date.ts
@@ -64,6 +64,15 @@ export class ViewDate {
   setInterval = (interval: Interval) => {
     this.interval = interval;
     this.current();
+
+    // When switching from year to month, the stored year-end date (Dec 31)
+    // causes current() to land on December. If that's in the future,
+    // clamp to the current month instead.
+    if (interval === "month" && this.date > new Date()) {
+      this.date = new Date();
+      this.current();
+    }
+
     return this;
   };
 


### PR DESCRIPTION
## Summary

Fixes the date picker showing December instead of the current month when switching from Yearly to Monthly view.

## Problem

When switching from Yearly 2026 → Monthly, the app showed **December 2026** instead of **March 2026** (current month). Users had to manually click back 9 times to reach the current month, and Dec 2026 displayed misleading data (current account balances paired with empty future-month budget capacities).

## Root Cause

`ViewDate.setInterval()` calls `this.current()` to normalize the stored date. In Yearly mode, the internal date is Dec 31. When switching to Monthly, `current()` computes end-of-December without checking if that month is in the future.

## Fix

Added a future-date guard in `setInterval()`: after switching to `month` interval, if the resulting date is after today, reset to the current date and re-normalize. Past years (e.g., Yearly 2025 → Monthly) correctly stay on December.

## Changes

- `src/common/utils/date.ts`: Added future-date clamp in `setInterval()`
- `src/common/utils/date.test.ts`: Added 2 unit tests for the interval switching behavior

## E2E Testing

1. Started app locally (`bun run dev` on port 3000)
2. Dashboard → Mar 2026 ✓
3. Switched to Yearly → 2026 ✓
4. Switched back to Monthly → **Mar 2026** ✓ (was Dec 2026 before fix)
5. Switched to Yearly → navigated to 2025 → switched to Monthly → **Dec 2025** ✓ (past year unaffected)
6. All existing tests pass (32/32)

Closes #179