### PR TITLE
fix: guard against empty capacities in BudgetFamily.fromJSON

### DIFF
--- a/src/client/lib/models/BudgetFamily.ts
+++ b/src/client/lib/models/BudgetFamily.ts
@@ -65,6 +65,7 @@ export class BudgetFamily {
       this.roll_over_start_date = new LocalDate(this.roll_over_start_date);
     }
     this.capacities = this.capacities.map((c) => new Capacity(c));
+    if (!this.capacities.length) this.capacities = [new Capacity()];
   };
 
   toJSON(): JSONBudgetFamily {


### PR DESCRIPTION
## Summary

Fixes a crash when any budget, section, or category has `capacities: []` in the database.

## Root Cause

`Budget`, `Section`, and `Category` subclasses all follow this constructor pattern:

```ts
constructor(init) {
  super(init);       // assigns, fromJSON, adds default capacity if empty
  assign(this, init); // OVERWRITES capacities back to [] from API data
  this.fromJSON();   // maps [] → [], no length check → capacities still []
}
```

The parent `BudgetFamily` constructor has a guard (`if (!this.capacities.length) this.capacities = [new Capacity()]`) but the subclass calls `assign(this, init)` again, resetting capacities to `[]`. The subsequent `fromJSON()` call in the subclass does not repeat that guard.

Result: `getActiveCapacity()` returns `undefined`, crashing `LabeledBar` with:
`TypeError: Cannot read properties of undefined (reading 'month')`

## Fix

Move the empty-capacities guard into `fromJSON()` itself so it runs every time — both from the parent and subclass constructor calls:

```diff
 protected fromJSON = () => {
   ...
   this.capacities = this.capacities.map((c) => new Capacity(c));
+  if (!this.capacities.length) this.capacities = [new Capacity()];
 };
```

## Testing

- e2e: Confirmed the existing DB entries with `capacities: []` (IDs `540b7170`, `86a6f730`) no longer crash the Budgets page
- The guard now runs in the subclass `fromJSON()` call, not just in the parent constructor

Closes #138