### PR TITLE
fix: use historical balance in BalanceChartRow for past months

### DIFF
--- a/src/client/components/BalanceChartRow/index.tsx
+++ b/src/client/components/BalanceChartRow/index.tsx
@@ -23,7 +23,7 @@ export const BalanceChartRow = ({
 }: BalanceChartRowProps) => {
   const { data, calculations, viewDate } = useAppContext();
   const { accounts, budgets } = data;
-  const { budgetData } = calculations;
+  const { budgetData, balanceData } = calculations;
   const { name, configuration } = chart;
 
   const {
@@ -37,21 +37,25 @@ export const BalanceChartRow = ({
     isDragging,
   } = useReorder(chart.id, onSetOrder);
 
+  const date = viewDate.getEndDate();
+  const interval = viewDate.getInterval();
+
   const column1: StackData[] = [];
   const column2: StackData[] = [];
 
   accounts.forEach((a) => {
     if (a.hide) return;
-    const stack = { type: a.type, name: a.custom_name || a.name, amount: getAccountBalance(a) };
+    // Use historical balance for the selected view date so that switching
+    // to a past month reflects the balance at that time rather than today's
+    // live Plaid balance.
+    const historicalBalance = balanceData.get(a.id, date) || getAccountBalance(a);
+    const stack = { type: a.type, name: a.custom_name || a.name, amount: historicalBalance };
     if (!configuration.account_ids.includes(a.id)) return;
     if (a.type === AccountType.Depository) column1.push(stack);
     else if (a.type === AccountType.Investment) column1.push(stack);
     else if (a.type === AccountType.Credit) column2.push(stack);
     else if (a.type === AccountType.Loan) column2.push(stack);
   });
-
-  const date = viewDate.getEndDate();
-  const interval = viewDate.getInterval();
 
   budgets.forEach((b) => {
     if (!configuration.budget_ids.includes(b.id)) return;


### PR DESCRIPTION
## Problem

`BalanceChartRow` called `getAccountBalance(a)` which always returns the current live Plaid balance. When viewing a historical month (e.g., February 2026), the balance chart total showed today's balances while budget allocations correctly used historical `viewDate` data — creating a misleading mismatch.

Example reported in #183:
| Chart | March 2026 (current) | February 2026 |
|-------|---------------------|---------------|
| Total Balance accounts | $107,976 | $107,976 ← wrong, unchanged |
| Total Balance budgets | -$108,149 | -$100,997 ← correct, varies |

## Fix

Use `balanceData.get(a.id, date)` (the historical snapshot for `viewDate.getEndDate()`) with `getAccountBalance(a)` as a fallback when no snapshot exists for that period. This matches the pattern already used in:
- `AccountsTable/Balance.tsx` — `balanceHistory.get(viewDateDate) || current`
- `AccountsDonut/BalanceInfo.tsx`

Also moved the `date`/`interval` declarations before the accounts loop to avoid duplicating the `viewDate.getEndDate()` call.

## Testing

TypeScript compiles cleanly. The fix uses the same historical balance system already working in AccountsTable and AccountsDonut.

Closes #183