### PR TITLE
reliability: validate SimpleFin HTTP responses and evict stale caches

### DIFF
--- a/src/server/lib/plaid/webhook.ts
+++ b/src/server/lib/plaid/webhook.ts
@@ -5,6 +5,14 @@ import { getProductionClient } from "./util";
 const keyCache = new Map<string, { key: jose.JWK; fetchedAt: number }>();
 const KEY_CACHE_TTL = 1000 * 60 * 60; // 1 hour
 
+// Periodically evict stale key cache entries to prevent unbounded growth.
+setInterval(() => {
+  const now = Date.now();
+  for (const [keyId, entry] of keyCache) {
+    if (now - entry.fetchedAt >= KEY_CACHE_TTL) keyCache.delete(keyId);
+  }
+}, KEY_CACHE_TTL).unref();
+
 /**
  * Verify a Plaid webhook request.
  * 

--- a/src/server/lib/polygon.ts
+++ b/src/server/lib/polygon.ts
@@ -29,6 +29,14 @@ export type PolygonResult<T> =
 const priceCache = new Map<string, { price: number; fetchedAt: number }>();
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
+// Periodically evict stale price cache entries to prevent unbounded growth.
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of priceCache) {
+    if (now - entry.fetchedAt >= CACHE_TTL_MS) priceCache.delete(key);
+  }
+}, CACHE_TTL_MS).unref();
+
 /**
  * Fetch with retry logic for transient failures
  */

--- a/src/server/lib/simple-fin/data.ts
+++ b/src/server/lib/simple-fin/data.ts
@@ -37,8 +37,24 @@ export const getData = async (item: JSONItem, options: GetSimpleFinDataOptions) 
     headers: { Authorization: `Basic ${credentials}` },
   });
 
+  if (!response.ok) {
+    throw new Error(
+      `SimpleFin API error: ${response.status} ${response.statusText} (${url})`
+    );
+  }
+
   type ResponseData = { errors: unknown[]; accounts: SimpleFinAccount[] };
   const data: ResponseData = await response.json();
+
+  if (!Array.isArray(data.accounts)) {
+    throw new Error(
+      `SimpleFin API returned unexpected response shape: missing accounts array`
+    );
+  }
+
+  if (data.errors && data.errors.length > 0) {
+    throw new Error(`SimpleFin API returned errors: ${JSON.stringify(data.errors)}`);
+  }
 
   return modelize(item, data.accounts);
 };

--- a/src/server/lib/simple-fin/tokens.ts
+++ b/src/server/lib/simple-fin/tokens.ts
@@ -17,6 +17,11 @@ type AccessUrl = string;
 export const exchangeSetupToken = async (setupToken: SetupToken): Promise<AccessUrl> => {
   const setupUrl = Buffer.from(setupToken, "base64").toString();
   const response = await fetch(setupUrl, { method: "POST", headers: { "Content-Length": "0" } });
+  if (!response.ok) {
+    throw new Error(
+      `SimpleFin token exchange failed: ${response.status} ${response.statusText}`
+    );
+  }
   return await response.text();
 };
 


### PR DESCRIPTION
## Problems Fixed

### SimpleFin response validation (Closes #184)

`getData()` and `exchangeSetupToken()` in `simple-fin/` called `fetch()` without checking `response.ok`. This caused:
- 4xx/5xx errors to throw with a cryptic JSON parse error (receiving HTML error page)
- `exchangeSetupToken` could return an HTML error page body as the access URL, causing silent failures later
- Non-empty `data.errors` arrays were silently ignored

**Changes:**
- `data.ts`: throw on `!response.ok`; validate `data.accounts` is an array; throw if `data.errors` is non-empty
- `tokens.ts`: throw on `!response.ok` in `exchangeSetupToken`

### Unbounded cache eviction (Closes #185)

`priceCache` (polygon.ts) and `keyCache` (webhook.ts) both had TTL checks on *read* but never *deleted* stale entries. In a long-running process with frequent ticker/date lookups, entries accumulate indefinitely.

**Changes:**
- `polygon.ts`: add `setInterval` eviction loop (runs every `CACHE_TTL_MS` = 1hr)
- `webhook.ts`: add `setInterval` eviction loop (runs every `KEY_CACHE_TTL` = 1hr)
- Both use `.unref()` so the timer does not prevent clean process shutdown

## Testing

TypeScript compiles cleanly. The SimpleFin validation matches the error-handling pattern already used in `polygon.ts`.