### PR TITLE
fix: duplicate barrel export and HTTP security headers

### DIFF
--- a/src/server/routes/accounts/index.ts
+++ b/src/server/routes/accounts/index.ts
@@ -3,7 +3,6 @@ export * from "./delete-snapshot";
 export * from "./delete-split-transaction";
 export * from "./get-oldest-transaction-date";
 export * from "./get-transactions";
-export * from "./get-transactions";
 export * from "./get-new-split-transaction";
 export * from "./get-split-transactions";
 export * from "./get-accounts";

--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -18,6 +18,17 @@ if (process.env.NODE_ENV === "production") {
   app.set("trust proxy", 1);
 }
 
+// Security headers
+app.use((_req, res, next) => {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("X-Frame-Options", "DENY");
+  res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+  if (process.env.NODE_ENV === "production") {
+    res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  }
+  next();
+});
+
 // Parse JSON and store raw body for webhook verification
 app.use(
   express.json({


### PR DESCRIPTION
## Summary

### Closes #190 — Duplicate barrel export
Removed duplicate `export * from './get-transactions'` in `src/server/routes/accounts/index.ts`.

### Closes #191 — HTTP security headers
Added security headers middleware to `src/server/start.ts`:
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Strict-Transport-Security` (production only)

## Testing

`bun run tsc --noEmit` passes cleanly.