### PR TITLE
fix: skip static file serving in dev mode to prevent ENOENT errors

### DIFF
--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -75,13 +75,15 @@ Object.values(routes).forEach(({ path, handler }) => router.use(path, handler));
 
 app.use("/api", router);
 
-const clientPath = path.resolve(import.meta.dir, "..", "client");
-
-app.use(express.static(clientPath));
-
-app.get("*", (_req, res) => {
-  res.sendFile(path.join(clientPath, "index.html"));
-});
+// In dev mode, Vite's dev server (port 3000) serves static files and proxies /api here.
+// Static file serving is only needed in production where the build output exists.
+if (process.env.NODE_ENV === "production") {
+  const clientPath = path.resolve(import.meta.dir, "..", "client");
+  app.use(express.static(clientPath));
+  app.get("*", (_req, res) => {
+    res.sendFile(path.join(clientPath, "index.html"));
+  });
+}
 
 app.listen(process.env.PORT || 3005, async () => {
   await initializePostgres();


### PR DESCRIPTION
## Problem

In dev mode (`bun run dev`), the express server (port 3005) was trying to serve static files from `src/client`, which doesn't contain `index.html` (that lives at the project root). This caused ENOENT errors on every non-API GET request:

```
Error: ENOENT: no such file or directory, stat '.../budget/src/client/index.html'
```

## Root Cause

The `clientPath` resolved to `src/client` in dev mode (where `import.meta.dir` is `src/server`), but the build output (`build/client`) doesn't exist in dev mode. In production, `import.meta.dir` is `build/server`, so `../client` resolves correctly to `build/client`.

## Fix

Guard static file serving behind `NODE_ENV === "production"`. In dev mode, Vite's dev server (port 3000) serves static files and proxies `/api` to the express server — the express server doesn't need to serve static files at all.

## Testing

- Dev: run `bun run dev` — no more ENOENT errors in server output; app loads via Vite (port 3000) as before
- Production: `NODE_ENV=production bun run start` — static files still served correctly from `build/client`

Closes #104