### PR TITLE
docs: add ownership verification and collection lookup patterns to DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -461,6 +461,50 @@ useEffect(() => {
 }, [deps]);
 ```
 
+### Resource Ownership Verification
+
+**Every delete/update route must verify the resource belongs to the authenticated user.**
+
+Repository-level `softDelete` by primary key alone is NOT sufficient — it doesn't scope by `user_id`:
+
+```typescript
+// ❌ Dangerous - deletes any user's resource
+await snapshotsTable.softDelete(snapshot_id);
+
+// ✅ Safe - verify ownership first
+const snapshot = await searchSnapshots(user, { snapshot_id });
+if (!snapshot) return { status: "failed", message: "Not found" };
+await snapshotsTable.softDelete(snapshot_id);
+
+// ✅ Better - scope the delete query itself by user_id
+await pool.query(
+  "UPDATE snapshots SET is_deleted = TRUE WHERE snapshot_id = $1 AND user_id = $2",
+  [snapshot_id, user.user_id]
+);
+```
+
+Routes like `deleteAccounts` correctly use `searchAccountsById(user, ...)` to verify ownership before deleting. All delete/update routes should follow this pattern.
+
+### Collection Lookup Performance
+
+When matching items across two collections (e.g., finding removed transactions), **pre-build lookup structures** instead of nested iteration:
+
+```typescript
+// ❌ O(n²) - .find() inside .forEach()
+storedTransactions.forEach((t) => {
+  const found = incoming.find((f) => f.id === t.id);
+  if (!found) removed.push(t);
+});
+
+// ✅ O(n) - Set lookup
+const incomingIds = new Set(incoming.map((t) => t.id));
+storedTransactions.forEach((t) => {
+  if (!incomingIds.has(t.id)) removed.push(t);
+});
+```
+
+This matters in sync operations where transaction lists can grow to thousands of entries.
+
 ## Common Tasks
 
 ### Adding a New API Route


### PR DESCRIPTION
## Changes

Adds two new patterns to the Design Patterns section of DEVELOPMENT.md:

### Resource Ownership Verification
Documents that every delete/update route must verify the resource belongs to the authenticated user. Highlights the gap between repository-level `softDelete` (which operates by primary key only) and proper user-scoped operations.

### Collection Lookup Performance
Documents the anti-pattern of using `.find()` inside loops (O(n²)) and the preferred Set/Map approach (O(n)) for matching items across collections during sync operations.

### Context
- Related issues: #168 (IDOR), #200 (O(n²) sync), #202 (non-atomic sync)
- Pattern extracted from existing good examples (`deleteAccounts` in accounts.ts)

### E2E Testing
Documentation-only change. Verified markdown renders correctly and no code changes.