### PR TITLE
fix: wrap deleteBudget, deleteSection, and deleteItem in transactions

### DIFF
--- a/src/server/lib/postgres/repositories/budgets.ts
+++ b/src/server/lib/postgres/repositories/budgets.ts
@@ -11,6 +11,7 @@ import {
   SECTION_ID,
   USER_ID,
 } from "../models";
+import { withTransaction } from "../client";
 import { logger } from "../../logger";
 
 export const getBudgets = async (user: MaskedUser): Promise<JSONBudget[]> => {
@@ -83,15 +84,18 @@ export const deleteBudget = async (user: MaskedUser, budget_id: string): Promise
   const sections = await sectionsTable.query({ [USER_ID]: user.user_id, [BUDGET_ID]: budget_id });
   const sectionIds = sections.map((s) => s.section_id);
 
-  for (const sid of sectionIds) {
-    await categoriesTable.bulkSoftDeleteByColumn(SECTION_ID, sid, user.user_id);
-  }
+  return withTransaction(async (client) => {
+    for (const sid of sectionIds) {
+      await categoriesTable.bulkSoftDeleteByColumn(SECTION_ID, sid, user.user_id, client);
+    }
 
-  for (const sid of sectionIds) {
-    await sectionsTable.softDelete(sid, user.user_id);
-  }
+    if (sectionIds.length > 0) {
+      await sectionsTable.bulkSoftDelete(sectionIds, { [USER_ID]: user.user_id }, client);
+    }
 
-  return await budgetsTable.softDelete(budget_id, user.user_id);
+    const deleted = await budgetsTable.bulkSoftDelete([budget_id], { [USER_ID]: user.user_id }, client);
+    return deleted > 0;
+  });
 };
 
 export const deleteBudgets = async (
@@ -156,8 +160,11 @@ export const updateSection = async (
 };
 
 export const deleteSection = async (user: MaskedUser, section_id: string): Promise<boolean> => {
-  await categoriesTable.bulkSoftDeleteByColumn(SECTION_ID, section_id, user.user_id);
-  return await sectionsTable.softDelete(section_id, user.user_id);
+  return withTransaction(async (client) => {
+    await categoriesTable.bulkSoftDeleteByColumn(SECTION_ID, section_id, user.user_id, client);
+    const deleted = await sectionsTable.bulkSoftDelete([section_id], { [USER_ID]: user.user_id }, client);
+    return deleted > 0;
+  });
 };
 
 export const deleteSections = async (

--- a/src/server/lib/postgres/repositories/items.ts
+++ b/src/server/lib/postgres/repositories/items.ts
@@ -15,7 +15,7 @@ import {
   ACCOUNT_ID,
   QueryExecutor,
 } from "../models";
-import { pool } from "../client";
+import { pool, withTransaction } from "../client";
 import { UpsertResult, successResult, errorResult, noChangeResult } from "../database";
 import { logger } from "../../logger";
 
@@ -142,16 +142,22 @@ export const deleteItem = async (user: MaskedUser, item_id: string): Promise<boo
   const accounts = await accountsTable.query({ [ITEM_ID]: item_id, [USER_ID]: user_id });
   const accountIds = accounts.map((a) => a.account_id);
 
-  for (const account_id of accountIds) {
-    await transactionsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id);
-    await investmentTransactionsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id);
-    await splitTransactionsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id);
-    await snapshotsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id);
-    await holdingsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id);
-    await accountsTable.softDelete(account_id);
-  }
+  return withTransaction(async (client) => {
+    for (const account_id of accountIds) {
+      await transactionsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id, client);
+      await investmentTransactionsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id, client);
+      await splitTransactionsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id, client);
+      await snapshotsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id, client);
+      await holdingsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id, client);
+    }
 
-  return await itemsTable.softDelete(item_id);
+    if (accountIds.length > 0) {
+      await accountsTable.bulkSoftDelete(accountIds, { [USER_ID]: user_id }, client);
+    }
+
+    const deleted = await itemsTable.bulkSoftDelete([item_id], { [USER_ID]: user_id }, client);
+    return deleted > 0;
+  });
 };
 
 export const deleteItems = async (


### PR DESCRIPTION
## Problem

Multi-step delete operations were not atomic. If a later step failed, earlier deletions would remain committed, leaving orphaned records in the database.

**`deleteBudget`** — deletes categories → sections → budget sequentially without a transaction. If section deletion fails, categories are already deleted but the budget remains.

**`deleteSection`** — deletes categories → section sequentially. If section deletion fails, categories are already gone.

**`deleteItem`** — deletes transactions/snapshots/holdings → accounts → item for each account. A failure mid-way leaves partially deleted item data.

## Solution

Wrap each multi-step delete in `withTransaction()` using the existing DB client infrastructure. Converts remaining `softDelete()` calls (which don't accept a client) to `bulkSoftDelete()` / `bulkSoftDeleteByColumn()` (which already support PoolClient injection).

`deleteAccount` was already fixed in a prior PR.

## Changes

- **`budgets.ts`**: `deleteBudget` and `deleteSection` wrapped in `withTransaction`
- **`items.ts`**: `deleteItem` wrapped in `withTransaction`

## Testing

- TypeScript builds cleanly (`npx tsc --noEmit`)
- All deletes are now atomic: a failure at any step rolls back the entire operation

Closes #65