### PR TITLE
refactor: propagate repository errors instead of swallowing them

### DIFF
--- a/src/server/lib/postgres/repositories/budgets.ts
+++ b/src/server/lib/postgres/repositories/budgets.ts
@@ -12,7 +12,6 @@ import {
   USER_ID,
 } from "../models";
 import { withTransaction } from "../client";
-import { logger } from "../../logger";
 
 export const getBudgets = async (user: MaskedUser): Promise<JSONBudget[]> => {
   const models = await budgetsTable.query({ [USER_ID]: user.user_id });
@@ -41,25 +40,20 @@ export const createBudget = async (
   user: MaskedUser,
   data: Partial<JSONBudget>,
 ): Promise<JSONBudget | null> => {
-  try {
-    const row = BudgetModel.fromJSON(
-      {
-        name: data.name || "New Budget",
-        iso_currency_code: data.iso_currency_code || "USD",
-        roll_over: data.roll_over || false,
-        roll_over_start_date: data.roll_over_start_date,
-        capacities: data.capacities || [],
-      },
-      user.user_id,
-    );
-    const result = await budgetsTable.insert(row, ["*"]);
-    if (!result) return null;
-    const model = new BudgetModel(result);
-    return model.toJSON();
-  } catch (error) {
-    logger.error("Failed to create budget", {}, error);
-    return null;
-  }
+  const row = BudgetModel.fromJSON(
+    {
+      name: data.name || "New Budget",
+      iso_currency_code: data.iso_currency_code || "USD",
+      roll_over: data.roll_over || false,
+      roll_over_start_date: data.roll_over_start_date,
+      capacities: data.capacities || [],
+    },
+    user.user_id,
+  );
+  const result = await budgetsTable.insert(row, ["*"]);
+  if (!result) return null;
+  const model = new BudgetModel(result);
+  return model.toJSON();
 };
 
 export const updateBudget = async (
@@ -121,25 +115,20 @@ export const createSection = async (
   user: MaskedUser,
   data: Partial<JSONSection>,
 ): Promise<JSONSection | null> => {
-  try {
-    const row = SectionModel.fromJSON(
-      {
-        budget_id: data.budget_id,
-        name: data.name || "New Section",
-        roll_over: data.roll_over || false,
-        roll_over_start_date: data.roll_over_start_date,
-        capacities: data.capacities || [],
-      },
-      user.user_id,
-    );
-    const result = await sectionsTable.insert(row, ["*"]);
-    if (!result) return null;
-    const model = new SectionModel(result);
-    return model.toJSON();
-  } catch (error) {
-    logger.error("Failed to create section", {}, error);
-    return null;
-  }
+  const row = SectionModel.fromJSON(
+    {
+      budget_id: data.budget_id,
+      name: data.name || "New Section",
+      roll_over: data.roll_over || false,
+      roll_over_start_date: data.roll_over_start_date,
+      capacities: data.capacities || [],
+    },
+    user.user_id,
+  );
+  const result = await sectionsTable.insert(row, ["*"]);
+  if (!result) return null;
+  const model = new SectionModel(result);
+  return model.toJSON();
 };
 
 export const updateSection = async (
@@ -193,25 +182,20 @@ export const createCategory = async (
   user: MaskedUser,
   data: Partial<JSONCategory>,
 ): Promise<JSONCategory | null> => {
-  try {
-    const row = CategoryModel.fromJSON(
-      {
-        section_id: data.section_id,
-        name: data.name || "New Category",
-        roll_over: data.roll_over || false,
-        roll_over_start_date: data.roll_over_start_date,
-        capacities: data.capacities || [],
-      },
-      user.user_id,
-    );
-    const result = await categoriesTable.insert(row, ["*"]);
-    if (!result) return null;
-    const model = new CategoryModel(result);
-    return model.toJSON();
-  } catch (error) {
-    logger.error("Failed to create category", {}, error);
-    return null;
-  }
+  const row = CategoryModel.fromJSON(
+    {
+      section_id: data.section_id,
+      name: data.name || "New Category",
+      roll_over: data.roll_over || false,
+      roll_over_start_date: data.roll_over_start_date,
+      capacities: data.capacities || [],
+    },
+    user.user_id,
+  );
+  const result = await categoriesTable.insert(row, ["*"]);
+  if (!result) return null;
+  const model = new CategoryModel(result);
+  return model.toJSON();
 };
 
 export const updateCategory = async (

--- a/src/server/lib/postgres/repositories/charts.ts
+++ b/src/server/lib/postgres/repositories/charts.ts
@@ -1,6 +1,5 @@
 import { JSONChart, ChartType } from "common";
 import { MaskedUser, chartsTable, ChartModel, CHART_ID, USER_ID } from "../models";
-import { logger } from "../../logger";
 
 export const getCharts = async (user: MaskedUser): Promise<JSONChart[]> => {
   const models = await chartsTable.query({ [USER_ID]: user.user_id });
@@ -28,28 +27,23 @@ export const createChart = async (
   user: MaskedUser,
   data: Partial<JSONChart>,
 ): Promise<JSONChart | null> => {
-  try {
-    const config = data.configuration
-      ? typeof data.configuration === "string"
-        ? data.configuration
-        : JSON.stringify(data.configuration)
-      : "{}";
+  const config = data.configuration
+    ? typeof data.configuration === "string"
+      ? data.configuration
+      : JSON.stringify(data.configuration)
+    : "{}";
 
-    const row = {
-      [USER_ID]: user.user_id,
-      name: data.name || "New Chart",
-      type: data.type || ChartType.BALANCE,
-      configuration: config,
-    };
+  const row = {
+    [USER_ID]: user.user_id,
+    name: data.name || "New Chart",
+    type: data.type || ChartType.BALANCE,
+    configuration: config,
+  };
 
-    const result = await chartsTable.insert(row, ["*"]);
-    if (!result) return null;
-    const model = new ChartModel(result);
-    return model.toJSON();
-  } catch (error) {
-    logger.error("Failed to create chart", {}, error);
-    return null;
-  }
+  const result = await chartsTable.insert(row, ["*"]);
+  if (!result) return null;
+  const model = new ChartModel(result);
+  return model.toJSON();
 };
 
 export const updateChart = async (

--- a/src/server/lib/postgres/repositories/users.ts
+++ b/src/server/lib/postgres/repositories/users.ts
@@ -1,7 +1,6 @@
 import bcrypt from "bcrypt";
 import { DeepPartial } from "common";
 import { MaskedUser, User, usersTable, USER_ID } from "../models";
-import { logger } from "../../logger";
 
 export type IndexUserInput = Omit<User, "user_id"> & { user_id?: string };
 export type PartialUser = { user_id: string } & DeepPartial<User>;
@@ -15,33 +14,23 @@ export const writeUser = async (user: IndexUserInput): Promise<{ _id: string } |
   const { user_id, username, password } = user;
   const hashedPassword = password ? await bcrypt.hash(password, 10) : undefined;
 
-  try {
-    const row: Record<string, unknown> = { username, password: hashedPassword };
-    if (user_id) row.user_id = user_id;
+  const row: Record<string, unknown> = { username, password: hashedPassword };
+  if (user_id) row.user_id = user_id;
 
-    const result = await usersTable.upsert(row);
-    if (result) return { _id: result.user_id as string };
-    return undefined;
-  } catch (error) {
-    logger.error("Failed to write user", {}, error);
-    return undefined;
-  }
+  const result = await usersTable.upsert(row);
+  if (result) return { _id: result.user_id as string };
+  return undefined;
 };
 
 export const searchUser = async (user: Partial<MaskedUser>): Promise<User | undefined> => {
-  try {
-    const filters: Record<string, unknown> = {};
-    if (user.user_id) filters[USER_ID] = user.user_id;
-    if (user.username) filters.username = user.username;
+  const filters: Record<string, unknown> = {};
+  if (user.user_id) filters[USER_ID] = user.user_id;
+  if (user.username) filters.username = user.username;
 
-    if (Object.keys(filters).length === 0) return undefined;
+  if (Object.keys(filters).length === 0) return undefined;
 
-    const model = await usersTable.queryOne(filters);
-    return model?.toUser();
-  } catch (error) {
-    logger.error("Failed to search user", {}, error);
-    return undefined;
-  }
+  const model = await usersTable.queryOne(filters);
+  return model?.toUser();
 };
 
 export const updateUser = async (user: PartialUser): Promise<boolean> => {
@@ -54,30 +43,15 @@ export const updateUser = async (user: PartialUser): Promise<boolean> => {
 
   if (Object.keys(updates).length === 0) return false;
 
-  try {
-    const model = await usersTable.update(user_id, updates);
-    return model !== null;
-  } catch (error) {
-    logger.error("Failed to update user", {}, error);
-    return false;
-  }
+  const model = await usersTable.update(user_id, updates);
+  return model !== null;
 };
 
 export const getUserById = async (user_id: string): Promise<User | undefined> => {
-  try {
-    const model = await usersTable.queryOne({ [USER_ID]: user_id });
-    return model?.toUser();
-  } catch (error) {
-    logger.error("Failed to get user by ID", { userId: user_id }, error);
-    return undefined;
-  }
+  const model = await usersTable.queryOne({ [USER_ID]: user_id });
+  return model?.toUser();
 };
 
 export const deleteUser = async (user_id: string): Promise<boolean> => {
-  try {
-    return await usersTable.softDelete(user_id);
-  } catch (error) {
-    logger.error("Failed to delete user", { userId: user_id }, error);
-    return false;
-  }
+  return await usersTable.softDelete(user_id);
 };


### PR DESCRIPTION
## Summary

Repository functions were catching database errors and silently returning `undefined`/`null`/`false`, making it impossible for callers to distinguish between 'record not found' and 'database unavailable'.

The `Route` class (`src/server/lib/route.ts`) already catches all unhandled errors and returns a 500 with the error message — so propagating DB errors surfaces real failures at the HTTP layer without losing data or silencing bugs.

## Changes

**Files modified:** `repositories/users.ts`, `repositories/budgets.ts`, `repositories/charts.ts`

**Functions fixed (try/catch removed, errors now propagate):**
- `users`: `writeUser`, `searchUser`, `updateUser`, `getUserById`, `deleteUser`
- `budgets`: `createBudget`, `createSection`, `createCategory`
- `charts`: `createChart`

**Intentionally unchanged:** Batch functions (`upsertAccounts`, `upsertTransactions`, etc.) that accumulate per-item `UpsertResult[]` — partial success is the correct semantic for bulk sync operations.

## Testing

- `bun run tsc --noEmit` — no type errors
- Route-level error handling confirmed in `src/server/lib/route.ts` (lines 29–35)

Closes #93