### PR TITLE
fix: accounts page total shows $0 in yearly view for current year

### DIFF
--- a/src/client/pages/AccountsPage/index.tsx
+++ b/src/client/pages/AccountsPage/index.tsx
@@ -34,7 +34,7 @@ export const AccountsPage = () => {
 
     filteredAccounts.forEach((a, i) => {
       const balanceHistory = balanceData.get(a.id);
-      const value = balanceHistory.get(viewDateDate) || 0;
+      const value = balanceHistory.get(viewDateDate) || getAccountBalance(a);
       balanceTotal += value;
       const color = colors[i % colors.length];
       const label = a.custom_name || a.name || "Unnamed";


### PR DESCRIPTION
## Problem

On the Accounts page, switching to yearly view (e.g., 2026) shows **$0** for the total balance in the donut chart, while individual account rows still display correct values.

## Root Cause

`viewDate.getEndDate()` returns Dec 31, 2026 in yearly view — a future date with no stored balance history. The donut total was summing zeros:

```ts
const value = balanceHistory.get(viewDateDate) || 0;  // always 0 for future dates
balanceTotal += value;
```

Meanwhile `Balance.tsx` (used by individual rows) already falls back to the raw Plaid balance when `dynamicAmount` is falsy.

## Fix

Apply the same fallback in `AccountsPage`:

```ts
const value = balanceHistory.get(viewDateDate) || getAccountBalance(a);
```

This matches the existing behavior of `AccountRow` / `Balance.tsx`.

## Testing
1. Log in, navigate to Accounts page
2. Switch to Yearly view (2026)
3. Verify total balance matches the sum of individual account rows

Closes #227