### PR TITLE
fix: correct plaid-hook URL path in rawBody capture middleware

### DIFF
--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -35,8 +35,10 @@ app.use(
   express.json({
     limit: "1mb",
     verify: (req, _res, buf) => {
-      // Store raw body for Plaid webhook verification
-      if (req.url === "/plaid-hook") {
+      // Store raw body for Plaid webhook verification.
+      // req.url at this middleware level includes the /api prefix, so we match
+      // against "/api/plaid-hook" (not just "/plaid-hook").
+      if (req.url === "/api/plaid-hook") {
         (req as any).rawBody = buf.toString();
       }
     },


### PR DESCRIPTION
## Problem

The `express.json` `verify` callback in `start.ts` was checking `req.url === "/plaid-hook"` to decide whether to capture the raw request body for Plaid webhook signature verification.

However, at the app-level middleware layer, `req.url` includes the full path — `/api/plaid-hook` — not just the route suffix. The condition never matched, so `rawBody` was never set, causing every Plaid webhook to fail verification and return 401.

**Observed in prod logs:**
```
[Plaid Webhook] Raw body not available for verification
```
Happening on every inbound `POST /api/plaid-hook` call.

## Fix

Change the URL check from `/plaid-hook` to `/api/plaid-hook` to match the actual value of `req.url` at the app middleware level.

## Testing

- Plaid webhooks will now pass the raw body check and proceed to signature verification
- Legitimate webhooks with a valid `plaid-verification` JWT header will be accepted
- Requests without the header continue to return 401 (unchanged behavior)

## Related

Discovered during prod alarm drill on 2026-03-25.