### PR TITLE
feat: add Docker healthcheck for budget container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,7 @@ COPY --from=builder /app/build ./build
 # Environment variables should be provided at runtime, not baked into the image.
 # Use: docker run --env-file .env ...
 # Or Docker Compose: env_file: - .env
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD curl -f http://localhost:3005/api/health || exit 1
+
 CMD ["bun", "./build/server/bundle.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,12 @@ services:
       - postgres
     depends_on:
       - postgres
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3005/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary

Adds a Docker HEALTHCHECK to both Dockerfile and docker-compose.yml using the existing /api/health endpoint.

- **Dockerfile**: HEALTHCHECK instruction before CMD — works in production Docker environments
- **docker-compose.yml**: healthcheck block on the budget service — enables depends_on health conditions and visibility via docker ps

**Endpoint**: GET /api/health — checks DB connectivity, returns 200/503
**Interval**: 30s | **Timeout**: 10s | **Start period**: 30s | **Retries**: 3

Discovered during prod alarm drill (2026-03-25): monitor showed healthcheck as 'none' for hoie-budget-1.