### PR TITLE
fix: replace curl with bun fetch in HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ COPY --from=builder /app/build ./build
 # Use: docker run --env-file .env ...
 # Or Docker Compose: env_file: - .env
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-  CMD curl -f http://localhost:3005/api/health || exit 1
+  CMD bun -e "fetch('http://localhost:3005/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 CMD ["bun", "./build/server/bundle.js"]


### PR DESCRIPTION
## Problem

`oven/bun:1` does not include `curl`, so the `HEALTHCHECK` command always exits non-zero even when the app is running correctly. This has been causing persistent `unhealthy` status in production despite the app starting cleanly (DB connected, Plaid syncs completing successfully).

## Fix

Replace `curl -f ...` with a `bun -e` one-liner using bun's built-in `fetch` API, which is always available in the `oven/bun:1` runtime image — no extra dependencies needed.

## Testing

Build and verify:
```bash
docker build -t budget-test .
docker inspect --format='{{json .State.Health}}' $(docker run -d budget-test)
```