### PR TITLE
fix: always register static file handler regardless of NODE_ENV

### DIFF
--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -114,15 +114,15 @@ Object.values(routes).forEach(({ path, handler }) => router.use(path, handler));
 
 app.use("/api", router);
 
-// In dev mode, Vite's dev server (port 3000) serves static files and proxies /api here.
-// Static file serving is only needed in production where the build output exists.
-if (process.env.NODE_ENV === "production") {
-  const clientPath = path.resolve(import.meta.dir, "..", "client");
-  app.use(express.static(clientPath));
-  app.get("*", (_req, res) => {
-    res.sendFile(path.join(clientPath, "index.html"));
-  });
-}
+// Serve the built client. In dev, the client/ dir doesn't exist (Vite serves it
+// on its own port), so express.static is a no-op and the wildcard never matches
+// real requests — safe to register unconditionally.
+// Guarding on NODE_ENV caused a prod outage when the env var was unset (PR #197).
+const clientPath = path.resolve(import.meta.dir, "..", "client");
+app.use(express.static(clientPath));
+app.get("*", (_req, res) => {
+  res.sendFile(path.join(clientPath, "index.html"));
+});
 
 const httpServer = app.listen(process.env.PORT || 3005, async () => {
   await initializePostgres();


### PR DESCRIPTION
## Problem

PR #197 introduced a `NODE_ENV === 'production'` guard around static file serving. The `Dockerfile` does not set `NODE_ENV`, so in the prod container the condition is falsy — the static handler and SPA fallback (`app.get('*', ...)`) are never registered. Every non-API request returns nothing, nginx gets no response, 502.

**Outage:** 2026-03-26 ~12:24 PDT until manually mitigated via `NODE_ENV=production` env var.

## Fix

Remove the guard. In dev, the `client/` build directory doesn't exist (Vite serves assets on its own port), so `express.static` is a no-op and the wildcard never matches real requests. Safe to register unconditionally — no behavior change in dev, correct behavior in prod regardless of `NODE_ENV`.

## Monitoring gap identified

The container healthcheck only tests `/api/health`, so the container stayed healthy even while the site was serving 502s. Need an external smoke test that hits the actual URL.