### PR TITLE
fix: preserve NODE_ENV as runtime expression in bun bundle

### DIFF
--- a/src/server/pack.ts
+++ b/src/server/pack.ts
@@ -10,6 +10,13 @@ async function bundle() {
     target: "bun",
     external: ["bcrypt", "pg", "plaid"],
     minify: false,
+    // Prevent Bun from inlining process.env.NODE_ENV at bundle time.
+    // Without this, Bun bakes in the value of NODE_ENV from the build environment
+    // (typically "development" in Docker builder stages), making it a compile-time
+    // constant that runtime env config cannot override.
+    define: {
+      "process.env.NODE_ENV": 'process.env["NODE_ENV"]',
+    },
   });
 
   if (!result.success) {


### PR DESCRIPTION
## Problem

Bun inlines `process.env.NODE_ENV` at **bundle time** using whatever value `NODE_ENV` has in the build environment. In the Dockerfile builder stage, `NODE_ENV` is unset — so Bun bakes in `"development"`, turning the check in `start.ts`:

```ts
if (process.env.NODE_ENV === "production") { ... }
```

...into the compile-time constant:

```ts
if ("development" === "production") { ... }  // always false
```

No amount of runtime env config (docker-compose `environment:`, `env_file:`, etc.) can override a baked-in constant. This caused the prod outage: the static file handler and SPA fallback were never registered, so every non-API request returned `Cannot GET /`.

Confirmed via Hoie's debugging: even with `NODE_ENV=production` in docker-compose, the startup log showed `env: "development"`.

## Fix

Add a `define` override in `pack.ts` that maps `process.env.NODE_ENV` to `process.env["NODE_ENV"]`:

```ts
define: {
  "process.env.NODE_ENV": 'process.env["NODE_ENV"]',
},
```

Bun only inlines dot-notation `process.env.X` accesses — bracket notation is left as a real runtime expression. This makes `NODE_ENV` work correctly from runtime environment config.

## Testing

Build locally and verify the bundle contains `process.env["NODE_ENV"]` instead of a string literal:
```bash
bun run build-server
grep NODE_ENV build/server/bundle.js
```

Should show `process.env["NODE_ENV"]`, not `"development"` or `"production"`.

Fixes the prod outage caused by #197 (the `NODE_ENV` guard). Supersedes #269.