### PR TITLE
feat: prod monitoring Phase 1 — Discord alarms for budget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
 HOST_NAME=example.com
 
+# Optional: Discord webhook URL for server error alarms (unhandled exceptions, 5xx errors, client JS errors)
+# DISCORD_ALARM_WEBHOOK=https://discord.com/api/webhooks/...
+
+# Optional: number of errors required before an alarm fires (default: 1 = any error triggers alarm)
+# ERROR_THRESHOLD=1
+
 ADMIN_PASSWORD=qwert12345
 
 # Optional: set server timezone (defaults to America/Los_Angeles)

--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,6 @@ HOST_NAME=example.com
 # Optional: Discord webhook URL for server error alarms (unhandled exceptions, 5xx errors, client JS errors)
 # DISCORD_ALARM_WEBHOOK=https://discord.com/api/webhooks/...
 
-# Optional: number of errors required before an alarm fires (default: 1 = any error triggers alarm)
-# ERROR_THRESHOLD=1
-
 ADMIN_PASSWORD=qwert12345
 
 # Optional: set server timezone (defaults to America/Los_Angeles)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,3 +24,23 @@ call.get<LoginGetResponse>("/api/login").then((r) => {
     </React.StrictMode>
   );
 });
+
+// Report unhandled JS errors to server
+window.addEventListener("error", (event) => {
+  const body = JSON.stringify({
+    message: event.message,
+    stack: event.error?.stack ?? "",
+    url: window.location.href,
+  });
+  navigator.sendBeacon("/api/client-error", new Blob([body], { type: "application/json" }));
+});
+
+window.addEventListener("unhandledrejection", (event) => {
+  const reason = event.reason;
+  const body = JSON.stringify({
+    message: reason instanceof Error ? reason.message : String(reason),
+    stack: reason instanceof Error ? (reason.stack ?? "") : "",
+    url: window.location.href,
+  });
+  navigator.sendBeacon("/api/client-error", new Blob([body], { type: "application/json" }));
+});

--- a/src/server/lib/alarm.test.ts
+++ b/src/server/lib/alarm.test.ts
@@ -16,7 +16,6 @@ beforeEach(async () => {
 
 afterEach(() => {
   delete process.env.DISCORD_ALARM_WEBHOOK;
-  delete process.env.ERROR_THRESHOLD;
 });
 
 describe("sendAlarm", () => {

--- a/src/server/lib/alarm.test.ts
+++ b/src/server/lib/alarm.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, mock, afterEach } from "bun:test";
+
+// We need to mock fetch before importing alarm
+const mockFetch = mock(() => Promise.resolve({ ok: true } as Response));
+global.fetch = mockFetch as typeof fetch;
+
+// Dynamically import so we can reset module state between tests
+let alarm: typeof import("./alarm");
+
+beforeEach(async () => {
+  mockFetch.mockClear();
+  // Re-import to reset module-level state
+  alarm = await import("./alarm");
+  alarm.resetAlarmState();
+});
+
+afterEach(() => {
+  delete process.env.DISCORD_ALARM_WEBHOOK;
+  delete process.env.ERROR_THRESHOLD;
+});
+
+describe("sendAlarm", () => {
+  it("does nothing when DISCORD_ALARM_WEBHOOK is not set", async () => {
+    delete process.env.DISCORD_ALARM_WEBHOOK;
+    await alarm.sendAlarm("Test", "detail");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("sends a POST to the webhook URL", async () => {
+    process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
+    await alarm.sendAlarm("Test Error", "Something went wrong");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://discord.com/api/webhooks/test");
+    expect(options.method).toBe("POST");
+  });
+
+  it("respects cooldown — second alarm within 60s is suppressed", async () => {
+    process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
+    await alarm.sendAlarm("Error 1", "detail 1");
+    await alarm.sendAlarm("Error 2", "detail 2");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/lib/alarm.ts
+++ b/src/server/lib/alarm.ts
@@ -3,29 +3,22 @@
  *
  * Sends a POST to the DISCORD_ALARM_WEBHOOK URL when errors occur.
  * A 1-minute cooldown prevents noise bursts.
- * ERROR_THRESHOLD env var (default: 1) sets how many errors trigger an alarm.
  */
 
 import { logger } from "server/lib/logger";
 
 const COOLDOWN_MS = 60_000; // 1 minute
-const ERROR_THRESHOLD = parseInt(process.env.ERROR_THRESHOLD || "1", 10);
 
 let lastAlarmAt = 0;
-let errorCount = 0;
 
 /** Send a Discord webhook alarm message. Respects cooldown. */
 export const sendAlarm = async (title: string, detail: string): Promise<void> => {
   const webhookUrl = process.env.DISCORD_ALARM_WEBHOOK;
   if (!webhookUrl) return;
 
-  errorCount++;
-  if (errorCount < ERROR_THRESHOLD) return;
-
   const now = Date.now();
   if (now - lastAlarmAt < COOLDOWN_MS) return;
   lastAlarmAt = now;
-  errorCount = 0;
 
   const body = JSON.stringify({
     embeds: [
@@ -53,5 +46,4 @@ export const sendAlarm = async (title: string, detail: string): Promise<void> =>
 /** Reset cooldown state (for testing). */
 export const resetAlarmState = (): void => {
   lastAlarmAt = 0;
-  errorCount = 0;
 };

--- a/src/server/lib/alarm.ts
+++ b/src/server/lib/alarm.ts
@@ -1,0 +1,57 @@
+/**
+ * Discord alarm module for server error notifications.
+ *
+ * Sends a POST to the DISCORD_ALARM_WEBHOOK URL when errors occur.
+ * A 1-minute cooldown prevents noise bursts.
+ * ERROR_THRESHOLD env var (default: 1) sets how many errors trigger an alarm.
+ */
+
+import { logger } from "server/lib/logger";
+
+const COOLDOWN_MS = 60_000; // 1 minute
+const ERROR_THRESHOLD = parseInt(process.env.ERROR_THRESHOLD || "1", 10);
+
+let lastAlarmAt = 0;
+let errorCount = 0;
+
+/** Send a Discord webhook alarm message. Respects cooldown. */
+export const sendAlarm = async (title: string, detail: string): Promise<void> => {
+  const webhookUrl = process.env.DISCORD_ALARM_WEBHOOK;
+  if (!webhookUrl) return;
+
+  errorCount++;
+  if (errorCount < ERROR_THRESHOLD) return;
+
+  const now = Date.now();
+  if (now - lastAlarmAt < COOLDOWN_MS) return;
+  lastAlarmAt = now;
+  errorCount = 0;
+
+  const body = JSON.stringify({
+    embeds: [
+      {
+        title: `🚨 Budget Server Error: ${title}`,
+        description: detail.slice(0, 4000),
+        color: 0xff0000,
+        timestamp: new Date().toISOString(),
+      },
+    ],
+  });
+
+  try {
+    await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+  } catch (err) {
+    // Don't throw — alarm failure should never crash the server
+    logger.error("Failed to send Discord alarm", {}, err);
+  }
+};
+
+/** Reset cooldown state (for testing). */
+export const resetAlarmState = (): void => {
+  lastAlarmAt = 0;
+  errorCount = 0;
+};

--- a/src/server/lib/compute-tools/schedule.ts
+++ b/src/server/lib/compute-tools/schedule.ts
@@ -1,5 +1,6 @@
 import { ItemProvider, ONE_HOUR } from "common";
 import { getAllItems, logger, updateItemSyncStatus } from "server";
+import { sendAlarm } from "server/lib/alarm";
 import { syncPlaidAccounts, syncPlaidTransactions } from "./sync-plaid";
 import { syncSimpleFinData } from "./sync-simple-fin";
 
@@ -29,6 +30,7 @@ export const scheduledSync = async () => {
           })
           .catch((error) => {
             logger.error("Sync Plaid accounts failed", { itemId: item_id }, error);
+            sendAlarm("Scheduled Sync Error: Plaid accounts failed", `**Item:** ${item_id}\n**Error:** ${error instanceof Error ? error.message : String(error)}`).catch(() => undefined);
             syncError = error instanceof Error ? error.message : String(error);
           });
 
@@ -41,6 +43,7 @@ export const scheduledSync = async () => {
             })
             .catch((error) => {
               logger.error("Sync Plaid transactions failed", { itemId: item_id }, error);
+              sendAlarm("Scheduled Sync Error: Plaid transactions failed", `**Item:** ${item_id}\n**Error:** ${error instanceof Error ? error.message : String(error)}`).catch(() => undefined);
               syncError = error instanceof Error ? error.message : String(error);
             });
         }
@@ -72,6 +75,7 @@ export const scheduledSync = async () => {
           })
           .catch((error) => {
             logger.error("Sync SimpleFin data failed", { itemId: item_id }, error);
+            sendAlarm("Scheduled Sync Error: SimpleFin data failed", `**Item:** ${item_id}\n**Error:** ${error instanceof Error ? error.message : String(error)}`).catch(() => undefined);
             syncError = error instanceof Error ? error.message : String(error);
           });
 
@@ -83,6 +87,7 @@ export const scheduledSync = async () => {
     }
   } catch (err) {
     logger.error("Error occurred during scheduled sync", {}, err);
+    sendAlarm("Scheduled Sync Failed", `**Error:** ${err instanceof Error ? err.message : String(err)}`).catch(() => undefined);
   } finally {
     isSyncing = false;
     logger.info("Scheduled sync completed");

--- a/src/server/lib/route.ts
+++ b/src/server/lib/route.ts
@@ -1,5 +1,6 @@
 import { RequestHandler, Request, Response } from "express";
 import { logger } from "server";
+import { sendAlarm } from "server/lib/alarm";
 
 export type Method = "GET" | "POST" | "DELETE";
 
@@ -38,6 +39,10 @@ export class Route<T> {
           // Always return a generic message in 500 responses — the full error is in server logs.
           // NODE_ENV is not reliably set at runtime (it's provided via docker run --env-file).
           const message = "Internal server error";
+          sendAlarm(
+            `Route Error: ${method} ${path}`,
+            `**Error:** ${error instanceof Error ? error.message : String(error)}`
+          ).catch(() => undefined);
           res.status(500).json({ status: "error", message });
         }
       }

--- a/src/server/routes/client-error.ts
+++ b/src/server/routes/client-error.ts
@@ -1,0 +1,37 @@
+import { Route } from "server/lib/route";
+import { sendAlarm } from "server/lib/alarm";
+import { logger } from "server/lib/logger";
+
+export type ClientErrorPostBody = {
+  message?: string;
+  stack?: string;
+  url?: string;
+};
+
+/**
+ * POST /client-error
+ *
+ * Accepts frontend error reports sent via navigator.sendBeacon.
+ * Forwards to Discord alarm. No auth required (beacon fires after page unload).
+ */
+export const postClientErrorRoute = new Route("POST", "/client-error", async (req) => {
+  const body = req.body as ClientErrorPostBody;
+
+  const message = typeof body.message === "string" ? body.message : "(no message)";
+  const stack = typeof body.stack === "string" ? body.stack : "";
+  const url = typeof body.url === "string" ? body.url : "";
+
+  logger.error("Client error reported", { url, message });
+
+  const detail = [
+    url ? `**URL:** ${url}` : null,
+    `**Message:** ${message}`,
+    stack ? `\`\`\`\n${stack.slice(0, 1000)}\n\`\`\`` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  await sendAlarm("Client JS Error", detail);
+
+  return { status: "success" as const };
+});

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -1,6 +1,7 @@
 export * from "./accounts";
 export * from "./budgets";
 export * from "./charts";
+export * from "./client-error";
 export * from "./health";
 export * from "./users";
 export * from "./webhooks";

--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -5,12 +5,14 @@ overrideConsoleLog();
 
 import path from "path";
 import express, { Router } from "express";
+import type { Request, Response, NextFunction } from "express";
 import session from "express-session";
 import { initializePostgres, PostgresSessionStore, scheduledSync } from "server";
 import { pool } from "server/lib/postgres/client";
 import { loginLimiter, startRateLimitCleanup, stopRateLimitCleanup } from "server/lib/rate-limit";
 import * as routes from "server/routes";
 import { logger } from "server/lib/logger";
+import { sendAlarm } from "server/lib/alarm";
 
 const app = express();
 
@@ -98,7 +100,7 @@ router.post("/login", loginLimiter);
 //   /plaid-hook — POST only. Plaid verifies authenticity via HMAC signature; no session needed.
 //   /health — GET only. Required by monitoring and load balancers without a session.
 // Exact match only — prefix matching would silently expose future sub-routes.
-const PUBLIC_PATHS = new Set(["/login", "/plaid-hook", "/health"]);
+const PUBLIC_PATHS = new Set(["/login", "/plaid-hook", "/health", "/client-error"]);
 router.use((req, res, next) => {
   if (PUBLIC_PATHS.has(req.path)) {
     return next();
@@ -111,6 +113,20 @@ router.use((req, res, next) => {
 });
 
 Object.values(routes).forEach(({ path, handler }) => router.use(path, handler));
+
+// Global 5xx error handler — catches unhandled errors thrown inside route handlers
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+router.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+  const message = err instanceof Error ? err.message : String(err);
+  const stack = err instanceof Error ? (err.stack ?? "") : "";
+  logger.error("Unhandled route error", { message });
+  sendAlarm("Unhandled Route Error", `**Message:** ${message}\n\`\`\`\n${stack.slice(0, 1000)}\n\`\`\``).catch(
+    () => undefined,
+  );
+  if (!res.headersSent) {
+    res.status(500).json({ status: "error", message: "Internal server error" });
+  }
+});
 
 app.use("/api", router);
 
@@ -159,10 +175,20 @@ process.on("SIGINT", () => shutdown("SIGINT"));
 
 process.on("unhandledRejection", (reason) => {
   logger.error("Unhandled promise rejection", {}, reason);
+  const message = reason instanceof Error ? reason.message : String(reason);
+  const stack = reason instanceof Error ? (reason.stack ?? "") : "";
+  sendAlarm(
+    "Unhandled Promise Rejection",
+    `**Message:** ${message}\n\`\`\`\n${stack.slice(0, 1000)}\n\`\`\``,
+  ).catch(() => undefined);
 });
 
 process.on("uncaughtException", async (error) => {
   logger.error("Uncaught exception", {}, error);
+  sendAlarm(
+    "Uncaught Exception",
+    `**Message:** ${error.message}\n\`\`\`\n${(error.stack ?? "").slice(0, 1000)}\n\`\`\``,
+  ).catch(() => undefined);
   try {
     await pool.end();
   } catch {


### PR DESCRIPTION
## What's added

Implements Prod Monitoring Phase 1 for the budget app per the approved design doc: <https://doc.hoie.kim/s/moltboie/p/prod-monitoring-HRzq5Krhlg>

**`src/server/lib/alarm.ts`**
- `sendAlarm(title, detail)` — posts to Discord webhook with embedded message
- 1-minute cooldown to prevent noise bursts (no error threshold — every error triggers)

**`src/server/start.ts`** — process-level hooks
- `process.on("unhandledRejection")` → `sendAlarm()`
- `process.on("uncaughtException")` → `sendAlarm()` then exit
- Unhandled express route errors → `sendAlarm()`

**`src/server/lib/compute-tools/schedule.ts`** — scheduled sync failures
- Plaid accounts sync failure → `sendAlarm()`
- Plaid transactions sync failure → `sendAlarm()`
- SimpleFin sync failure → `sendAlarm()`
- Outer catch (unexpected errors in the sync loop) → `sendAlarm()`

**`src/server/lib/route.ts`** — generic HTTP route error handler
- Any uncaught exception in a route handler → `sendAlarm()`
- Covers Plaid webhook-triggered syncs and all other routes

**`src/server/routes/client-error.ts`** — `POST /api/client-error`
- Accepts `{ message, stack, url }` from frontend `navigator.sendBeacon`
- No auth required (beacon fires after page unload)
- Proxied to `sendAlarm()`

**`src/index.tsx`** — client-side error capture
- `window.addEventListener("error")` → `navigator.sendBeacon("/api/client-error")`
- `window.addEventListener("unhandledrejection")` → `navigator.sendBeacon("/api/client-error")`

## Intentionally not alarmed
- Bulk upsert per-item failures (`accounts`, `transactions`, `snapshots`, etc.) — partial success is the correct semantic for batch sync; per-item errors accumulate as `errorResult` and are already logged
- Per-connection IMAP/SMTP socket errors — client protocol noise, not server crashes
- Plaid per-item API errors — accumulated per-item, callers (schedule.ts) already alarm

## Env vars
| Var | Required | Default | Description |
|---|---|---|---|
| `DISCORD_ALARM_WEBHOOK` | yes | — | Discord webhook URL; if unset, alarms silently no-op |

Closes #256