### PR TITLE
feat: add HoldingsComposition UI component for investment accounts

### DIFF
--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -12,6 +12,7 @@ import {
   DateLabel,
   DynamicCapacityInput,
   Graph,
+  HoldingsComposition,
   InstitutionSpan,
   MoneyLabel,
   ToggleInput,
@@ -212,6 +213,7 @@ export const AccountProperties = ({ account }: Props) => {
         </>
       )}
 
+      {type === AccountType.Investment && <HoldingsComposition account={account} />}
       <div className="propertyLabel">Navigate</div>
       <div className="property">
         <div className="row button">

--- a/src/client/components/App/lib/hooks.ts
+++ b/src/client/components/App/lib/hooks.ts
@@ -1,5 +1,6 @@
 import {
   getBalanceData,
+  getHoldingsValueData,
   ScreenType,
   useMemoryState,
   Calculations,
@@ -38,6 +39,7 @@ export const useData = () => {
         accounts,
         accountSnapshots,
         holdingSnapshots,
+        securitySnapshots,
         transactions,
         splitTransactions,
         investmentTransactions,
@@ -68,7 +70,19 @@ export const useData = () => {
 
         const capacityData = getCapacityData(budgets, sections, categories);
 
-        newCalculations.update({ balanceData, transactionFamilies, budgetData, capacityData });
+        const holdingsValueData = getHoldingsValueData({
+          holdingSnapshots,
+          securitySnapshots,
+          investmentTransactions,
+        });
+
+        newCalculations.update({
+          balanceData,
+          transactionFamilies,
+          budgetData,
+          capacityData,
+          holdingsValueData,
+        });
 
         newCalculations.status.isInit = true;
         newCalculations.status.isLoading = false;

--- a/src/client/components/HoldingsComposition/index.css
+++ b/src/client/components/HoldingsComposition/index.css
@@ -1,10 +1,10 @@
-div.HoldingsComposition .holdingsTable {
+.holdingsTable {
   padding: 0;
   overflow-x: auto;
 }
 
-div.HoldingsComposition .holdingsHeader,
-div.HoldingsComposition .holdingsRow {
+.holdingsTable .holdingsHeader,
+.holdingsTable .holdingsRow {
   display: grid;
   grid-template-columns: 1fr 6em 7em 4em;
   gap: 0.25em;
@@ -13,49 +13,49 @@ div.HoldingsComposition .holdingsRow {
   align-items: center;
 }
 
-div.HoldingsComposition .holdingsHeader {
+.holdingsTable .holdingsHeader {
   font-weight: 600;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
   color: rgba(255, 255, 255, 0.6);
 }
 
-div.HoldingsComposition .holdingsRow {
+.holdingsTable .holdingsRow {
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 
-div.HoldingsComposition .holdingsRow:last-of-type {
+.holdingsTable .holdingsRow:last-of-type {
   border-bottom: none;
 }
 
-div.HoldingsComposition .holdingsRow.total {
+.holdingsTable .holdingsRow.total {
   font-weight: 600;
   border-top: 1px solid rgba(255, 255, 255, 0.15);
   border-bottom: none;
   margin-top: 0.2em;
 }
 
-div.HoldingsComposition .col-value,
-div.HoldingsComposition .col-gain,
-div.HoldingsComposition .col-pct {
+.holdingsTable .col-value,
+.holdingsTable .col-gain,
+.holdingsTable .col-pct {
   text-align: right;
   white-space: nowrap;
 }
 
-div.HoldingsComposition .col-name {
+.holdingsTable .col-name {
   overflow: hidden;
   display: flex;
   flex-direction: column;
   gap: 0.1em;
 }
 
-div.HoldingsComposition .security-name {
+.holdingsTable .security-name {
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-div.HoldingsComposition .security-fullname {
+.holdingsTable .security-fullname {
   font-size: 0.8em;
   color: rgba(255, 255, 255, 0.5);
   overflow: hidden;
@@ -63,25 +63,25 @@ div.HoldingsComposition .security-fullname {
   white-space: nowrap;
 }
 
-div.HoldingsComposition .col-gain.positive {
+.holdingsTable .col-gain.positive {
   color: #4ade80;
 }
 
-div.HoldingsComposition .col-gain.negative {
+.holdingsTable .col-gain.negative {
   color: #f87171;
 }
 
-div.HoldingsComposition .no-data {
+.holdingsTable .no-data {
   color: rgba(255, 255, 255, 0.3);
 }
 
-div.HoldingsComposition .inferred-flag {
+.holdingsTable .inferred-flag {
   color: rgba(255, 255, 255, 0.4);
   margin-left: 0.2em;
   font-size: 0.85em;
 }
 
-div.HoldingsComposition .holdingsFootnote {
+.holdingsTable .holdingsFootnote {
   padding: 0.4em 0.75em 0.5em;
   font-size: 0.75em;
   color: rgba(255, 255, 255, 0.4);

--- a/src/client/components/HoldingsComposition/index.css
+++ b/src/client/components/HoldingsComposition/index.css
@@ -1,0 +1,89 @@
+div.HoldingsComposition .holdingsTable {
+  padding: 0;
+  overflow-x: auto;
+}
+
+div.HoldingsComposition .holdingsHeader,
+div.HoldingsComposition .holdingsRow {
+  display: grid;
+  grid-template-columns: 1fr 6em 7em 4em;
+  gap: 0.25em;
+  padding: 0.35em 0.75em;
+  font-size: 0.85em;
+  align-items: center;
+}
+
+div.HoldingsComposition .holdingsHeader {
+  font-weight: 600;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.6);
+}
+
+div.HoldingsComposition .holdingsRow {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+div.HoldingsComposition .holdingsRow:last-of-type {
+  border-bottom: none;
+}
+
+div.HoldingsComposition .holdingsRow.total {
+  font-weight: 600;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  border-bottom: none;
+  margin-top: 0.2em;
+}
+
+div.HoldingsComposition .col-value,
+div.HoldingsComposition .col-gain,
+div.HoldingsComposition .col-pct {
+  text-align: right;
+  white-space: nowrap;
+}
+
+div.HoldingsComposition .col-name {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1em;
+}
+
+div.HoldingsComposition .security-name {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+div.HoldingsComposition .security-fullname {
+  font-size: 0.8em;
+  color: rgba(255, 255, 255, 0.5);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+div.HoldingsComposition .col-gain.positive {
+  color: #4ade80;
+}
+
+div.HoldingsComposition .col-gain.negative {
+  color: #f87171;
+}
+
+div.HoldingsComposition .no-data {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+div.HoldingsComposition .inferred-flag {
+  color: rgba(255, 255, 255, 0.4);
+  margin-left: 0.2em;
+  font-size: 0.85em;
+}
+
+div.HoldingsComposition .holdingsFootnote {
+  padding: 0.4em 0.75em 0.5em;
+  font-size: 0.75em;
+  color: rgba(255, 255, 255, 0.4);
+  font-style: italic;
+}

--- a/src/client/components/HoldingsComposition/index.tsx
+++ b/src/client/components/HoldingsComposition/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 interface HoldingRow {
   holdingId: string;
   securityId: string;
-  name: string;
+  name: string | null;
   ticker: string | null;
   quantity: number;
   price: number;
@@ -20,6 +20,8 @@ interface HoldingRow {
   costBasisInferred: boolean;
   pct: number;
 }
+
+const truncateSecurityId = (id: string) => id.slice(0, 6);
 
 export const HoldingsComposition = ({ account }: Props) => {
   const { account_id, balances } = account;
@@ -45,14 +47,13 @@ export const HoldingsComposition = ({ account }: Props) => {
         const { security_id, quantity, price, value, costBasis, unrealizedGain, costBasisInferred } =
           summary;
 
-        // Find security name/ticker from securitySnapshots
-        let name = security_id;
+        let name: string | null = null;
         let ticker: string | null = null;
 
         securitySnapshots.forEach((snap) => {
           if (snap.security.security_id === security_id) {
-            name = snap.security.name || security_id;
-            ticker = snap.security.ticker_symbol;
+            name = snap.security.name?.trim() || null;
+            ticker = snap.security.ticker_symbol ?? null;
           }
         });
 
@@ -88,7 +89,7 @@ export const HoldingsComposition = ({ account }: Props) => {
   const isCurrentDate = viewEndDate >= latestViewDate.getEndDate();
 
   return (
-    <div className="HoldingsComposition">
+    <>
       <div className="propertyLabel">Holdings&nbsp;Composition</div>
       <div className="property holdingsTable">
         <div className="holdingsHeader">
@@ -104,15 +105,18 @@ export const HoldingsComposition = ({ account }: Props) => {
               : row.unrealizedGain >= 0
                 ? "positive"
                 : "negative";
+          const primaryLabel = row.ticker ?? row.name ?? truncateSecurityId(row.securityId);
+          const secondaryLabel = row.ticker ? row.name : null;
+          const titleLabel = row.name ?? row.securityId;
           return (
             <div key={row.holdingId} className="holdingsRow">
               <span className="col-name">
-                <span className="security-name" title={row.name}>
-                  {row.ticker || row.name}
+                <span className="security-name" title={titleLabel}>
+                  {primaryLabel}
                 </span>
-                {row.ticker && (
-                  <span className="security-fullname" title={row.name}>
-                    {row.name}
+                {secondaryLabel && (
+                  <span className="security-fullname" title={titleLabel}>
+                    {secondaryLabel}
                   </span>
                 )}
               </span>
@@ -160,6 +164,6 @@ export const HoldingsComposition = ({ account }: Props) => {
           <div className="holdingsFootnote">* Cost basis inferred from transaction history</div>
         )}
       </div>
-    </div>
+    </>
   );
 };

--- a/src/client/components/HoldingsComposition/index.tsx
+++ b/src/client/components/HoldingsComposition/index.tsx
@@ -1,0 +1,165 @@
+import { useMemo } from "react";
+import { currencyCodeToSymbol, numberToCommaString, ViewDate } from "common";
+import { Account, useAppContext } from "client";
+import "./index.css";
+
+interface Props {
+  account: Account;
+}
+
+interface HoldingRow {
+  holdingId: string;
+  securityId: string;
+  name: string;
+  ticker: string | null;
+  quantity: number;
+  price: number;
+  value: number;
+  costBasis: number | null;
+  unrealizedGain: number | null;
+  costBasisInferred: boolean;
+  pct: number;
+}
+
+export const HoldingsComposition = ({ account }: Props) => {
+  const { account_id, balances } = account;
+  const { iso_currency_code } = balances;
+  const currencySymbol = currencyCodeToSymbol(iso_currency_code || "");
+
+  const { calculations, viewDate, data } = useAppContext();
+  const { holdingsValueData } = calculations;
+  const { securitySnapshots } = data;
+
+  const viewEndDate = viewDate.getEndDate();
+
+  const rows = useMemo<HoldingRow[]>(() => {
+    const holdingIds = holdingsValueData.getHoldingsForAccount(account_id);
+    const totalValue = holdingsValueData.getAccountTotalValue(account_id, viewEndDate);
+
+    return holdingIds
+      .map((holdingId): HoldingRow | null => {
+        const history = holdingsValueData.getHistory(holdingId);
+        const summary = history.get(viewEndDate);
+        if (!summary || summary.value === 0) return null;
+
+        const { security_id, quantity, price, value, costBasis, unrealizedGain, costBasisInferred } =
+          summary;
+
+        // Find security name/ticker from securitySnapshots
+        let name = security_id;
+        let ticker: string | null = null;
+
+        securitySnapshots.forEach((snap) => {
+          if (snap.security.security_id === security_id) {
+            name = snap.security.name || security_id;
+            ticker = snap.security.ticker_symbol;
+          }
+        });
+
+        const pct = totalValue > 0 ? (value / totalValue) * 100 : 0;
+
+        return {
+          holdingId,
+          securityId: security_id,
+          name,
+          ticker,
+          quantity,
+          price,
+          value,
+          costBasis,
+          unrealizedGain,
+          costBasisInferred,
+          pct,
+        };
+      })
+      .filter((r): r is HoldingRow => r !== null)
+      .sort((a, b) => b.value - a.value);
+  }, [account_id, holdingsValueData, viewEndDate, securitySnapshots]);
+
+  if (rows.length === 0) return null;
+
+  const totalValue = rows.reduce((s, r) => s + r.value, 0);
+  const totalCostBasis = rows.every((r) => r.costBasis !== null)
+    ? rows.reduce((s, r) => s + (r.costBasis ?? 0), 0)
+    : null;
+  const totalGain = totalCostBasis !== null ? totalValue - totalCostBasis : null;
+
+  const latestViewDate = new ViewDate(viewDate.getInterval());
+  const isCurrentDate = viewEndDate >= latestViewDate.getEndDate();
+
+  return (
+    <div className="HoldingsComposition">
+      <div className="propertyLabel">Holdings&nbsp;Composition</div>
+      <div className="property holdingsTable">
+        <div className="holdingsHeader">
+          <span className="col-name">Security</span>
+          <span className="col-value">Value</span>
+          <span className="col-gain">Unrealized G/L</span>
+          <span className="col-pct">%</span>
+        </div>
+        {rows.map((row) => {
+          const gainClass =
+            row.unrealizedGain === null
+              ? ""
+              : row.unrealizedGain >= 0
+                ? "positive"
+                : "negative";
+          return (
+            <div key={row.holdingId} className="holdingsRow">
+              <span className="col-name">
+                <span className="security-name" title={row.name}>
+                  {row.ticker || row.name}
+                </span>
+                {row.ticker && (
+                  <span className="security-fullname" title={row.name}>
+                    {row.name}
+                  </span>
+                )}
+              </span>
+              <span className="col-value">
+                {currencySymbol}&nbsp;{numberToCommaString(row.value, 0)}
+              </span>
+              <span className={`col-gain ${gainClass}`}>
+                {row.unrealizedGain !== null ? (
+                  <>
+                    {row.unrealizedGain >= 0 ? "+" : ""}
+                    {currencySymbol}&nbsp;{numberToCommaString(row.unrealizedGain, 0)}
+                    {row.costBasisInferred && <span className="inferred-flag" title="Cost basis inferred from transactions">*</span>}
+                  </>
+                ) : (
+                  <span className="no-data">—</span>
+                )}
+              </span>
+              <span className="col-pct">{row.pct.toFixed(1)}%</span>
+            </div>
+          );
+        })}
+        <div className="holdingsRow total">
+          <span className="col-name">Total</span>
+          <span className="col-value">
+            {currencySymbol}&nbsp;{numberToCommaString(totalValue, 0)}
+          </span>
+          <span className={`col-gain ${totalGain === null ? "" : totalGain >= 0 ? "positive" : "negative"}`}>
+            {totalGain !== null ? (
+              <>
+                {totalGain >= 0 ? "+" : ""}
+                {currencySymbol}&nbsp;{numberToCommaString(totalGain, 0)}
+              </>
+            ) : (
+              <span className="no-data">—</span>
+            )}
+          </span>
+          <span className="col-pct">100%</span>
+        </div>
+        {!isCurrentDate && (
+          <div className="holdingsFootnote">
+            Showing {viewDate.toString()} data
+          </div>
+        )}
+        {rows.some((r) => r.costBasisInferred) && (
+          <div className="holdingsFootnote">* Cost basis inferred from transaction history</div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/client/components/index.ts
+++ b/src/client/components/index.ts
@@ -6,6 +6,7 @@ export * from "./SimpleFinLinkButton";
 export * from "./TransactionsTable";
 export * from "./AccountsTable";
 export * from "./AccountProperties";
+export * from "./HoldingsComposition";
 export * from "./InstitutionSpan";
 export * from "./AccountsDonut";
 export * from "./Header";


### PR DESCRIPTION
## Summary

Adds the HoldingsComposition UI component showing a per-holding breakdown for investment accounts — per the Holdings Value Calculation design doc at doc.hoie.kim/p/ZDhNQZtVic.

## Changes

### New: `HoldingsComposition` component
- Displays a table of holdings for the current view date
- Columns: Security (ticker + full name), Value, Unrealized G/L, % of portfolio
- Sorted by value descending
- Totals row with aggregate value and unrealized gain
- `*` flag on inferred cost basis with footnote
- Shows current view date label when not viewing latest period
- Renders only for `AccountType.Investment` accounts

### Wired into `App/lib/hooks.ts`
- `getHoldingsValueData()` now called in `calculateAll()` and stored in `calculations.holdingsValueData`
- Previously this function was implemented but never called

### Integration
- Added to `AccountProperties` — renders `<HoldingsComposition account={account} />` just before the Navigate section, for investment accounts only

## Testing

- TypeScript compiles clean (`bun run typecheck`)
- 12 pre-existing test failures in `holdings.test.ts` (Dictionary.set() disabled in server environment — unrelated to this PR)
- Manual test: open AccountProperties for an investment account with holdings data, verify table renders

Closes #29