### PR TITLE
fix: soft-delete pending transactions when settled counterpart arrives from Plaid

### DIFF
--- a/src/server/lib/compute-tools/sync-plaid.ts
+++ b/src/server/lib/compute-tools/sync-plaid.ts
@@ -126,10 +126,22 @@ export const syncPlaidTransactions = async (item_id: string) => {
       const modeledModified = modified.map(modelize);
       const removedTransactionIds = removed.map((e) => e.transaction_id);
 
+      // When a pending transaction settles, Plaid sends the settled version with a
+      // pending_transaction_id but does NOT always include the pending transaction in
+      // the `removed` list. We must soft-delete the pending counterpart ourselves to
+      // prevent both from appearing in the UI (double-count bug).
+      const settledFromPendingIds = added
+        .filter((e) => e.pending_transaction_id)
+        .map((e) => lookupMaps.byTransactionId.get(e.pending_transaction_id!))
+        .filter((e): e is JSONTransaction => !!e && e.pending === true)
+        .map((e) => e.transaction_id);
+
+      const allRemovedIds = [...removedTransactionIds, ...settledFromPendingIds];
+
       const updateJobs = [
         upsertTransactions(user, [...modeledAdded, ...modeledModified]),
-        deleteTransactions(user, removedTransactionIds),
-        ...removedTransactionIds.map((txId) => deleteSplitTransactionsByTransaction(user, txId)),
+        deleteTransactions(user, allRemovedIds),
+        ...allRemovedIds.map((txId) => deleteSplitTransactionsByTransaction(user, txId)),
       ];
 
       const updated = getDateString();
@@ -139,7 +151,7 @@ export const syncPlaidTransactions = async (item_id: string) => {
         .then(() => {
           addedCount += added.length;
           modifiedCount += modified.length;
-          removedCount += removed.length;
+          removedCount += removed.length + settledFromPendingIds.length;
         })
         .then(() => upsertItems(user, partialItems))
         .catch((err) => {


### PR DESCRIPTION
## Problem

When a pending Plaid transaction settles, some institutions don't include the original pending transaction in the `removed` list. This causes both the pending and the settled version to appear in the UI simultaneously, double-counting the charge.

**Confirmed in prod data:** Claude.ai subscription on 2026-03-04 shows both:
- `jNqYAxAKXwSej8r5K09bHBYmoRne8Nf1w8N3p` — pending=true, is_deleted=false
- `vzYKOBO6yAhxAyM4ZNP1uP5z310KZaU0berby` — pending=false, pending_transaction_id→above, is_deleted=false

Both show in the transaction list → $100 charge appears as $200.

## Fix

In `syncPlaidTransactions`, after building the lookup maps, identify any incoming `added` transactions whose `pending_transaction_id` points to a still-stored, still-pending transaction. Add those IDs to the deletion list so they get soft-deleted when the settled version arrives.

```typescript
// Find pending transactions that have settled (but Plaid forgot to include in removed[])
const settledFromPendingIds = added
  .filter((e) => e.pending_transaction_id)
  .map((e) => lookupMaps.byTransactionId.get(e.pending_transaction_id!))
  .filter((e): e is JSONTransaction => !!e && e.pending === true)
  .map((e) => e.transaction_id);
```

## Testing

- All 15 existing unit tests pass
- Logic is straightforward: only deletes stored transactions that are `pending = true` and whose ID matches a `pending_transaction_id` from an incoming settled transaction

Closes #301