### PR TITLE
fix: logger formatError loses detail on non-Error objects

### DIFF
--- a/src/server/lib/logger.test.ts
+++ b/src/server/lib/logger.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { logger } from "./logger";
+
+let consoleErrorSpy: ReturnType<typeof spyOn>;
+const originalLogLevel = process.env.LOG_LEVEL;
+const originalNodeEnv = process.env.NODE_ENV;
+
+beforeEach(() => {
+  process.env.LOG_LEVEL = "error";
+  process.env.NODE_ENV = "development";
+  consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
+  if (originalLogLevel === undefined) delete process.env.LOG_LEVEL;
+  else process.env.LOG_LEVEL = originalLogLevel;
+  if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = originalNodeEnv;
+});
+
+describe("logger.error", () => {
+  it("formats Error instances with their message", () => {
+    logger.error("boom", undefined, new Error("kaboom"));
+    const out = String(consoleErrorSpy.mock.calls[0]?.[0] ?? "");
+    expect(out).toContain("kaboom");
+    expect(out).not.toContain("[object Object]");
+  });
+
+  it("serializes plain object errors instead of [object Object]", () => {
+    const plaidLikeError = {
+      error_type: "ITEM_ERROR",
+      error_code: "ITEM_LOGIN_REQUIRED",
+      error_message: "the login details have changed",
+    };
+    logger.error("Failed to get accounts data", { itemId: "abc" }, plaidLikeError);
+    const out = String(consoleErrorSpy.mock.calls[0]?.[0] ?? "");
+    expect(out).not.toContain("[object Object]");
+    expect(out).toContain("ITEM_LOGIN_REQUIRED");
+    expect(out).toContain("ITEM_ERROR");
+  });
+
+  it("falls back to String() for primitives", () => {
+    logger.error("primitive", undefined, "raw string error");
+    const out = String(consoleErrorSpy.mock.calls[0]?.[0] ?? "");
+    expect(out).toContain("raw string error");
+  });
+
+  it("handles circular object references without throwing", () => {
+    const circular: Record<string, unknown> = { a: 1 };
+    circular.self = circular;
+    expect(() => logger.error("circular", undefined, circular)).not.toThrow();
+    const out = String(consoleErrorSpy.mock.calls[0]?.[0] ?? "");
+    expect(out).not.toContain("[object Object]");
+  });
+});

--- a/src/server/lib/logger.ts
+++ b/src/server/lib/logger.ts
@@ -66,6 +66,19 @@ function formatError(error: unknown): LogEntry["error"] | undefined {
       name: error.name,
     };
   }
+  if (typeof error === "object") {
+    try {
+      return { message: JSON.stringify(error) };
+    } catch {
+      const parts: string[] = [];
+      for (const [key, value] of Object.entries(error as Record<string, unknown>)) {
+        if (value === null || ["string", "number", "boolean"].includes(typeof value)) {
+          parts.push(`${key}=${String(value)}`);
+        }
+      }
+      return { message: parts.length > 0 ? parts.join(" ") : Object.prototype.toString.call(error) };
+    }
+  }
   return { message: String(error) };
 }
 


### PR DESCRIPTION
## Problem

`logger.error("...", ctx, error)` accepts an `unknown` error. When the error is a plain object (e.g. a `PlaidError` from `error.response.data`) instead of an `Error` instance, `formatError` falls into:

```ts
return { message: String(error) };
```

`String({})` returns `"[object Object]"`, so every Plaid sync failure currently logs:

```
ERROR Failed to get accounts data {"itemId":"..."}
  Error: [object Object]
```

All diagnostic fields (`error_code`, `error_type`, `error_message`, `request_id`) are silently discarded — making it impossible to tell why Plaid syncs are failing without attaching a debugger.

This affects ~40 files / ~79 call sites across the server (Plaid handlers, Postgres repos, sync jobs, route handlers).

## Fix

Add a branch in `formatError` for non-Error objects: try `JSON.stringify`, with a fallback that enumerates primitive own-properties in case of circular refs.

## E2E verification

Started the dev server before the fix:

```
ERROR Failed to get accounts data {"itemId":"9BLRJoJDw3hA5LkbJpY7Sr9JmrYnDjFdeVZ3D"}
  Error: [object Object]
```

After the fix:

```
ERROR Failed to get accounts data {"itemId":"9BLRJoJDw3hA5LkbJpY7Sr9JmrYnDjFdeVZ3D"}
  Error: {"display_message":null,"documentation_url":"...","error_code":"MISSING_FIELDS","error_message":"the following required fields are missing: client_id, secret","error_type":"INVALID_REQUEST","request_id":"0dbb4401a184428","suggested_action":null}
```

(The underlying `MISSING_FIELDS` is just dev env without Plaid creds — expected and pre-existing. The point is the error is now diagnosable.)

## Tests

- `src/server/lib/logger.test.ts` (new): covers Error instances, plain object errors, primitives, and circular references.
- `bun run test:server` — 274 pass / 0 fail
- `bun run typecheck` — clean
- `bun run lint` — clean