### PR TITLE
docs: fix stale snippets in new docs/ directory

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -32,15 +32,19 @@ interface ApiResponse<T> {
 
 ## Authentication
 
-All API routes require an authenticated session by default. Authentication is enforced by centralized middleware in `start.ts` — individual routes do **not** need to check `req.session.user`.
+All API routes require an authenticated session by default. Authentication is enforced inside the `Bun.serve` fetch handler in `start.ts` — individual routes do **not** need to check `req.session.user`.
 
-Public routes are explicitly allowlisted:
+Public routes are explicitly allowlisted with optional method scoping:
 
 ```typescript
-const PUBLIC_PATHS = ["/login", "/plaid-hook", "/health"];
+const PUBLIC_PATH_METHODS: [string, Set<string> | null][] = [
+  ["/login", null],
+  ["/plaid-hook", new Set(["POST"])],
+  ["/health", new Set(["GET"])],
+];
 ```
 
-When adding a new public endpoint, add its path to `PUBLIC_PATHS`. All other routes automatically return 401 if no session exists.
+When adding a new public endpoint, add an entry to `PUBLIC_PATH_METHODS`. Pass `null` to allow all HTTP methods, or a `Set` to scope the exemption to specific methods. All other routes automatically return 401 if no session exists.
 
 ## Security Headers
 

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -23,14 +23,23 @@ import { useAppContext } from "../context";
 
 ## Error Handling
 
-Server routes catch errors and return 500:
+**Route handlers should not wrap their own logic in try/catch for the purpose of returning 500.** `Route.execute` (`src/server/lib/route.ts`) centralizes that — it logs the error, fires a Discord alarm, sets status 500, and returns `{ status: "error", message: "Internal server error" }`. Let exceptions propagate and only catch errors when you can recover or want to convert them into a `failed`/`success` response.
 
 ```typescript
+// Good — let Route.execute handle unexpected failures
+export const myRoute = new Route<MyResponse>("POST", "/my-path", async (req, res) => {
+  const result = await doWork(req.body);
+  return { status: "success", body: result };
+});
+
+// Good — catch when you want a non-500 outcome
 try {
-  // route logic
-} catch (error: any) {
-  console.error(error);
-  res.status(500).json({ status: "error", info: error?.message });
+  await doWork(req.body);
+} catch (error) {
+  if (error instanceof ValidationError) {
+    return { status: "failed", message: error.message };
+  }
+  throw error;
 }
 ```
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -10,52 +10,52 @@ Configure via environment variables:
 | `POSTGRES_PORT` | 5432 | PostgreSQL port |
 | `POSTGRES_USER` | — | PostgreSQL user |
 | `POSTGRES_PASSWORD` | — | PostgreSQL password |
-| `POSTGRES_DB` | — | PostgreSQL database name |
+| `POSTGRES_DATABASE` | `budget` | PostgreSQL database name |
 
 ## Table Class Methods
 
 **Use `Table` class methods instead of direct SQL/pool operations.**
 
-The `Table` base class (`src/server/lib/postgres/models/base.ts`) provides type-safe methods for common operations:
+The `Table` base class (`src/server/lib/postgres/models/base.ts`) provides type-safe methods for common operations. Each table is exported as a `camelCase` singleton (e.g. `usersTable`, `accountsTable`):
 
 ```typescript
 // Good — use Table class methods
-const user = await UsersTable.findById(userId);
-const users = await UsersTable.findByCondition("email", email);
-await UsersTable.insert(userData);
-await UsersTable.update(userId, updates);
-await UsersTable.deleteById(userId);
+const users = await usersTable.query({ user_id: userId });
+const oneUser = await usersTable.queryOne({ username });
+const someByIds = await usersTable.queryByIds([id1, id2]);
+await usersTable.insert(row);
+await usersTable.update(userId, updates);
+await usersTable.upsert(row);
+await usersTable.softDelete(userId);
+await usersTable.hardDelete(userId);
 
 // Avoid — direct pool.query
-const result = await pool.query("SELECT * FROM users WHERE id = $1", [userId]);
+const result = await pool.query("SELECT * FROM users WHERE user_id = $1", [userId]);
 ```
 
 Use direct SQL for: complex joins or aggregations, performance-critical bulk operations, one-off migrations.
 
 ## Repository Pattern
 
-Database operations live in `src/server/lib/postgres/repositories/`:
+Higher-level helpers live in `src/server/lib/postgres/repositories/` and wrap the table singletons (e.g. `searchUser`, `writeUser`, `updateUser`, `getUserById`, `deleteUser`). Import them from the `server` alias:
 
 ```typescript
-import { pgGetUsers, pgUpsertUser } from "server";
+import { searchUser, writeUser } from "server";
 ```
 
 ## Transaction Atomicity
 
-Multi-step database operations must be wrapped in transactions:
+Multi-step database operations must be wrapped in transactions. Prefer the `withTransaction` helper from `src/server/lib/postgres/client.ts` — it handles `BEGIN` / `COMMIT` / `ROLLBACK` / `release` automatically:
 
 ```typescript
-const client = await pool.connect();
-try {
-  await client.query("BEGIN");
-  // ... multiple operations ...
-  await client.query("COMMIT");
-} catch (error) {
-  await client.query("ROLLBACK");
-  throw error;
-} finally {
-  client.release();
-}
+import { withTransaction } from "server";
+
+await withTransaction(async (client) => {
+  await accountsTable.update(account_id, { balance }, undefined, user.user_id, client);
+  await snapshotsTable.insert({ account_id, balance }, undefined, client);
+});
 ```
 
-See `deleteAccounts` in `src/server/lib/postgres/repositories/accounts.ts` for an example.
+Most `Table` methods accept an optional `client?: QueryExecutor` so the same statement can run inside or outside a transaction.
+
+See `deleteAccounts` in `src/server/lib/postgres/repositories/accounts.ts` for a real example.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -56,7 +56,7 @@ Copy `.env.example` to `.env.local` and fill in values:
 | `POSTGRES_PORT` | No | PostgreSQL port (default: 5432) |
 | `POSTGRES_USER` | No | PostgreSQL user |
 | `POSTGRES_PASSWORD` | No | PostgreSQL password |
-| `POSTGRES_DB` | No | PostgreSQL database name |
+| `POSTGRES_DATABASE` | No | PostgreSQL database name (default: `budget`) |
 | `PLAID_CLIENT_ID` | No | Plaid API client ID (for Plaid bank connections) |
 | `PLAID_SECRET_PRODUCTION` | No | Plaid API secret (for Plaid bank connections) |
 | `HOST_NAME` | No | Domain name for hosting (required for Plaid OAuth) |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,25 +1,26 @@
 # Security
 
-## Centralized Authentication Middleware
+## Centralized Authentication
 
-Authentication is enforced at the router level in `src/server/start.ts`, not per-route. All API endpoints require an authenticated session by default.
+Authentication is enforced inside the `Bun.serve` fetch handler in `src/server/start.ts`, not per-route. All API endpoints require an authenticated session by default.
 
 ```typescript
-const PUBLIC_PATHS = ["/login", "/plaid-hook", "/health"];
-router.use((req, res, next) => {
-  if (PUBLIC_PATHS.some((p) => req.path === p || req.path.startsWith(p + "/"))) {
-    return next();
-  }
-  if (!req.session.user) {
-    res.status(401).json({ status: "failed", message: "Not authenticated." });
-    return;
-  }
-  next();
-});
+const PUBLIC_PATH_METHODS: [string, Set<string> | null][] = [
+  ["/login", null],
+  ["/plaid-hook", new Set(["POST"])],
+  ["/health", new Set(["GET"])],
+];
+
+// inside Bun.serve fetch():
+const entry = PUBLIC_PATH_METHODS.find(([p]) => p === apiPath);
+const isPublic = !!entry && (!entry[1] || entry[1].has(request.method));
+if (!isPublic && !session.user) {
+  return jsonResponse({ status: "failed", message: "Not authenticated." }, 401);
+}
 ```
 
 - New routes are protected automatically — no per-route auth checks needed
-- To make a route public, add its path to `PUBLIC_PATHS` with justification
+- To make a route public, add an entry to `PUBLIC_PATH_METHODS`. The second tuple element scopes the exemption to specific HTTP methods (`null` means all methods)
 - Public routes must have external verification (e.g., `/plaid-hook` verifies Plaid signatures)
 
 ## Session Fixation Prevention


### PR DESCRIPTION
## Summary

Follow-up to #306 (closed because the underlying files were deleted by upstream commit `878ab21` "updates docs"). The new `docs/` tree carried over several snippets that no longer match `upstream/main`:

- **`docs/SECURITY.md`, `docs/API.md`** — Replaced the Express `router.use((req, res, next) => …)` example and `PUBLIC_PATHS: string[]` with the current `Bun.serve` fetch-handler check against `PUBLIC_PATH_METHODS: [string, Set<string> | null][]` (`src/server/start.ts` line 174 and the inline auth check at line 306).
- **`docs/CODE_STYLE.md`** — Removed the per-route `try/catch` returning 500. `Route.execute` (`src/server/lib/route.ts`) already logs, fires a Discord alarm, sets status 500, and returns `{ status: "error", message: "Internal server error" }`. New guidance: handlers should let exceptions propagate and only catch when they want a `failed`/`success` outcome.
- **`docs/DATABASE.md`** — Replaced fictional method names (`UsersTable.findById`, `findByCondition`, `deleteById`) with the actual `Table` API (`usersTable.query` / `queryOne` / `queryByIds` / `insert` / `update` / `upsert` / `softDelete` / `hardDelete`) per `src/server/lib/postgres/models/base.ts`. Replaced fictional repository exports (`pgGetUsers`, `pgUpsertUser`) with the real ones (`searchUser`, `writeUser`, etc.). Transactions section now points to the existing `withTransaction` helper from `src/server/lib/postgres/client.ts` instead of hand-rolled `BEGIN`/`COMMIT`.
- **`docs/DATABASE.md`, `docs/GETTING_STARTED.md`** — Env var name corrected from `POSTGRES_DB` to `POSTGRES_DATABASE` (matches `.env.example` and `src/server/lib/postgres/client.ts` line 9).

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] All snippets verified against `upstream/main` source files
- [x] No remaining `PUBLIC_PATHS` / `router.use` / `POSTGRES_DB` / `findById` / `pgGetUsers` references in `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)