### PR TITLE
fix(accounts): use dynamicAmount for Changes widget on depository balance row

### DIFF
--- a/src/client/components/AccountsTable/Balance.tsx
+++ b/src/client/components/AccountsTable/Balance.tsx
@@ -75,7 +75,9 @@ export const Balance = ({ account }: BalanceProps) => {
           {symbol}
           {dynamicAmount ? numberToCommaString(dynamicAmount) : currentString}
         </div>
-        {!!previousAmount && <Changes currentAmount={current!} previousAmount={previousAmount} />}
+        {!!previousAmount && (
+          <Changes currentAmount={dynamicAmount || current!} previousAmount={previousAmount} />
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- AccountsTable Balance widget for depository accounts shows the wrong change for past `viewDate` because `Changes` was passed `current!` (today's) while the displayed value uses `dynamicAmount` (historical). Mixes time periods.
- PR #285 fixed the same issue for the Investment branch (`dynamicAmount || current!`); the default branch was overlooked. One-line fix applies the same pattern.

Closes #310

## Reproduction (local prod-snapshot DB, today = 2026-05-02)

Account: `TOTAL CHECKING` (depository)

| month | balance at end of month |
|-------|------------------------|
| 2025-08 | \$2,925.81 |
| 2025-09 | \$3,045.44 |
| 2026-01 | \$6,325.63 |
| 2026-02 | \$6,778.10 |
| 2026-03 | \$7,445.44 |

`balances_current` today = \$7,445.44.

ViewDate = **February 2026**:
- Display: \$6,778.10 (correct)
- Changes (bug, before fix): \$7,445.44 − \$6,325.63 = **+\$1,119.81**
- Changes (correct, after fix): \$6,778.10 − \$6,325.63 = **+\$452.47**
- Off by \$667.34

ViewDate = **September 2025**:
- Display: \$3,045.44
- Changes (bug): \$7,445.44 − \$2,925.81 = **+\$4,519.63**
- Changes (fix): \$3,045.44 − \$2,925.81 = **+\$119.63**
- Off by \$4,400

## Test plan
- [x] `bun run tsc --noEmit` clean
- [ ] Manually load Accounts page, switch viewDate to a past month/year, confirm depository row's change number matches `dynamicAmount - previousAmount` (not today's `current` minus previous).
- [ ] Investment row already correct (PR #285); regression-check it still shows the same number.
- [ ] Credit row unaffected (Credit branch returns earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)