### PR TITLE
fix(accounts): use dynamicAmount for CryptoExchange balance row (closes #312)

### DIFF
--- a/src/client/components/AccountsTable/Balance.tsx
+++ b/src/client/components/AccountsTable/Balance.tsx
@@ -51,9 +51,11 @@ export const Balance = ({ account }: BalanceProps) => {
       <div className="Balance">
         <div>
           {symbol}
-          {currentString}
+          {dynamicAmount ? numberToCommaString(dynamicAmount) : currentString}
         </div>
-        {!!previousAmount && <Changes currentAmount={current!} previousAmount={previousAmount} />}
+        {!!previousAmount && (
+          <Changes currentAmount={dynamicAmount || current!} previousAmount={previousAmount} />
+        )}
       </div>
     );
   } else if (type === AccountType.Investment) {


### PR DESCRIPTION
## Summary
- The CryptoExchange subtype branch in `AccountsTable/Balance.tsx` rendered today's `balances.current` for both the amount cell and the Changes widget, ignoring the selected viewDate's historical balance.
- Same bug shape PR #285 fixed for the Investment branch and PR #311 (open) is fixing for the depository/loan branch — three instances, this PR closes the third.
- One file, four lines changed. Mirrors the Investment branch exactly.

Closes #312.

## Reproduction (local prod-snapshot DB)
Account: `QY6XDvjOKxFvADwrPyYZCwRqOQP9K8uJBBzr7` (Binance, type=investment, subtype=crypto exchange).

- `balances.current` (today) = `$1,835.77`
- balance snapshot 2026-01-31 = `$2,134.53`
- balance snapshot 2025-12-31 = `$2,366.09`
- viewDate = January 2026

| | Amount | Changes |
|---|---|---|
| Pre-fix render | `$1,835.77` | `-$530.32` (today − Dec) |
| Post-fix render | `$2,134.53` | `-$231.56` (Jan − Dec) |
| Donut on the same page (already correct) | `$2,134.53` | n/a |

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test:client` 158/158 pass
- [x] Render test via `react-dom/server.renderToStaticMarkup` confirms pre-fix renders `$1,835.77` / `-$530.32` and post-fix renders `$2,134.53` / `-$231.56` for the repro fixture above
- [x] viewDate = today regression check: with no snapshot for today, `dynamicAmount === 0`, so `dynamicAmount ? numberToCommaString(dynamicAmount) : currentString` falls through to `currentString` and `dynamicAmount || current!` falls through to `current!` — identical to pre-fix behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)