### PR TITLE
fix(accounts): Balance row shows today's balance for past dates with no history

### DIFF
--- a/src/client/components/AccountsTable/Balance.tsx
+++ b/src/client/components/AccountsTable/Balance.tsx
@@ -51,7 +51,7 @@ export const Balance = ({ account }: BalanceProps) => {
       <div className="Balance">
         <div>
           {symbol}
-          {dynamicAmount ? numberToCommaString(dynamicAmount) : currentString}
+          {numberToCommaString(dynamicAmount)}
         </div>
         {!!previousAmount && (
           <Changes currentAmount={dynamicAmount || current!} previousAmount={previousAmount} />
@@ -63,7 +63,7 @@ export const Balance = ({ account }: BalanceProps) => {
       <div className="Balance">
         <div>
           {symbol}
-          {dynamicAmount ? numberToCommaString(dynamicAmount) : currentString}
+          {numberToCommaString(dynamicAmount)}
         </div>
         {!!previousAmount && (
           <Changes currentAmount={dynamicAmount || current!} previousAmount={previousAmount} />
@@ -75,7 +75,7 @@ export const Balance = ({ account }: BalanceProps) => {
       <div className="Balance">
         <div>
           {symbol}
-          {dynamicAmount ? numberToCommaString(dynamicAmount) : currentString}
+          {numberToCommaString(dynamicAmount)}
         </div>
         {!!previousAmount && (
           <Changes currentAmount={dynamicAmount || current!} previousAmount={previousAmount} />


### PR DESCRIPTION
Closes #318

## Summary
Drop the `: currentString` fallback in `AccountsTable/Balance.tsx`'s three non-Credit branches. `dynamicAmount = balanceHistory.get(viewDateDate) ?? fallback` already encodes the past-vs-future rule documented in the leading comment (0 for past, today's for future); the extra ternary contradicts that intent specifically when dynamicAmount is 0, silently substituting today's `balances.current` for the missing historical value.

Same shape as PR #285 / #311 / #313 — table widget mixing today's `current!` into a historical view.

## Concrete repro (local prod-snapshot DB, today = 2026-05-06)

Account: **IBM - RBA** (`fda9c`, earliest snapshot 2025-09-30)
- today `balances.current` = $14,423.98
- `balanceHistory.get(Dec 31 2024)` = undefined → `dynamicAmount` = 0

| viewDate | pre-fix display | post-fix display | donut contribution |
|----------|-----------------|------------------|--------------------|
| Dec 2024 | $14,423.98 (today's) | $0.00 | $0 |

## Aggregate impact (AccountsPage, viewDate = December 2024)

| metric | value |
|--------|-------|
| Donut center total | $536,199 |
| Pre-fix sum of non-credit table rows | $610,294.88 |
| **Discrepancy** | **+$74,095.88** |
| Post-fix sum of non-credit table rows | $536,199.21 (rounding noise only) |

Four accounts at Dec 2024 silently displayed today's balance: IBM-Stock (recorded $0 snapshot → dynamicAmount===0 triggered the fallback), IBM-RSU, IBM-RBA, Binance.

Discrepancy across past months:

| viewDate | Donut | Table sum | Diff (pre-fix) | Diff (post-fix) |
|----------|-------|-----------|----------------|-----------------|
| 2024 (year) / Dec 2024 | $536,199 | $610,294.88 → $536,199.21 | +$74,095.88 | +$0.21 |
| Jan 2025 | $565,066 | $613,082.43 → $565,066.07 | +$48,016.43 | +$0.07 |
| Feb 2025 | $564,050 | $612,065.99 → $564,049.63 | +$48,015.99 | -$0.37 |
| Mar 2025 | $546,018 | $594,034.15 → $546,017.79 | +$48,016.15 | -$0.21 |
| Apr 2025 | $577,665 | $625,681.71 → $577,665.35 | +$48,016.71 | +$0.35 |
| May 2025 | $627,708 | $675,724.04 → $627,707.68 | +$48,016.04 | -$0.32 |

Post-fix residual diffs are pure rounding from the donut's whole-dollar `numberToCommaString(balanceTotal, 0)`.

## Diff
3-line change, applied identically to all three branches (CryptoExchange, Investment, default):

```diff
-{dynamicAmount ? numberToCommaString(dynamicAmount) : currentString}
+{numberToCommaString(dynamicAmount)}
```

Credit branch is unchanged: it intentionally shows today's spent/available regardless of viewDate.

## Test plan
- [x] typecheck (`bun run typecheck`) clean
- [x] lint (`bun run lint`) clean
- [x] `bun test` — 372 pass, 12 fail (12 pre-existing failures on upstream/main, unchanged by this PR; verified by running tests on stashed working tree)
- [x] E2E via Playwright on local prod-snapshot DB:
  - Logged in as admin, navigated to AccountsPage
  - Captured (donut center total, sum of non-credit table row balances) at viewDates spanning May 2026 → Dec 2024
  - Pre-fix: diff up to $74,095.88 at past dates
  - Post-fix: diff ≤ $0.50 (donut whole-dollar rounding) at all dates tested
- [x] Branch from `upstream/main` (`cda2cf2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)