### PR TITLE
fix(client): generateUUID falls back when crypto.randomUUID is unavailable (Closes #320)

### DIFF
--- a/src/client/lib/models/Capacity.test.ts
+++ b/src/client/lib/models/Capacity.test.ts
@@ -1,0 +1,61 @@
+import { test, expect, afterEach } from "bun:test";
+import { Capacity } from "./Capacity";
+
+const UUID_V4_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+const originalRandomUUID = globalThis.crypto?.randomUUID;
+const originalGetRandomValues = globalThis.crypto?.getRandomValues;
+
+afterEach(() => {
+  if (!globalThis.crypto) return;
+  if (originalRandomUUID) {
+    Object.defineProperty(globalThis.crypto, "randomUUID", {
+      value: originalRandomUUID,
+      configurable: true,
+      writable: true,
+    });
+  }
+  if (originalGetRandomValues) {
+    Object.defineProperty(globalThis.crypto, "getRandomValues", {
+      value: originalGetRandomValues,
+      configurable: true,
+      writable: true,
+    });
+  }
+});
+
+test("Capacity assigns a v4 UUID when crypto.randomUUID is available", () => {
+  const c = new Capacity();
+  expect(c.capacity_id).toMatch(UUID_V4_RE);
+});
+
+test("Capacity preserves an explicitly provided capacity_id", () => {
+  const c = new Capacity({ capacity_id: "preset-id" });
+  expect(c.capacity_id).toBe("preset-id");
+});
+
+test("Capacity falls back to manual UUID v4 when crypto.randomUUID is missing (issue #320)", () => {
+  Object.defineProperty(globalThis.crypto, "randomUUID", {
+    value: undefined,
+    configurable: true,
+    writable: true,
+  });
+  const c = new Capacity();
+  expect(c.capacity_id).toMatch(UUID_V4_RE);
+});
+
+test("Capacity falls back to Math.random when both randomUUID and getRandomValues are missing", () => {
+  Object.defineProperty(globalThis.crypto, "randomUUID", {
+    value: undefined,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(globalThis.crypto, "getRandomValues", {
+    value: undefined,
+    configurable: true,
+    writable: true,
+  });
+  const c = new Capacity();
+  expect(c.capacity_id).toMatch(UUID_V4_RE);
+});

--- a/src/client/lib/models/Capacity.ts
+++ b/src/client/lib/models/Capacity.ts
@@ -10,7 +10,19 @@ import {
 export type Interval = "year" | "month";
 export const intervals: Interval[] = ["year", "month"];
 
-const generateUUID = (): string => crypto.randomUUID();
+const generateUUID = (): string => {
+  const c = (typeof globalThis !== "undefined" && globalThis.crypto) || undefined;
+  if (c?.randomUUID) return c.randomUUID();
+  // Fallback: RFC 4122 v4 UUID built from getRandomValues (available in all
+  // browsers since 2011, no secure-context requirement).
+  const bytes = new Uint8Array(16);
+  if (c?.getRandomValues) c.getRandomValues(bytes);
+  else for (let i = 0; i < 16; i++) bytes[i] = Math.floor(Math.random() * 256);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0"));
+  return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10, 16).join("")}`;
+};
 
 export class Capacity {
   get id() {


### PR DESCRIPTION
Closes #320

## Summary

`crypto.randomUUID` is only exposed in **secure contexts** (HTTPS or `localhost`) and on relatively recent browsers. The Capacity constructor — which runs on every budget/section/category creation — calls it unconditionally, so on HTTP non-localhost or older browsers the SPA throws `TypeError: crypto.randomUUID is not a function` and the create flow breaks. Stack from the issue:

```
main-BOmojLYO.js:40 Uncaught TypeError: crypto.randomUUID is not a function
    at wb (main-BOmojLYO.js:48:413301)        ← generateUUID
    at new ha (main-BOmojLYO.js:48:413714)    ← new Capacity
    at Qa.fromJSON (main-BOmojLYO.js:48:414786)
    at new Gc (main-BOmojLYO.js:48:415762)
    at new Qa (main-BOmojLYO.js:48:416872)
```

## Fix

Feature-detect `randomUUID` and progressively degrade:

1. `globalThis.crypto.randomUUID()` — preferred (modern browsers, secure context)
2. RFC 4122 v4 UUID assembled from `crypto.getRandomValues` — universally available since 2011, **no secure-context requirement**, so it works on HTTP non-localhost
3. `Math.random` — last-resort fallback so the call never throws even in unusual sandboxes

The output format (`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`) is identical in all three paths.

`Capacity.ts` is the only client-side `crypto.randomUUID` site (`grep` confirms across `src/`). Server-side usages all `import { randomUUID } from "crypto"` and are unaffected.

## Test plan

- [x] **Unit regression** `src/client/lib/models/Capacity.test.ts` — 4 cases:
  - native `crypto.randomUUID` produces a v4 UUID (no regression)
  - explicit `capacity_id` is preserved (no regression)
  - `crypto.randomUUID === undefined` → fallback produces a valid v4 UUID (the bug condition)
  - `crypto.randomUUID` and `crypto.getRandomValues` both undefined → Math.random fallback still produces a valid v4 UUID
- [x] `bun run test:client` — **162 / 0 fail** (158 existing + 4 new)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] **Browser E2E (Playwright, headless chromium against `bun run dev`)**
  - Logged in as admin, opened the SPA at `http://localhost:3000`
  - Sanity: native `crypto.randomUUID` is reachable in browser context — produced `b3642246-ae3c-4f83-a902-a73ee24f4f56`
  - Bug condition: stashed `crypto.randomUUID = undefined`, then dynamically imported the real `lib/models/Capacity.ts` from the dev module graph, called `new Capacity()` → `capacity_id = 64288765-ad4d-4fc9-a657-c35fe41e5cca` (matches v4 regex). No exception thrown.
  - Restored `randomUUID` afterward; no `pageerror`s during page load.
- [x] Branched from `upstream/main` (`cda2cf2`)

## Why not just `window.crypto.randomUUID`

That was the suggestion in the issue body, but `window.crypto === globalThis.crypto` in browser contexts — both fail in the exact same scenarios (insecure context, older browser). The real cause of the error is that `randomUUID` itself is missing, not that `crypto` is shadowed. A feature-detected fallback is the only fix that actually unbreaks affected users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)