### PR TITLE
fix(transactions): kebab navigation updates URL when already on TRANSACTION_DETAIL

### DIFF
--- a/src/client/components/TransactionsTable/InvestmentTransactionRow.tsx
+++ b/src/client/components/TransactionsTable/InvestmentTransactionRow.tsx
@@ -24,7 +24,7 @@ const InvestmentTransactionRow = ({ investmentTransaction, isEditable = false }:
 
   const { data, setData, router } = useAppContext();
   const { accounts, budgets, sections, categories } = data;
-  const { path, go } = router;
+  const { go } = router;
 
   const account = accounts.get(account_id);
   const institution_id = account?.institution_id;
@@ -144,7 +144,6 @@ const InvestmentTransactionRow = ({ investmentTransaction, isEditable = false }:
   };
 
   const onClickKebab = () => {
-    if (path === PATH.TRANSACTION_DETAIL) return;
     const params = new URLSearchParams(router.params);
     params.set("investment_transaction_id", id);
     go(PATH.TRANSACTION_DETAIL, { params });

--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -30,7 +30,7 @@ const TransactionRow = ({ transaction }: Props) => {
   const amountAfterSplit = amount - transactionFamilies.getChildrenAmountTotal(id);
 
   const { accounts, budgets, sections, categories } = data;
-  const { path, go } = router;
+  const { go } = router;
 
   const account = accounts.get(account_id);
   const institution_id = account?.institution_id;
@@ -185,7 +185,6 @@ const TransactionRow = ({ transaction }: Props) => {
   };
 
   const onClickKebab = () => {
-    if (path === PATH.TRANSACTION_DETAIL) return;
     const params = new URLSearchParams(router.params);
     params.set("transaction_id", parentTransaction.transaction_id);
     go(PATH.TRANSACTION_DETAIL, { params });


### PR DESCRIPTION
## Summary
- In wide-screen layout, the right `<aside>` always renders `TransactionsPage` (Router.tsx:80), so its kebab buttons remain clickable while the left `<main>` shows `TransactionDetailPage`.
- After the first kebab click, `path` becomes `TRANSACTION_DETAIL`. Subsequent kebab clicks then early-return at `if (path === PATH.TRANSACTION_DETAIL) return;` (TransactionRow.tsx:188 / InvestmentTransactionRow.tsx:147) and the URL `transaction_id` never changes — the detail pane stays stuck on the first-clicked transaction.
- Drop the early-return so each click pushes a fresh `transaction_id` (or `investment_transaction_id`) onto the URL. Same fix applied to both row components.

The early-return predates the wide-screen `<aside>` layout (introduced when the page was first added in Jan 2025); it was only safe back when `TRANSACTION_DETAIL` was the only thing on screen, so no `TransactionRow` could be visible to click.

Closes #322

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test` — same 12 pre-existing failures as bare `upstream/main` (verified by stashing fix, re-running, then `git stash pop`); 383/383 of the rest pass
- [x] Browser E2E (Playwright headless chromium against `bun run dev`, viewport 1400x900):
  - Pre-fix: first kebab → `transaction_id=07KoQz…`, second kebab → URL still `transaction_id=07KoQz…` (BUG REPRODUCED)
  - Post-fix on this branch: first kebab → `transaction_id=07KoQz…`, second kebab → `transaction_id=Xxbgpb…` (URL updates correctly on every click)