### PR TITLE
docs(architecture): add transfers route + TransferPair data model

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,7 @@ budget/
 │   │       ├── accounts/     # Account management
 │   │       ├── budgets/      # Budget management
 │   │       ├── charts/       # Chart data
+│   │       ├── transfers/    # Transfer pair management
 │   │       ├── users/        # User management
 │   │       └── webhooks/     # Webhook handlers
 │   └── common/               # Shared code (client + server)
@@ -51,6 +52,7 @@ Core models are defined in `src/common/models/`:
 - **Item** — a connection to a financial institution
 - **Snapshot** — point-in-time record of account balances
 - **Chart** — visualization configuration
+- **TransferPair** — pairs two transactions across accounts as a single transfer (suggested or confirmed)
 
 ## External API Integrations
 


### PR DESCRIPTION
## Summary

Reflects PR #305 (transfers Phase 1 — data model and API endpoints) merged 2026-05-08:
- `src/server/routes/transfers/` exists alongside `accounts/budgets/charts/users/webhooks` but the project-tree in ARCHITECTURE.md was missing it.
- `JSONTransferPair` and `TransferPairStatus` are exported from `src/common/models/Transaction.ts`, but the Data Models list in ARCHITECTURE.md didn't list TransferPair.

## Verification

- `git ls-tree -d upstream/main:src/server/routes --name-only` → `accounts budgets charts transfers users webhooks` ✅
- `grep -E "JSONTransferPair|TransferPairStatus" src/common/models/Transaction.ts` → exported types confirmed ✅

No source code touched; pure docs PR.

## Test plan

- [ ] CI green (no test changes; markdown only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)