### PR TITLE
fix(charts): bail projection loop when goal is unreachable (Closes #327)

### DIFF
--- a/src/client/components/ProjectionChartRow/lib.ts
+++ b/src/client/components/ProjectionChartRow/lib.ts
@@ -71,30 +71,43 @@ export const calculateProjection = (config: ProjectionConfig): ProjectionCalcula
     }
   }
 
-  // calculate monthly progress until retirement
-  while (savedAmount * (monthlyPercentageYield - monthOverMonthInflation) < inflatedLivingCost) {
+  // bail after 100 years so a config that can never reach the goal
+  // (e.g. apy ≤ inflation with contribution too small to close the gap) doesn't loop forever
+  const MAX_PROJECTION_MONTHS = 1200;
+  let monthsProjected = 0;
+  while (
+    savedAmount * (monthlyPercentageYield - monthOverMonthInflation) < inflatedLivingCost &&
+    monthsProjected < MAX_PROJECTION_MONTHS
+  ) {
     savedAmount = savedAmount * monthlyPercentageYield + contribution;
     inflatedLivingCost *= monthOverMonthInflation;
     line.sequence.push(savedAmount);
     viewDate.next();
+    monthsProjected++;
   }
 
-  const retireDate = viewDate.clone().getStartDate();
-  const retireAmount = savedAmount;
+  const reachedRetirement =
+    savedAmount * (monthlyPercentageYield - monthOverMonthInflation) >= inflatedLivingCost;
 
-  const point: PointInput = {
-    point: { value: savedAmount, index: line.sequence.length - 1 },
-    color: pointColor,
-    guideX: true,
-    guideY: false,
-  };
+  const retireDate = reachedRetirement ? viewDate.clone().getStartDate() : undefined;
+  const retireAmount = reachedRetirement ? savedAmount : undefined;
 
-  // adds 5% padding after the retire point
-  const padding = line.sequence.length / 20;
-  for (let i = 0; i < padding; i++) {
-    savedAmount = savedAmount * monthOverMonthInflation;
-    line.sequence.push(savedAmount);
-    viewDate.next();
+  const points: PointInput[] = [];
+  if (reachedRetirement) {
+    points.push({
+      point: { value: savedAmount, index: line.sequence.length - 1 },
+      color: pointColor,
+      guideX: true,
+      guideY: false,
+    });
+
+    // adds 5% padding after the retire point
+    const padding = line.sequence.length / 20;
+    for (let i = 0; i < padding; i++) {
+      savedAmount = savedAmount * monthOverMonthInflation;
+      line.sequence.push(savedAmount);
+      viewDate.next();
+    }
   }
 
   // makes sure specified endDate is covered
@@ -115,7 +128,7 @@ export const calculateProjection = (config: ProjectionConfig): ProjectionCalcula
 
   return {
     graphViewDate: viewDate,
-    graphData: { lines: [line], points: [point] },
+    graphData: { lines: [line], points },
     retireDate,
     retireAmount,
   };


### PR DESCRIPTION
## Summary
- Cap the retirement projection loop at 100 years (1200 months) so a config where savings can never reach the goal stops looping.
- When the cap is hit, return `retireDate` / `retireAmount` undefined and emit no retire point — the chart still renders but the retirement rows in the table are omitted (the existing `!!retireDate && !!retireAmount` checks in `ProjectionChartRow/index.tsx` already handle this).

## Why it was infinite
`while (savedAmount * (mpy - momi) < inflatedLivingCost)` keeps iterating until LHS ≥ RHS. When `apy ≤ inflation` (e.g. user sets apy = 1.0 with positive inflation), `(mpy - momi) ≤ 0`, so LHS is non-positive while RHS is positive and grows. Even with a non-zero contribution, savings grow at most linearly while the living-cost target grows multiplicatively — the gap widens, the loop never exits.

## Test plan
- [x] `bun run typecheck` — passes
- [x] Standalone math sanity check: bad config (apy=1.0, inflation=1.038, contrib=0) hits cap at 1200 months and returns `reachedRetirement=false`; healthy config (apy=1.07, inflation=1.02, contrib=2000) reaches retirement at 322 months
- [x] E2E (Playwright via `bun`): login → dashboard with healthy charts (`Retirement` + `Super Retirement`) renders; patch a projection chart's config to `apy=1.0, inflation=1.038, contrib=0` via `POST /api/chart`, reload `/dashboard` — page completes in ~1.5s (no hang), SVG renders; restore original config