### PR TITLE
fix(accounts): exclude hidden accounts from 'Credits' badge + outstanding total

### DIFF
--- a/src/client/components/AccountsDonut/BalanceInfo.tsx
+++ b/src/client/components/AccountsDonut/BalanceInfo.tsx
@@ -1,3 +1,4 @@
+import { AccountType } from "plaid";
 import { DonutData, useAppContext } from "client";
 import { Changes } from "client/components";
 
@@ -25,11 +26,10 @@ export const BalanceInfo = ({ balanceTotal, currencySymbol, donutData, isShrunk 
   let totalCredit = 0;
   let numberOfOthers = 0;
 
-  accounts.forEach(({ account_id, balances }) => {
-    if (!donutData.find(({ id }) => id === account_id)) {
-      totalCredit += balances.current || 0;
-      numberOfOthers++;
-    }
+  accounts.forEach(({ balances, hide, type }) => {
+    if (hide || type !== AccountType.Credit) return;
+    totalCredit += balances.current || 0;
+    numberOfOthers++;
   });
 
   return (

--- a/src/client/components/AccountsDonut/BalanceInfo.tsx
+++ b/src/client/components/AccountsDonut/BalanceInfo.tsx
@@ -1,4 +1,3 @@
-import { AccountType } from "plaid";
 import { DonutData, useAppContext } from "client";
 import { Changes } from "client/components";
 
@@ -6,12 +5,20 @@ interface Props {
   balanceTotal: number;
   currencySymbol: string;
   donutData: DonutData[];
+  totalCredit: number;
+  numberOfCredits: number;
   isShrunk: boolean;
 }
 
-export const BalanceInfo = ({ balanceTotal, currencySymbol, donutData, isShrunk }: Props) => {
-  const { data, calculations, viewDate } = useAppContext();
-  const { accounts } = data;
+export const BalanceInfo = ({
+  balanceTotal,
+  currencySymbol,
+  donutData,
+  totalCredit,
+  numberOfCredits,
+  isShrunk,
+}: Props) => {
+  const { calculations, viewDate } = useAppContext();
   const { balanceData } = calculations;
 
   const viewDateSpan = Math.max(-viewDate.getSpanFrom(new Date()), 0);
@@ -22,15 +29,6 @@ export const BalanceInfo = ({ balanceTotal, currencySymbol, donutData, isShrunk 
     if (!balanceHistory) return a;
     return a + (balanceHistory.get(previousDate) || 0);
   }, 0);
-
-  let totalCredit = 0;
-  let numberOfOthers = 0;
-
-  accounts.forEach(({ balances, hide, type }) => {
-    if (hide || type !== AccountType.Credit) return;
-    totalCredit += balances.current || 0;
-    numberOfOthers++;
-  });
 
   return (
     <div className="BalanceInfo">
@@ -50,7 +48,7 @@ export const BalanceInfo = ({ balanceTotal, currencySymbol, donutData, isShrunk 
             currencySymbol={currencySymbol}
           />
           <div className="credit label">outstanding</div>
-          <div className="credit label">in&nbsp;{numberOfOthers}&nbsp;Credits</div>
+          <div className="credit label">in&nbsp;{numberOfCredits}&nbsp;Credits</div>
         </>
       )}
     </div>

--- a/src/client/components/AccountsDonut/index.tsx
+++ b/src/client/components/AccountsDonut/index.tsx
@@ -9,6 +9,8 @@ interface Props {
   balanceTotal: number;
   currencySymbol: string;
   donutData: DonutData[];
+  totalCredit: number;
+  numberOfCredits: number;
   radius: number;
   style?: CSSProperties;
 }
@@ -17,6 +19,8 @@ export const AccountsDonut = ({
   balanceTotal,
   currencySymbol,
   donutData,
+  totalCredit,
+  numberOfCredits,
   radius,
   style,
 }: Props) => {
@@ -36,6 +40,8 @@ export const AccountsDonut = ({
         balanceTotal={balanceTotal}
         currencySymbol={currencySymbol}
         donutData={donutData}
+        totalCredit={totalCredit}
+        numberOfCredits={numberOfCredits}
         isShrunk={isShrunk}
       />
     </div>

--- a/src/client/pages/AccountsPage/index.tsx
+++ b/src/client/pages/AccountsPage/index.tsx
@@ -19,16 +19,25 @@ export const AccountsPage = () => {
     return () => window.removeEventListener("scroll", listener);
   }, [debouncer]);
 
-  const { donutData, currencySymbol, balanceTotal } = useMemo(() => {
+  const { donutData, currencySymbol, balanceTotal, totalCredit, numberOfCredits } = useMemo(() => {
     let balanceTotal = 0;
+    let totalCredit = 0;
+    let numberOfCredits = 0;
     const donutData: DonutData[] = [];
 
-    const filteredAccounts = accounts
+    const sortedAccounts = accounts
       .toArray()
-      .sort((a, b) => getAccountBalance(b) - getAccountBalance(a))
-      .filter(({ hide, type }) => {
-        return !hide && type !== AccountType.Credit;
-      });
+      .sort((a, b) => getAccountBalance(b) - getAccountBalance(a));
+
+    const filteredAccounts = sortedAccounts.filter(({ hide, type }) => {
+      return !hide && type !== AccountType.Credit;
+    });
+
+    sortedAccounts.forEach(({ hide, type, balances }) => {
+      if (hide || type !== AccountType.Credit) return;
+      totalCredit += balances.current || 0;
+      numberOfCredits++;
+    });
 
     // For yearly view of the current (incomplete) year, viewDate.getEndDate()
     // returns Dec 31 which has no balance data yet. Cap the lookup to the
@@ -56,7 +65,7 @@ export const AccountsPage = () => {
     const currencyCode = currencyCodes.values().next().value || "USD";
     const currencySymbol = currencyCodeToSymbol(currencyCode);
 
-    return { donutData, currencySymbol, balanceTotal };
+    return { donutData, currencySymbol, balanceTotal, totalCredit, numberOfCredits };
   }, [accounts, balanceData, viewDate]);
 
   const isNarrow = screenType === ScreenType.Narrow;
@@ -77,6 +86,8 @@ export const AccountsPage = () => {
         balanceTotal={balanceTotal}
         currencySymbol={currencySymbol}
         donutData={donutData}
+        totalCredit={totalCredit}
+        numberOfCredits={numberOfCredits}
         radius={donutRadius}
         style={{ top: donutTop, position: donutPosition }}
       />


### PR DESCRIPTION
Closes #329

## Summary

`AccountsDonut/BalanceInfo.tsx` was iterating over the unfiltered `accounts` collection and counting/summing anything not present in `donutData` (which only contains visible asset accounts). The loop intent was "any non-asset is a credit," but the implementation also swept in:

- hidden credit accounts (visible bug — badge said "in 5 Credits" while `AccountsTable` rendered 4)
- hidden asset accounts (latent — would be miscategorized as credit and added to outstanding total in the wrong direction)
- non-credit liabilities (latent — `loan` etc. would be miscategorized)

Initial fix replaced "not on the donut" with the explicit predicate the same-page `AccountsTable` already uses for its credit rows: `!hide && type === AccountType.Credit`. A follow-up refactor (addressing review) then lifted credits composition into `AccountsPage` so the donut and the badge share a single source of truth.

## Commits

1. **`fix(accounts): exclude hidden accounts from "Credits" badge + outstanding total`** — original one-line predicate fix in `BalanceInfo.tsx`.
2. **`refactor(accounts): lift credits composition into AccountsPage`** — review follow-up. `AccountsPage` now computes both `donutData` and the credit totals (`totalCredit`, `numberOfCredits`) in the same `useMemo` and passes them through `AccountsDonut` to `BalanceInfo`. `BalanceInfo` becomes purely presentational and no longer reads `accounts` directly. Behavior unchanged.

## Files

- `src/client/components/AccountsDonut/BalanceInfo.tsx` — presentational only; takes `totalCredit` + `numberOfCredits` as props.
- `src/client/components/AccountsDonut/index.tsx` — passes credit totals through.
- `src/client/pages/AccountsPage/index.tsx` — single `useMemo` builds `donutData` and credit totals together.

## Verification

- Pre-fix: rendered "in 5 Credits" badge while `AccountsTable` rendered 4 credit rows on local prod-snapshot DB (5 credit accounts in DB, 1 with `hide=TRUE` and `balances.current=0`).
- Post-fix: badge renders "in 4 Credits", matching the visible row count. Sum (`-$<amount> outstanding`) is unchanged because the hidden card had a zero balance.
- Playwright E2E against `localhost:3000/accounts` (logged in as admin):
  - `document.querySelector('.BalanceInfo')?.textContent` → "+$<changes>from last monthin 11 Accounts-$<outstanding>outstandingin 4 Credits" (was "in 5 Credits" pre-fix).
- `bun run typecheck` clean
- `bun run lint` clean

## Test plan
- [x] Typecheck + lint
- [x] E2E: badge count matches rendered credit-row count
- [ ] Hoie review
