### PR TITLE
docs(CODE_STYLE): document component className and …Page padding conventions

### DIFF
--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -90,6 +90,54 @@ Use named constants from `common/utils/date.ts`:
 import { ONE_HOUR, TWO_WEEKS, THIRTY_DAYS } from "common";
 ```
 
+## Component className Convention
+
+### Root className matches component name
+
+Every component renders a root `<div>` (or other element) whose class name matches the component identifier exactly:
+
+```tsx
+// AccountDetailPage/index.tsx
+const AccountDetailPage = () => (
+  <div className="AccountDetailPage">
+    <AccountProperties ... />
+  </div>
+);
+
+// AccountProperties/index.tsx
+const AccountProperties = () => (
+  <div className="AccountProperties Properties">
+    {/* ... */}
+  </div>
+);
+```
+
+CSS selectors target the same name (`div.AccountDetailPage > div { ... }`), making it easy to jump from a class in DevTools to the component file. Never reuse another component's class name on a different component (e.g. `<div className="ConfigPage">` inside `ConnectionDetailPage` is wrong).
+
+### Generic shared classes co-exist with the specific class
+
+When a component conforms to a shared visual contract, append the generic class after the specific one:
+
+```tsx
+<div className="AccountProperties Properties">      {/* shared layout from div.Properties */}
+<div className="TransactionProperties Properties">
+<div className="BudgetProperties Properties">
+```
+
+The generic class (`Properties`) carries shared rules (`div.Properties > .property { ... }` defined in `App/index.css`). The specific class (`AccountProperties`) carries component-specific overrides. Order: **specific first, then generic**.
+
+### `…Page` components have a standard padding rule
+
+Page components live under `src/client/pages/<Name>Page/` and render the routed view. Their CSS always defines:
+
+```css
+div.AccountDetailPage > div {
+  padding: 0 10px;
+}
+```
+
+This gives all direct children a consistent horizontal inset. Use the same `div.<PageName> > div { padding: 0 10px; }` block in every new `…Page`'s `index.css`.
+
 ## Accessibility
 
 ### Interactive Elements


### PR DESCRIPTION
## Summary

Adds a new "Component className Convention" section to `docs/CODE_STYLE.md`. Three repo-wide conventions that are universally applied in the existing code but undocumented — Hoie has had to repeat them in PR review (most recently in PR #196 on 2026-05-08, ending with "Remember that"):

1. **Root className matches component name.** `AccountDetailPage` → `<div className="AccountDetailPage">`. Lets a class in DevTools jump straight to the component file.
2. **Specific class first, generic class second.** Components that conform to a shared visual contract append the generic class after the specific one: `<div className="AccountProperties Properties">`. The generic (`Properties`) class carries the shared rules from `App/index.css`; the specific class carries component-specific overrides.
3. **`…Page` components define `div.<Name>Page > div { padding: 0 10px; }`.** Consistent horizontal inset on every direct child of the page root.

## Why

A new `…Page` or `…Properties` component shouldn't need a code-review round-trip to learn these rules — a quick read of `CODE_STYLE.md` should be enough.

## Verification — conventions universally applied at upstream/main HEAD `4bea199`

**`…Page` root className matches component name (6/6 sampled):**
```
src/client/pages/AccountDetailPage/index.tsx       <div className="AccountDetailPage">
src/client/pages/BudgetDetailPage/index.tsx        <div className="BudgetDetailPage">
src/client/pages/TransactionDetailPage/index.tsx   <div className="TransactionDetailPage">
src/client/pages/HoldingDetailPage/index.tsx       <div className="HoldingDetailPage">
src/client/pages/ConfigPage/index.tsx              <div className="ConfigPage">
src/client/pages/DashboardPage/index.tsx           <div className="DashboardPage">
```

**Specific + generic Properties pattern (5/5 found):**
```
<div className="AccountProperties Properties">
<div className="BudgetProperties Properties">
<div className="Configuration Properties">
<div className="ConnectionProperties Properties">
<div className="TransactionProperties Properties">
```
Shared `div.Properties { ... }` rules live in `src/client/components/App/index.css`.

**`…Page > div { padding: 0 10px }` (sampled):**
```
src/client/pages/AccountDetailPage/index.css:      div.AccountDetailPage > div { padding: 0 10px; }
src/client/pages/TransactionDetailPage/index.css:  div.TransactionDetailPage > div { padding: 0 10px; }
src/client/pages/ConfigPage/index.css:             div.ConfigPage > div { padding: 0 10px; }
```

## Test plan

- [x] Pure markdown — single file changed (`docs/CODE_STYLE.md`, +48/-0).
- [x] No source files touched. `git diff --stat` confirms.
- [x] All three conventions cross-checked against current `upstream/main` source as shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)