### PR TITLE
feat(transfers): Phase 2 — detection engine and background job (Closes #235)

### DIFF
--- a/src/server/lib/compute-tools/detect-transfers.test.ts
+++ b/src/server/lib/compute-tools/detect-transfers.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, mock } from "bun:test";
+import {
+  runTransferDetection,
+  scoreConfidence,
+  type DetectionCandidate,
+} from "./detect-transfers";
+
+const noopLogger = {
+  info: () => {},
+  error: mock(() => {}),
+};
+
+type CreateCall = {
+  userId: string;
+  transactionIdA: string;
+  transactionIdB: string;
+};
+
+describe("scoreConfidence", () => {
+  it("returns 0.7 base for a same-window non-Plaid match", () => {
+    expect(scoreConfidence(false, 2)).toBe(0.7);
+  });
+
+  it("adds 0.2 when Plaid tagged either side as TRANSFER_*", () => {
+    expect(scoreConfidence(true, 2)).toBeCloseTo(0.9);
+  });
+
+  it("adds 0.1 same-day boost", () => {
+    expect(scoreConfidence(false, 0)).toBeCloseTo(0.8);
+  });
+
+  it("stacks Plaid + same-day, capped at 0.99", () => {
+    expect(scoreConfidence(true, 0)).toBeCloseTo(0.99);
+  });
+
+  it("does not apply same-day boost when delta is 1 day", () => {
+    expect(scoreConfidence(false, 1)).toBe(0.7);
+  });
+});
+
+describe("runTransferDetection", () => {
+  it("does nothing when there are no users", async () => {
+    const queryFn = mock(async () => ({ rows: [] }));
+    const fetchUsers = mock(async () => []);
+    const fetchCandidates = mock(async () => [] as DetectionCandidate[]);
+    const createPair = mock(async () => {});
+
+    await runTransferDetection(
+      queryFn,
+      noopLogger,
+      fetchUsers,
+      fetchCandidates,
+      createPair,
+    );
+
+    expect(fetchUsers).toHaveBeenCalledTimes(1);
+    expect(fetchCandidates).toHaveBeenCalledTimes(0);
+    expect(createPair).toHaveBeenCalledTimes(0);
+  });
+
+  it("inserts a pair for a single candidate above threshold", async () => {
+    const created: CreateCall[] = [];
+    const queryFn = mock(async () => ({ rows: [] }));
+    const fetchUsers = async () => ["user-1"];
+    const fetchCandidates = async (): Promise<DetectionCandidate[]> => [
+      {
+        transaction_id_a: "txn-a",
+        transaction_id_b: "txn-b",
+        date_delta: 1,
+        is_plaid_transfer: false,
+      },
+    ];
+    const createPair = async (
+      userId: string,
+      transactionIdA: string,
+      transactionIdB: string,
+    ) => {
+      created.push({ userId, transactionIdA, transactionIdB });
+    };
+
+    await runTransferDetection(queryFn, noopLogger, fetchUsers, fetchCandidates, createPair);
+    expect(created).toEqual([
+      { userId: "user-1", transactionIdA: "txn-a", transactionIdB: "txn-b" },
+    ]);
+  });
+
+  it("prevents a single transaction from being paired twice in one run", async () => {
+    const created: CreateCall[] = [];
+    const fetchUsers = async () => ["user-1"];
+    const fetchCandidates = async (): Promise<DetectionCandidate[]> => [
+      {
+        transaction_id_a: "txn-shared",
+        transaction_id_b: "txn-1",
+        date_delta: 0,
+        is_plaid_transfer: false,
+      },
+      {
+        transaction_id_a: "txn-shared",
+        transaction_id_b: "txn-2",
+        date_delta: 1,
+        is_plaid_transfer: false,
+      },
+      {
+        transaction_id_a: "txn-1",
+        transaction_id_b: "txn-3",
+        date_delta: 0,
+        is_plaid_transfer: false,
+      },
+    ];
+    const createPair = async (
+      userId: string,
+      a: string,
+      b: string,
+    ) => {
+      created.push({ userId, transactionIdA: a, transactionIdB: b });
+    };
+
+    await runTransferDetection(
+      async () => ({ rows: [] }),
+      noopLogger,
+      fetchUsers,
+      fetchCandidates,
+      createPair,
+    );
+
+    // First candidate consumes txn-shared and txn-1.
+    // Second candidate (txn-shared, txn-2) is skipped because txn-shared is used.
+    // Third candidate (txn-1, txn-3) is skipped because txn-1 is used.
+    expect(created).toEqual([
+      { userId: "user-1", transactionIdA: "txn-shared", transactionIdB: "txn-1" },
+    ]);
+  });
+
+  it("processes each user independently and isolates failures", async () => {
+    const created: CreateCall[] = [];
+    const errorLogger = {
+      info: () => {},
+      error: mock(() => {}),
+    };
+    const fetchUsers = async () => ["user-bad", "user-good"];
+    const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> => {
+      if (userId === "user-bad") throw new Error("boom");
+      return [
+        {
+          transaction_id_a: "g-a",
+          transaction_id_b: "g-b",
+          date_delta: 0,
+          is_plaid_transfer: true,
+        },
+      ];
+    };
+    const createPair = async (userId: string, a: string, b: string) => {
+      created.push({ userId, transactionIdA: a, transactionIdB: b });
+    };
+
+    await runTransferDetection(
+      async () => ({ rows: [] }),
+      errorLogger,
+      fetchUsers,
+      fetchCandidates,
+      createPair,
+    );
+
+    expect(errorLogger.error).toHaveBeenCalledTimes(1);
+    expect(created).toEqual([
+      { userId: "user-good", transactionIdA: "g-a", transactionIdB: "g-b" },
+    ]);
+  });
+
+  it("logs but continues when an INSERT throws", async () => {
+    const errorLogger = {
+      info: () => {},
+      error: mock(() => {}),
+    };
+    const fetchUsers = async () => ["user-1"];
+    const fetchCandidates = async (): Promise<DetectionCandidate[]> => [
+      {
+        transaction_id_a: "a1",
+        transaction_id_b: "b1",
+        date_delta: 0,
+        is_plaid_transfer: false,
+      },
+      {
+        transaction_id_a: "a2",
+        transaction_id_b: "b2",
+        date_delta: 0,
+        is_plaid_transfer: false,
+      },
+    ];
+    let calls = 0;
+    const createPair = async () => {
+      calls++;
+      if (calls === 1) throw new Error("conflict");
+    };
+
+    await runTransferDetection(
+      async () => ({ rows: [] }),
+      errorLogger,
+      fetchUsers,
+      fetchCandidates,
+      createPair,
+    );
+
+    expect(calls).toBe(2);
+    expect(errorLogger.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/lib/compute-tools/detect-transfers.ts
+++ b/src/server/lib/compute-tools/detect-transfers.ts
@@ -1,0 +1,234 @@
+import { pool, logger, usersTable } from "server";
+import { canonicalizePairIds } from "../postgres/models";
+
+const BASE_CONFIDENCE = 0.7;
+const PLAID_TRANSFER_BOOST = 0.2;
+const SAME_DAY_BOOST = 0.1;
+const SUGGEST_THRESHOLD = 0.7;
+const DATE_WINDOW_DAYS = 3;
+const PER_USER_CANDIDATE_LIMIT = 500;
+
+export interface DetectionCandidate {
+  transaction_id_a: string;
+  transaction_id_b: string;
+  date_delta: number;
+  is_plaid_transfer: boolean;
+}
+
+type QueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: Record<string, unknown>[] }>;
+type LogFn = {
+  info: (message: string, context?: Record<string, unknown>) => void;
+  error: (message: string, context?: Record<string, unknown>, error?: unknown) => void;
+};
+type FetchUsersFn = () => Promise<string[]>;
+type FetchCandidatesFn = (userId: string) => Promise<DetectionCandidate[]>;
+type CreatePairFn = (
+  userId: string,
+  transactionIdA: string,
+  transactionIdB: string,
+) => Promise<void>;
+
+export const scoreConfidence = (
+  isPlaidTransfer: boolean,
+  dateDelta: number,
+): number => {
+  let confidence = BASE_CONFIDENCE;
+  if (isPlaidTransfer) confidence += PLAID_TRANSFER_BOOST;
+  if (dateDelta < 1) confidence += SAME_DAY_BOOST;
+  return Math.min(confidence, 0.99);
+};
+
+const defaultFetchUsers: FetchUsersFn = async () => {
+  const users = await usersTable.query({});
+  return users.map((u) => u.user_id);
+};
+
+const defaultFetchCandidates =
+  (queryFn: QueryFn): FetchCandidatesFn =>
+  async (userId) => {
+    const result = await queryFn(
+      `SELECT
+         t1.transaction_id AS transaction_id_a,
+         t2.transaction_id AS transaction_id_b,
+         ABS(t1.date - t2.date) AS date_delta,
+         (
+           (t1.raw->'personal_finance_category'->>'primary') LIKE 'TRANSFER%'
+           OR (t2.raw->'personal_finance_category'->>'primary') LIKE 'TRANSFER%'
+         ) AS is_plaid_transfer
+       FROM transactions t1
+       JOIN transactions t2
+         ON t1.user_id = t2.user_id
+        AND t1.user_id = $1
+        AND ABS(t1.amount) = ABS(t2.amount)
+        AND t1.amount * t2.amount < 0
+        AND t1.account_id <> t2.account_id
+        AND ABS(t1.date - t2.date) <= $2
+        AND t1.transaction_id < t2.transaction_id
+       WHERE (t1.is_deleted IS NULL OR t1.is_deleted = FALSE)
+         AND (t2.is_deleted IS NULL OR t2.is_deleted = FALSE)
+         AND NOT EXISTS (
+           SELECT 1 FROM transaction_pairs tp
+           WHERE tp.user_id = t1.user_id
+             AND (tp.is_deleted IS NULL OR tp.is_deleted = FALSE)
+             AND (
+               tp.transaction_id_a IN (t1.transaction_id, t2.transaction_id)
+               OR tp.transaction_id_b IN (t1.transaction_id, t2.transaction_id)
+             )
+         )
+       ORDER BY ABS(t1.date - t2.date) ASC, t1.transaction_id ASC
+       LIMIT $3`,
+      [userId, DATE_WINDOW_DAYS, PER_USER_CANDIDATE_LIMIT],
+    );
+
+    return result.rows.map((row) => ({
+      transaction_id_a: row.transaction_id_a as string,
+      transaction_id_b: row.transaction_id_b as string,
+      date_delta: Number(row.date_delta),
+      is_plaid_transfer: row.is_plaid_transfer === true,
+    }));
+  };
+
+const defaultCreatePair =
+  (queryFn: QueryFn): CreatePairFn =>
+  async (userId, transactionIdA, transactionIdB) => {
+    const pair_id = crypto.randomUUID();
+    const canonical = canonicalizePairIds(transactionIdA, transactionIdB);
+    // INSERT...SELECT WHERE NOT EXISTS instead of ON CONFLICT to avoid
+    // requiring a UNIQUE (transaction_id_a, transaction_id_b) constraint
+    // that isn't enforced by the auto-migration. Also stronger: this rejects
+    // any insert that would re-use a transaction already in a non-deleted
+    // pair, even with a different counterpart (the candidates query already
+    // filters these out, but the IN clause closes the SELECT-then-INSERT
+    // race window).
+    await queryFn(
+      `INSERT INTO transaction_pairs
+         (pair_id, user_id, transaction_id_a, transaction_id_b, status)
+       SELECT $1, $2, $3, $4, 'suggested'
+       WHERE NOT EXISTS (
+         SELECT 1 FROM transaction_pairs tp
+         WHERE tp.user_id = $2
+           AND (tp.is_deleted IS NULL OR tp.is_deleted = FALSE)
+           AND (
+             tp.transaction_id_a IN ($3, $4)
+             OR tp.transaction_id_b IN ($3, $4)
+           )
+       )`,
+      [
+        pair_id,
+        userId,
+        canonical.transaction_id_a,
+        canonical.transaction_id_b,
+      ],
+    );
+  };
+
+/**
+ * Background job that scans unpaired transactions and suggests transfer pairs.
+ *
+ * Match criteria (enforced by the SQL):
+ *   - same user, different accounts
+ *   - equal absolute amount with opposite signs (debit/credit)
+ *   - |date_a - date_b| <= 3 days
+ *   - neither transaction already participates in a non-deleted pair
+ *
+ * Confidence scoring (`scoreConfidence`):
+ *   - base 0.7
+ *   - +0.2 if Plaid tagged either transaction with personal_finance_category
+ *     primary = TRANSFER_IN/TRANSFER_OUT
+ *   - +0.1 if same calendar day (date_delta < 1)
+ *
+ * Candidates with confidence >= 0.7 are inserted with status `suggested`.
+ *
+ * Concurrency: within one run, the first accepted pair for a transaction
+ * removes that transaction from further pairing in this run, preventing one
+ * transaction from being paired with multiple others if several candidates
+ * fall in the date window.
+ *
+ * Backfill semantics: the same code path handles incremental and historical
+ * scans. The first run after deploy sees every previously-unpaired transaction
+ * and emits pairs for it; subsequent hourly runs are cheap because the SQL
+ * filters out anything already in `transaction_pairs`.
+ */
+export const runTransferDetection = async (
+  queryFn: QueryFn = (sql, params) => pool.query(sql, params),
+  log: LogFn = logger,
+  fetchUsers: FetchUsersFn = defaultFetchUsers,
+  fetchCandidates: FetchCandidatesFn = defaultFetchCandidates((sql, params) =>
+    queryFn(sql, params),
+  ),
+  createPair: CreatePairFn = defaultCreatePair((sql, params) => queryFn(sql, params)),
+): Promise<void> => {
+  log.info("Transfer-detection job started");
+
+  let totalUsers = 0;
+  let totalSuggested = 0;
+
+  try {
+    const userIds = await fetchUsers();
+    for (const userId of userIds) {
+      try {
+        const candidates = await fetchCandidates(userId);
+        const usedTxnIds = new Set<string>();
+        let userSuggested = 0;
+
+        for (const candidate of candidates) {
+          if (
+            usedTxnIds.has(candidate.transaction_id_a) ||
+            usedTxnIds.has(candidate.transaction_id_b)
+          ) {
+            continue;
+          }
+
+          const confidence = scoreConfidence(
+            candidate.is_plaid_transfer,
+            candidate.date_delta,
+          );
+          if (confidence < SUGGEST_THRESHOLD) continue;
+
+          try {
+            await createPair(
+              userId,
+              candidate.transaction_id_a,
+              candidate.transaction_id_b,
+            );
+            usedTxnIds.add(candidate.transaction_id_a);
+            usedTxnIds.add(candidate.transaction_id_b);
+            userSuggested++;
+          } catch (err) {
+            log.error(
+              "Failed to insert transfer pair",
+              {
+                userId,
+                transaction_id_a: candidate.transaction_id_a,
+                transaction_id_b: candidate.transaction_id_b,
+              },
+              err,
+            );
+          }
+        }
+
+        totalSuggested += userSuggested;
+        totalUsers++;
+        if (userSuggested > 0) {
+          log.info("Suggested transfer pairs for user", {
+            userId,
+            suggested: userSuggested,
+            candidatesConsidered: candidates.length,
+          });
+        }
+      } catch (err) {
+        log.error("Transfer detection failed for user", { userId }, err);
+      }
+    }
+  } catch (err) {
+    log.error("Transfer-detection job failed to fetch users", {}, err);
+  }
+
+  log.info("Transfer-detection job completed", {
+    usersProcessed: totalUsers,
+    pairsSuggested: totalSuggested,
+  });
+};

--- a/src/server/lib/compute-tools/index.ts
+++ b/src/server/lib/compute-tools/index.ts
@@ -2,3 +2,4 @@ export * from "./sync-plaid";
 export * from "./sync-simple-fin";
 export * from "./schedule";
 export * from "./auto-suggest";
+export * from "./detect-transfers";

--- a/src/server/lib/compute-tools/schedule.ts
+++ b/src/server/lib/compute-tools/schedule.ts
@@ -4,6 +4,7 @@ import { sendAlarm } from "server/lib/alarm";
 import { syncPlaidAccounts, syncPlaidTransactions } from "./sync-plaid";
 import { syncSimpleFinData } from "./sync-simple-fin";
 import { runAutoSuggestions } from "./auto-suggest";
+import { runTransferDetection } from "./detect-transfers";
 
 let syncTimer: ReturnType<typeof setInterval> | null = null;
 let isSyncing = false;
@@ -88,6 +89,9 @@ const runSync = async () => {
     }
     await runAutoSuggestions().catch((error) => {
       logger.error("Auto-suggestion job failed", {}, error);
+    });
+    await runTransferDetection().catch((error) => {
+      logger.error("Transfer-detection job failed", {}, error);
     });
   } catch (err) {
     logger.error("Error occurred during scheduled sync", {}, err);


### PR DESCRIPTION
Closes #235. Phase 1 (#305) landed the data model and `pairTransactions` API; this PR adds the background detection engine that proposes pairs automatically.

## What it does

`src/server/lib/compute-tools/detect-transfers.ts` exposes `runTransferDetection()` — runs per user, finds candidate transfer pairs via a self-JOIN on `transactions`, scores them, and inserts qualifying pairs as `status='suggested'`.

**Match criteria (in the SQL):**
- same user, different `account_id`
- `ABS(t1.amount) = ABS(t2.amount)` AND `t1.amount * t2.amount < 0` (equal absolute amount, opposite signs)
- `ABS(t1.date - t2.date) <= 3` days
- Canonical ordering: `t1.transaction_id < t2.transaction_id` (no symmetric duplicates)
- `NOT EXISTS` against `transaction_pairs` so already-paired transactions are excluded
- `LIMIT 500` candidates per user per run (bounded DB pressure; subsequent runs pick up the rest)

**Confidence scoring** (`scoreConfidence`):
- base 0.7
- +0.2 if either side's `raw->'personal_finance_category'->>'primary'` matches `TRANSFER%` (Plaid tagged it as a transfer)
- +0.1 if `date_delta < 1` (same calendar day)
- cap at 0.99

Threshold 0.7 (everything above base qualifies as `suggested`; below would mean manual-only, but the base equals the threshold today). Within a single run, the first accepted pair for a transaction prevents that transaction from being paired again — protects against the 3-day window producing two valid candidates for the same row.

## Wiring

`scheduledSync` already runs hourly and calls `runAutoSuggestions()` at the end. This PR adds a `runTransferDetection()` call right after it (`schedule.ts`). The first run after deploy scans all historical data — that doubles as the backfill task from the issue checklist. Subsequent hourly runs are cheap because the candidates SQL filters out anything already in `transaction_pairs`.

## INSERT path

Uses `INSERT ... SELECT WHERE NOT EXISTS` instead of `ON CONFLICT (transaction_id_a, transaction_id_b) DO NOTHING`. Two reasons:

1. The auto-migration tool only handles columns, not constraints — the `transaction_pairs_pair_unique` UNIQUE declared in the model isn't actually applied to existing tables, so `ON CONFLICT` would 42P10 on dev DBs (verified locally).
2. Stronger guarantee: the NOT EXISTS subquery rejects any insert where *either* transaction is already paired with anything, closing the SELECT-then-INSERT race window. The candidates query already filters this, but the INSERT-time check makes it safe against concurrent manual-pair API calls.

## Files

- `src/server/lib/compute-tools/detect-transfers.ts` — new, 235 lines
- `src/server/lib/compute-tools/detect-transfers.test.ts` — new, 10 unit tests
- `src/server/lib/compute-tools/schedule.ts` — wire `runTransferDetection()` after `runAutoSuggestions()`
- `src/server/lib/compute-tools/index.ts` — re-export

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test src/server` → 260 pass / 0 fail (10 new in `detect-transfers.test.ts`)

**Unit tests** cover scoring (5 cases: base, Plaid-only, same-day-only, capped at 0.99, delta=1 no boost) and the run loop (5 cases: no users, single candidate, prevent double-pairing within a run, per-user failure isolation, INSERT failure isolation).

**E2E against the real `budget` Postgres** (`/tmp/e2e-detect-transfers.ts` and `/tmp/e2e-detect-insert.ts`, both ROLLBACK-only):

- Candidates query against 6,265 production-snapshot transactions: 265 candidate pairs returned for the active user. Top-of-list examples all show same-day equal-absolute-amount opposite-sign pairs across two accounts, exactly as expected.
- INSERT path verified in a transaction (rolled back so dev DB is unchanged):
  - first insert → `rowCount=1` with `status='suggested'`, `is_deleted=false`
  - duplicate insert (same a,b) → `rowCount=0` (NOT EXISTS blocks)
  - partial-overlap (a already paired, try a + otherB) → `rowCount=0` (NOT EXISTS blocks)
- Sandbox spin-up will run end-to-end against fresh DB; Hoie can UI-verify suggested pairs surface for the Phase 3 UI work tracked in #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)