### PR TITLE
chore: add CODEOWNERS so only hoiekim's review counts toward merge gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default code owner. Used with the existing `protect_main` branch ruleset
+# (rules → pull_request → require_code_owner_review) so a Write-tier
+# collaborator's approval doesn't satisfy the 1-required-approval gate —
+# only @hoiekim's approval counts.
+#
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @hoiekim


### PR DESCRIPTION
## Why

The `protect_main` ruleset on this repo enforces "require pull request before merging" with `required_approving_review_count: 1`, but doesn't restrict who can supply that approval. If a Write-tier collaborator gets added (e.g. `claoie` so it can close issues / manage labels on this repo), their own approving review would satisfy the 1-approval gate. The owner of the repo (you) would never need to be in the loop.

## What

Adding `.github/CODEOWNERS` with `* @hoiekim` makes `hoiekim` the default code owner for every file in the repo.

```
* @hoiekim
```

This file alone is inert — the matching ruleset change is a separate one-line flip:

```
require_code_owner_review: false → true
```

on the existing `protect_main` ruleset's `pull_request` rule. That patch can be made via `gh api -X PUT repos/hoiekim/budget/rulesets/12426501` without needing a PR (ruleset configuration is repo settings, not source).

After both changes: every PR requires a review specifically from `@hoiekim` to merge. Collaborators can still review and comment, their approvals just don't count toward the gate.

## Scope

Pure GitHub configuration file. No code, no behaviour, no test impact. The bot's daily-prs and PR-readiness crons keep working the same way; they don't approve anything anyway.

## Test plan

- [ ] After merging this PR, flip `require_code_owner_review: true` on the `protect_main` ruleset.
- [ ] Verify by opening a test PR (or using a non-mutating dry-run check); `gh pr view --json reviewDecision` should report `REVIEW_REQUIRED` until `@hoiekim`'s approval lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)