### PR TITLE
fix(transactions): treat legacy null-confidence labels and splits as confirmed (Closes #339)

### DIFF
--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -10,6 +10,7 @@ import {
   CategoryDictionary,
   AccountDictionary,
   BudgetDictionary,
+  isLabelConfirmed,
 } from "client";
 
 interface GetBudgetDataResult {
@@ -45,24 +46,14 @@ export const getBudgetData = (
     const childrenAmountTotal = transactionFamilies.getChildrenAmountTotal(transaction_id);
     const amountAfterSplit = amount - childrenAmountTotal;
 
-    const { budget_id, category_id, category_confidence } = label;
+    const { budget_id, category_id } = label;
 
     const nextMonthDate = new ViewDate("month", transactionDate).next().getEndDate();
 
-    // "Unsorted" for the purposes of budget bar graphs / counts is any
-    // transaction the user hasn't confirmed. That bundles three states:
-    //   - genuinely unlabeled (category_id null, confidence null)
-    //   - explicitly rejected (category_id null, confidence 0)
-    //   - auto-suggested but unreviewed (category_id set, 0 < confidence < 1)
-    // Per Hoie's directive on PR #332: the unsorted-count and the
-    // unsorted-amount-bar must reflect "needs my review" not just
-    // "literally lacking a category", so the gate is `confidence !== 1`.
-    // A row only counts toward the sorted/category bucket if it's
-    // confirmed AND has a category_id; the latter guards against a
-    // malformed `confidence=1 AND category_id=null` row falling into the
-    // sorted-amount path below where `categories.get(null)` would skip it
-    // entirely (contributing to neither bucket).
-    const isConfirmed = category_confidence === 1 && !!category_id;
+    // isLabelConfirmed already guarantees category_id is truthy, but TS
+    // can't carry that narrowing through the function call — assert via
+    // the local boolean so the later categories.get(category_id) typechecks.
+    const isConfirmed = isLabelConfirmed(label) && !!category_id;
 
     // Calculates unsorted transactions amount for budgets
     if (!isConfirmed) {

--- a/src/client/lib/models/Transaction.test.ts
+++ b/src/client/lib/models/Transaction.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "bun:test";
+import { isLabelConfirmed } from "./Transaction";
+
+describe("isLabelConfirmed", () => {
+  test("unlabeled (no category, no confidence) → not confirmed", () => {
+    expect(isLabelConfirmed({ category_id: null, category_confidence: null })).toBe(false);
+  });
+
+  test("rejected suggestion (no category, confidence 0) → not confirmed", () => {
+    expect(isLabelConfirmed({ category_id: null, category_confidence: 0 })).toBe(false);
+  });
+
+  test("auto-suggested unreviewed (category set, 0 < confidence < 1) → not confirmed", () => {
+    expect(isLabelConfirmed({ category_id: "cat-1", category_confidence: 0.5 })).toBe(false);
+    expect(isLabelConfirmed({ category_id: "cat-1", category_confidence: 0.99 })).toBe(false);
+  });
+
+  test("post-Phase-2 user-confirmed (category set, confidence 1) → confirmed", () => {
+    expect(isLabelConfirmed({ category_id: "cat-1", category_confidence: 1 })).toBe(true);
+  });
+
+  test("legacy user label (category set, confidence null) → confirmed", () => {
+    // Population (1): transactions labeled before Phase 2 added the
+    // label_category_confidence column; no backfill migration ran, so the
+    // confidence sits at NULL. These must NOT show up as unsorted.
+    expect(isLabelConfirmed({ category_id: "cat-1", category_confidence: null })).toBe(true);
+  });
+
+  test("split transaction shape (category set, confidence undefined) → confirmed", () => {
+    // Population (2): split_transactions table has no confidence column at
+    // all, so SplitTransactionModel.toJSON() omits the field. After
+    // round-trip, SplitTransaction.label.category_confidence is undefined.
+    // Splits are not reached by auto-suggest, so a category_id-set split
+    // always means "user assigned this".
+    expect(isLabelConfirmed({ category_id: "cat-1", category_confidence: undefined })).toBe(true);
+    expect(isLabelConfirmed({ category_id: "cat-1" })).toBe(true);
+  });
+
+  test("malformed (no category, confidence 1) → not confirmed (defensive)", () => {
+    // The sorted-amount branch in getBudgetData does categories.get(category_id)
+    // and skips on miss, so a confidence-1-but-no-category row would be
+    // dropped entirely. Excluding it from "confirmed" keeps it in the
+    // unsorted bucket where it's at least visible.
+    expect(isLabelConfirmed({ category_id: null, category_confidence: 1 })).toBe(false);
+  });
+});

--- a/src/client/lib/models/Transaction.ts
+++ b/src/client/lib/models/Transaction.ts
@@ -19,6 +19,20 @@ import {
 import { TransactionFamilies } from "client";
 import { globalData } from "./Data";
 
+// A label is "confirmed" when it has a category_id and is not a live
+// auto-suggestion. `confidence === 1` is the post-Phase-2 confirmed marker;
+// `confidence == null` covers (a) legacy transactions labeled before the
+// confidence column existed and never backfilled, and (b) every split —
+// split_transactions has no confidence column, so the field is undefined
+// after toJSON round-trip. Treating null as "not confirmed" would mis-bucket
+// both populations as unsorted in budget bars / counts / list filters.
+export const isLabelConfirmed = (
+  label: Pick<JSONTransactionLabel, "category_id" | "category_confidence">,
+): boolean => {
+  const { category_id, category_confidence } = label;
+  return !!category_id && (category_confidence === 1 || category_confidence == null);
+};
+
 export class TransactionLabel implements JSONTransactionLabel {
   budget_id?: string | null;
   category_id?: string | null;

--- a/src/client/pages/TransactionsPage/index.tsx
+++ b/src/client/pages/TransactionsPage/index.tsx
@@ -11,6 +11,7 @@ import {
   SplitTransactionDictionary,
   TransactionDictionary,
   indexedDb,
+  isLabelConfirmed,
   useAppContext,
   PATH,
   useSorter,
@@ -144,11 +145,11 @@ export const TransactionsPage = () => {
         const transactionDate = new LocalDate(date);
         const within = viewDate.has(transactionDate);
         if (!within) return false;
-        // "unsorted" view now includes every transaction that is not
-         // user-confirmed (confidence === 1). That covers genuinely
-         // unlabeled rows AND auto-suggested ones — per Hoie's directive
-         // in #98: suggested + non-confirmed both belong here.
-         if (type === "unsorted" && e.label.category_confidence === 1) return false;
+        // "unsorted" view shows every row that needs review: unlabeled rows
+         // and unreviewed auto-suggestions. Confirmed rows (whether
+         // post-Phase-2 user-confirmed at confidence=1 or legacy/split rows
+         // at null confidence) are filtered out.
+         if (type === "unsorted" && isLabelConfirmed(e.label)) return false;
          // "suggested" view is the narrower slice: rows currently bearing
          // an unreviewed auto-suggestion (0 < confidence < 1).
          if (type === "suggested") {


### PR DESCRIPTION
## Summary
PR #332 (merged ~9 hours ago) changed the unsorted gate to `category_confidence === 1 && !!category_id`. Two real populations have `category_id` set but `category_confidence == null` and should NOT be unsorted:

1. **Legacy pre-Phase-2 user labels** — no backfill migration ran. Local prod-snapshot DB: 5,166 of 6,052 admin transactions are in this state.
2. **Every `split_transactions` row** — the table has no confidence column at all, so `SplitTransaction.label.category_confidence` is always undefined.

Both end up in the unsorted bucket in budget bars, in the BudgetDetailPage 'See N Unsorted' count, and in TransactionsPage `transactions_type=unsorted`. The per-row dot indicator (red iff !category_id, grey iff 0 < confidence < 1) doesn't agree with the bar/count, so the same page disagrees with itself.

## Fix
New helper `isLabelConfirmed(label) = !!category_id && (confidence === 1 || confidence == null)` next to TransactionLabel. Used at the two impacted gates:
- `src/client/lib/hooks/calculation/budgets.ts` (budget-bar / unsorted-count calc)
- `src/client/pages/TransactionsPage/index.tsx` (`unsorted` filter)

Same shape as the per-row indicator already used, so all three paths now agree.

## E2E (local prod-snapshot DB, admin user)
Predicate comparison via in-browser `fetch('/api/transactions')`, both predicates run side-by-side on the same data:

| Budget          | Pre-fix unsorted (count) | Post-fix unsorted (count) | Confirmed (post-fix) |
|-----------------|--------------------------|---------------------------|----------------------|
| Hoie's Budget   | 926                      | 6                         | 920                  |
| Shared Budget   | 2,638                    | 178                       | 2,460                |

BudgetDetailPage in current-month view post-fix: 'There is no unsorted transactions' for both budgets (matches the per-row dots which show no red).

## Tests
7 new cases on `isLabelConfirmed` in `src/client/lib/models/Transaction.test.ts`:
- unlabeled / rejected / suggested (0.5 + 0.99) / post-Phase-2 confirmed / **legacy null+category (confirmed)** / **split-shape undefined+category (confirmed)** / malformed `confidence=1, category=null` (defensive: not confirmed).
All 7 pass. Existing 12 holdings.test.ts failures are pre-existing on upstream/main (verified by stash + re-run; same set documented in `project_budget.md` 2026-05-06).

## Out of scope (separate follow-ups)
- DB backfill migration `UPDATE transactions SET label_category_confidence = 1 WHERE label_category_id IS NOT NULL AND label_category_confidence IS NULL` — still worth shipping so auto-suggest can mine signal.
- `defaultFetchUnlabeled` in `auto-suggest.ts:44` filters only on `label_category_confidence: null` (not `label_category_id IS NULL`) → 5,166 legacy-labeled rows are in the engine's overwrite pool; latent until any signal forms.
- `post-suggest-category.ts:133` `existing.label_category_confidence === 1` guard has the same null-treats-as-overwritable issue.

## Test plan
- [x] Typecheck clean
- [x] Lint clean
- [x] 7/7 new tests pass; pre-existing failures unchanged
- [x] E2E: budget-bar / unsorted-count counts drop from 926→6 (Hoie's Budget) and 2,638→178 (Shared Budget) on local prod-snapshot DB
- [ ] Sandbox UI verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)