### PR TITLE
docs: document scoped API keys + Bearer auth from #314

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -12,6 +12,8 @@ export const myRoute = new Route<ResponseType>("POST", "/path", async (req, res,
 });
 ```
 
+A fourth `options` argument enables API-key bearer auth for that route — see [Authentication](#authentication).
+
 ## Response Format
 
 All API responses follow this structure:
@@ -45,6 +47,27 @@ const PUBLIC_PATH_METHODS: [string, Set<string> | null][] = [
 ```
 
 When adding a new public endpoint, add an entry to `PUBLIC_PATH_METHODS`. Pass `null` to allow all HTTP methods, or a `Set` to scope the exemption to specific methods. All other routes automatically return 401 if no session exists.
+
+### Opting a route into API-key bearer auth
+
+For routes that need to accept calls from an external client (e.g. a daily-cron LLM agent labelling transactions), pass a `requiredScope` in the `Route` options:
+
+```typescript
+export const suggestCategoryRoute = new Route<SuggestCategoryResponse>(
+  "POST",
+  "/suggest-category",
+  async (req, res) => { /* ... */ },
+  { requiredScope: "transactions:suggest" },
+);
+```
+
+Behaviour:
+
+- Cookie-session auth is still accepted (and remains more privileged).
+- `Authorization: Bearer <api_key>` is consulted **only** as a fallback, and only on routes that declare a `requiredScope`. The presented key's `scopes` array must contain the declared scope.
+- Bearer-authenticated requests are stateless — no session cookie is written back.
+
+See `docs/SECURITY.md` for the full bearer-auth contract.
 
 ## Security Headers
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,6 +29,7 @@ budget/
 │   │   │   └── compute-tools/  # Data processing utilities
 │   │   └── routes/           # API endpoints
 │   │       ├── accounts/     # Account management
+│   │       ├── api-keys/     # Scoped API key management
 │   │       ├── budgets/      # Budget management
 │   │       ├── charts/       # Chart data
 │   │       ├── transfers/    # Transfer pair management

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -23,6 +23,27 @@ if (!isPublic && !session.user) {
 - To make a route public, add an entry to `PUBLIC_PATH_METHODS`. The second tuple element scopes the exemption to specific HTTP methods (`null` means all methods)
 - Public routes must have external verification (e.g., `/plaid-hook` verifies Plaid signatures)
 
+### API-Key Bearer Auth (opt-in)
+
+Cookie sessions are the privileged default. A route may additionally accept `Authorization: Bearer <api_key>` by declaring a `requiredScope` in its `Route` options:
+
+```typescript
+new Route<MyResponse>(
+  "POST",
+  "/my-path",
+  async (req, res) => { /* ... */ },
+  { requiredScope: "transactions:suggest" },
+);
+```
+
+Rules enforced in `start.ts`:
+
+- Bearer auth is only attempted when the matched route declares a `requiredScope`, and only as a fallback when no cookie session is present.
+- The presented key must verify (via `verifyApiKey`) **and** its `scopes` array must contain the route's `requiredScope`.
+- Bearer-authenticated requests are stateless — `_bearer` is flagged on the session so `persistSession` skips writing a session cookie back.
+
+Keys are minted in the UI ("API Keys" section on the Config page) and shown plaintext once at creation. Storage is SHA-256 hex with a `UNIQUE` index; verification uses indexed lookup + `timingSafeEqual`. Keys carry `name`, `key_prefix`, `scopes[]`, `created_at`, `last_used_at`, `revoked_at`, `expires_at`. Revocation is a one-way bit; revoked keys fail `verifyApiKey`.
+
 ## Session Fixation Prevention
 
 On successful login, the session ID is regenerated to prevent session fixation attacks:


### PR DESCRIPTION
## Summary

PR #314 landed the scoped-API-key feature: a per-user keys table, an opt-in `requiredScope` field on the `Route` class, and a Bearer-token auth shim in `start.ts`. None of that was reflected in the existing docs — API.md/SECURITY.md still described cookie sessions as the only auth path, and ARCHITECTURE.md's project tree didn't list the new `api-keys/` routes directory.

- **`docs/ARCHITECTURE.md`** — add `api-keys/` line under `routes/` (verified with `ls -d src/server/routes/*/`).
- **`docs/SECURITY.md`** — new "API-Key Bearer Auth (opt-in)" subsection covering the opt-in nature, scope check, stateless `_bearer` flag (`start.ts:62-64, 322-336`, `persistSession` skip `start.ts:107-109`), and key lifecycle (SHA-256 hex storage, `timingSafeEqual` verify, revocation).
- **`docs/API.md`** — Route Definition: note the fourth `options` argument. Authentication: mirror SECURITY.md with a concrete example tied to `post-suggest-category.ts`.

Pure markdown — no source touched.

## Test plan

- [x] All claims grounded in current `upstream/main`:
  - `requiredScope` field/options arg: `src/server/lib/route.ts:53-71`
  - Bearer fallback + scope check: `src/server/start.ts:319-336`
  - `_bearer` flag + skip cookie persist: `src/server/start.ts:57-64, 102-110`
  - `verifyApiKey` + key storage shape: `src/server/lib/postgres/repositories/api_keys.ts` and `src/server/lib/postgres/models/api_key.ts`
  - `api-keys/` directory: `ls -d src/server/routes/*/` confirms
- [x] No env-var or schema claims added (no migration risk)
- [x] No code changes — markdown only

🤖 Generated with [Claude Code](https://claude.com/claude-code)