### PR TITLE
fix(auto-suggest): two-pass run also writes suggestions to split transactions (Closes #334)

### DIFF
--- a/src/server/lib/compute-tools/auto-suggest.test.ts
+++ b/src/server/lib/compute-tools/auto-suggest.test.ts
@@ -28,7 +28,15 @@ describe("runAutoSuggestions", () => {
     const fetchUsers = mock(async () => []);
     const fetchUnlabeled = mock(async () => []);
     const applyLabel = mock(async () => {});
-    await runAutoSuggestions(queryFn, noopLogger, fetchUsers, fetchUnlabeled, applyLabel);
+    await runAutoSuggestions(
+      queryFn,
+      noopLogger,
+      fetchUsers,
+      fetchUnlabeled,
+      applyLabel,
+      async () => [],
+      async () => {},
+    );
     expect(fetchUsers).toHaveBeenCalledTimes(1);
     expect(fetchUnlabeled).toHaveBeenCalledTimes(0);
     expect(applyLabel).toHaveBeenCalledTimes(0);
@@ -53,7 +61,15 @@ describe("runAutoSuggestions", () => {
       applyCalls.push({ transactionId, userId, labelCategoryId, labelBudgetId, labelCategoryConfidence });
     };
 
-    await runAutoSuggestions(queryFn, noopLogger, fetchUsers, fetchUnlabeled, applyLabel);
+    await runAutoSuggestions(
+      queryFn,
+      noopLogger,
+      fetchUsers,
+      fetchUnlabeled,
+      applyLabel,
+      async () => [],
+      async () => {},
+    );
     expect(applyCalls).toHaveLength(0);
   });
 
@@ -75,7 +91,15 @@ describe("runAutoSuggestions", () => {
       applyCalls.push({ transactionId, userId, labelCategoryId, labelBudgetId, labelCategoryConfidence });
     };
 
-    await runAutoSuggestions(queryFn, noopLogger, fetchUsers, fetchUnlabeled, applyLabel);
+    await runAutoSuggestions(
+      queryFn,
+      noopLogger,
+      fetchUsers,
+      fetchUnlabeled,
+      applyLabel,
+      async () => [],
+      async () => {},
+    );
     expect(applyCalls).toHaveLength(0);
   });
 
@@ -97,7 +121,15 @@ describe("runAutoSuggestions", () => {
       applyCalls.push({ transactionId, userId, labelCategoryId, labelBudgetId, labelCategoryConfidence });
     };
 
-    await runAutoSuggestions(queryFn, noopLogger, fetchUsers, fetchUnlabeled, applyLabel);
+    await runAutoSuggestions(
+      queryFn,
+      noopLogger,
+      fetchUsers,
+      fetchUnlabeled,
+      applyLabel,
+      async () => [],
+      async () => {},
+    );
     expect(applyCalls).toHaveLength(0);
   });
 
@@ -119,7 +151,15 @@ describe("runAutoSuggestions", () => {
       applyCalls.push({ transactionId, userId, labelCategoryId, labelBudgetId, labelCategoryConfidence });
     };
 
-    await runAutoSuggestions(queryFn, noopLogger, fetchUsers, fetchUnlabeled, applyLabel);
+    await runAutoSuggestions(
+      queryFn,
+      noopLogger,
+      fetchUsers,
+      fetchUnlabeled,
+      applyLabel,
+      async () => [],
+      async () => {},
+    );
     expect(applyCalls).toHaveLength(1);
     expect(applyCalls[0].labelCategoryId).toBe("cat-groceries");
     expect(applyCalls[0].labelCategoryConfidence).toBe(0.99);
@@ -145,7 +185,15 @@ describe("runAutoSuggestions", () => {
       applyCalls.push({ transactionId, userId, labelCategoryId, labelBudgetId, labelCategoryConfidence });
     };
 
-    await runAutoSuggestions(queryFn, noopLogger, fetchUsers, fetchUnlabeled, applyLabel);
+    await runAutoSuggestions(
+      queryFn,
+      noopLogger,
+      fetchUsers,
+      fetchUnlabeled,
+      applyLabel,
+      async () => [],
+      async () => {},
+    );
     expect(applyCalls).toHaveLength(1);
     expect(applyCalls[0].labelCategoryConfidence).toBeCloseTo(0.95, 5);
   });
@@ -163,7 +211,15 @@ describe("runAutoSuggestions", () => {
     ];
     const applyLabel = async () => {};
 
-    await runAutoSuggestions(queryFn, noopLogger, fetchUsers, fetchUnlabeled, applyLabel);
+    await runAutoSuggestions(
+      queryFn,
+      noopLogger,
+      fetchUsers,
+      fetchUnlabeled,
+      applyLabel,
+      async () => [],
+      async () => {},
+    );
     expect(signalQueryCount).toBe(1);
   });
 
@@ -180,7 +236,15 @@ describe("runAutoSuggestions", () => {
     const fetchUnlabeled = async () => [{ transaction_id: "txn-7", merchant_name: "STARBUCKS #1234" }];
     const applyLabel = async () => {};
 
-    await runAutoSuggestions(queryFn, noopLogger, fetchUsers, fetchUnlabeled, applyLabel);
+    await runAutoSuggestions(
+      queryFn,
+      noopLogger,
+      fetchUsers,
+      fetchUnlabeled,
+      applyLabel,
+      async () => [],
+      async () => {},
+    );
     expect(signalSql).toContain("similarity(merchant_name");
     expect(signalSql).not.toContain("merchant_name = $2");
     // Threshold and limit are passed as parameters, not interpolated
@@ -211,7 +275,15 @@ describe("runAutoSuggestions", () => {
     const applyLabel = async () => {};
 
     await expect(
-      runAutoSuggestions(queryFn, errorLogger, fetchUsers, fetchUnlabeled, applyLabel),
+      runAutoSuggestions(
+        queryFn,
+        errorLogger,
+        fetchUsers,
+        fetchUnlabeled,
+        applyLabel,
+        async () => [],
+        async () => {},
+      ),
     ).resolves.toBeUndefined();
     expect(errorLogger.error).toHaveBeenCalledWith(
       "Auto-suggestion failed for user",
@@ -219,5 +291,112 @@ describe("runAutoSuggestions", () => {
       expect.any(Error),
     );
     expect(user2UnlabeledCalled).toBe(true);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Split-transactions pass (#334)
+  // ──────────────────────────────────────────────────────────────────────
+
+  type SplitApplyCall = {
+    splitTransactionId: string;
+    userId: string;
+    labelCategoryId: string;
+    labelBudgetId: string;
+    labelCategoryConfidence: number;
+  };
+
+  it("applies suggestions to split transactions via the second pass", async () => {
+    const splitApplyCalls: SplitApplyCall[] = [];
+    const queryFn = mock(async () => ({
+      rows: [{ label_category_id: "cat-groceries", label_budget_id: "bud-household", accepted: "10", rejected: "0" }],
+    }));
+    const fetchUsers = async () => ["user-split-1"];
+    const fetchUnlabeled = async () => []; // no top-level transactions to score
+    const applyLabel = async () => {};
+    const fetchUnlabeledSplits = async () => [
+      { split_transaction_id: "split-1", merchant_name: "Grocery Store" },
+    ];
+    const applyLabelToSplit = async (
+      splitTransactionId: string,
+      userId: string,
+      labelCategoryId: string,
+      labelBudgetId: string,
+      labelCategoryConfidence: number,
+    ) => {
+      splitApplyCalls.push({ splitTransactionId, userId, labelCategoryId, labelBudgetId, labelCategoryConfidence });
+    };
+
+    await runAutoSuggestions(
+      queryFn,
+      noopLogger,
+      fetchUsers,
+      fetchUnlabeled,
+      applyLabel,
+      fetchUnlabeledSplits,
+      applyLabelToSplit,
+    );
+
+    expect(splitApplyCalls).toHaveLength(1);
+    expect(splitApplyCalls[0].splitTransactionId).toBe("split-1");
+    expect(splitApplyCalls[0].labelCategoryId).toBe("cat-groceries");
+    expect(splitApplyCalls[0].labelBudgetId).toBe("bud-household");
+    expect(splitApplyCalls[0].labelCategoryConfidence).toBe(0.99);
+  });
+
+  it("reuses the merchant cache between transaction and split passes", async () => {
+    // A parent transaction and a split share the same merchant_name. The
+    // signal query should fire exactly once even though it's "needed" twice.
+    let signalQueryCount = 0;
+    const queryFn = mock(async () => {
+      signalQueryCount++;
+      return { rows: [{ label_category_id: "cat-x", label_budget_id: "bud-x", accepted: "5", rejected: "0" }] };
+    });
+    const fetchUsers = async () => ["user-cache"];
+    const fetchUnlabeled = async () => [{ transaction_id: "txn-1", merchant_name: "Same Merchant" }];
+    const applyLabel = async () => {};
+    const fetchUnlabeledSplits = async () => [
+      { split_transaction_id: "split-1", merchant_name: "Same Merchant" },
+    ];
+    const applyLabelToSplit = async () => {};
+
+    await runAutoSuggestions(
+      queryFn,
+      noopLogger,
+      fetchUsers,
+      fetchUnlabeled,
+      applyLabel,
+      fetchUnlabeledSplits,
+      applyLabelToSplit,
+    );
+    expect(signalQueryCount).toBe(1);
+  });
+
+  it("respects the gates on splits the same way as on transactions", async () => {
+    // 8 accepted / 2 rejected → reject_rate = 0.2 > 0.1 → skip both passes.
+    const queryFn = mock(async () => ({
+      rows: [{ label_category_id: "cat-y", label_budget_id: "bud-y", accepted: "8", rejected: "2" }],
+    }));
+    const fetchUsers = async () => ["user-gates"];
+    const fetchUnlabeled = async () => [];
+    const applyLabel = async () => {};
+    const splitApplyCalls: SplitApplyCall[] = [];
+    const fetchUnlabeledSplits = async () => [
+      { split_transaction_id: "split-1", merchant_name: "Skip Me" },
+    ];
+    const applyLabelToSplit = async (...args: Parameters<typeof applyLabelToSplit>) => {
+      const [splitTransactionId, userId, labelCategoryId, labelBudgetId, labelCategoryConfidence] = args;
+      splitApplyCalls.push({ splitTransactionId, userId, labelCategoryId, labelBudgetId, labelCategoryConfidence });
+    };
+
+    await runAutoSuggestions(
+      queryFn,
+      noopLogger,
+      fetchUsers,
+      fetchUnlabeled,
+      applyLabel,
+      fetchUnlabeledSplits,
+      applyLabelToSplit,
+    );
+    expect(splitApplyCalls).toHaveLength(0);
   });
 });

--- a/src/server/lib/compute-tools/auto-suggest.ts
+++ b/src/server/lib/compute-tools/auto-suggest.ts
@@ -1,4 +1,11 @@
-import { pool, logger, usersTable, transactionsTable, IS_NOT_NULL } from "server";
+import {
+  pool,
+  logger,
+  usersTable,
+  transactionsTable,
+  splitTransactionsTable,
+  IS_NOT_NULL,
+} from "server";
 
 interface MerchantSignal {
   label_category_id: string;
@@ -20,6 +27,15 @@ interface UnlabeledTransaction {
   merchant_name: string;
 }
 
+// A split row doesn't store its own merchant_name — it inherits from its parent
+// transaction via `split_transactions.transaction_id`. We join to the parent in
+// `defaultFetchUnlabeledSplits` so the merchant-signal lookup uses the parent's
+// merchant, matching how a user mentally categorizes splits.
+interface UnlabeledSplit {
+  split_transaction_id: string;
+  merchant_name: string;
+}
+
 type QueryFn = (sql: string, params?: unknown[]) => Promise<{ rows: Record<string, unknown>[] }>;
 type LogFn = {
   info: (message: string, context?: Record<string, unknown>) => void;
@@ -27,8 +43,16 @@ type LogFn = {
 };
 type FetchUsersFn = () => Promise<string[]>;
 type FetchUnlabeledFn = (userId: string) => Promise<UnlabeledTransaction[]>;
+type FetchUnlabeledSplitsFn = (userId: string) => Promise<UnlabeledSplit[]>;
 type ApplyLabelFn = (
   transactionId: string,
+  userId: string,
+  labelCategoryId: string,
+  labelBudgetId: string,
+  labelCategoryConfidence: number,
+) => Promise<void>;
+type ApplyLabelToSplitFn = (
+  splitTransactionId: string,
   userId: string,
   labelCategoryId: string,
   labelBudgetId: string,
@@ -74,6 +98,50 @@ const defaultApplyLabel: ApplyLabelFn = async (
   );
 };
 
+// Splits have no merchant_name of their own — join to the parent transaction to
+// borrow it. Filters: user-scoped, never-labeled, parent has a merchant_name,
+// neither side soft-deleted. The custom JOIN can't be expressed via
+// `splitTransactionsTable.query`, so this is a raw pool query with the same
+// shape as `defaultFetchUnlabeled`. Closes #334.
+const defaultFetchUnlabeledSplits: FetchUnlabeledSplitsFn = async (userId) => {
+  const result = await pool.query(
+    `SELECT st.split_transaction_id, t.merchant_name
+       FROM split_transactions st
+       JOIN transactions t
+         ON t.transaction_id = st.transaction_id
+        AND t.user_id = st.user_id
+      WHERE st.user_id = $1
+        AND st.label_category_confidence IS NULL
+        AND (st.is_deleted IS NULL OR st.is_deleted = FALSE)
+        AND t.merchant_name IS NOT NULL
+        AND (t.is_deleted IS NULL OR t.is_deleted = FALSE)`,
+    [userId],
+  );
+  return result.rows.map((r) => ({
+    split_transaction_id: r.split_transaction_id as string,
+    merchant_name: r.merchant_name as string,
+  }));
+};
+
+const defaultApplyLabelToSplit: ApplyLabelToSplitFn = async (
+  splitTransactionId,
+  userId,
+  labelCategoryId,
+  labelBudgetId,
+  labelCategoryConfidence,
+) => {
+  await splitTransactionsTable.update(
+    splitTransactionId,
+    {
+      label_category_id: labelCategoryId,
+      label_budget_id: labelBudgetId,
+      label_category_confidence: labelCategoryConfidence,
+    },
+    undefined,
+    userId,
+  );
+};
+
 /**
  * Runs auto-suggestion for transaction categories based on historical merchant patterns.
  *
@@ -98,6 +166,8 @@ export const runAutoSuggestions = async (
   },
   fetchUnlabeled: FetchUnlabeledFn = defaultFetchUnlabeled,
   applyLabel: ApplyLabelFn = defaultApplyLabel,
+  fetchUnlabeledSplits: FetchUnlabeledSplitsFn = defaultFetchUnlabeledSplits,
+  applyLabelToSplit: ApplyLabelToSplitFn = defaultApplyLabelToSplit,
 ): Promise<void> => {
   log.info("Auto-suggestion job started");
 
@@ -115,6 +185,8 @@ export const runAutoSuggestions = async (
           log,
           fetchUnlabeled,
           applyLabel,
+          fetchUnlabeledSplits,
+          applyLabelToSplit,
         );
         totalSuggested += suggested;
         totalUsersProcessed++;
@@ -132,52 +204,74 @@ export const runAutoSuggestions = async (
   });
 };
 
+// Score a per-merchant signal against the gates. Returns the capped
+// confidence to apply (in [0, 1)), or null if any gate fails.
+const evaluateSignal = (signal: MerchantSignal): number | null => {
+  const totalLabeled = signal.accepted + signal.rejected;
+  if (totalLabeled < 3) return null;
+  const rejectRate = signal.rejected / totalLabeled;
+  if (rejectRate > 0.1) return null;
+  const confidence = signal.accepted / totalLabeled;
+  if (confidence < 0.95) return null;
+  // Cap at 0.99 — 1.0 is reserved for user-confirmed labels.
+  return Math.min(confidence, 0.99);
+};
+
 const processUserSuggestions = async (
   userId: string,
   queryFn: QueryFn,
   log: LogFn,
   fetchUnlabeled: FetchUnlabeledFn,
   applyLabel: ApplyLabelFn,
+  fetchUnlabeledSplits: FetchUnlabeledSplitsFn,
+  applyLabelToSplit: ApplyLabelToSplitFn,
 ): Promise<number> => {
-  const unlabeled = await fetchUnlabeled(userId);
-  if (unlabeled.length === 0) return 0;
-
-  // Cache signal per merchant to avoid redundant queries
+  // Cache signal per merchant across both passes — splits share their parent's
+  // merchant_name, so a parent and its splits will hit the same cache entry.
   const merchantCache = new Map<string, MerchantSignal | null>();
   let suggested = 0;
 
-  for (const { transaction_id, merchant_name } of unlabeled) {
-    let signal: MerchantSignal | null | undefined = merchantCache.get(merchant_name);
-
+  const lookupSignal = async (merchantName: string): Promise<MerchantSignal | null> => {
+    let signal = merchantCache.get(merchantName);
     if (signal === undefined) {
-      signal = await getMerchantSignal(userId, merchant_name, queryFn);
-      merchantCache.set(merchant_name, signal);
+      signal = await getMerchantSignal(userId, merchantName, queryFn);
+      merchantCache.set(merchantName, signal);
     }
+    return signal;
+  };
 
+  // Pass 1: top-level transactions.
+  const unlabeled = await fetchUnlabeled(userId);
+  for (const { transaction_id, merchant_name } of unlabeled) {
+    const signal = await lookupSignal(merchant_name);
     if (!signal) continue;
-
-    const { label_category_id, label_budget_id, accepted, rejected } = signal;
-    const totalLabeled = accepted + rejected;
-
-    if (totalLabeled < 3) continue;
-
-    const rejectRate = rejected / totalLabeled;
-    if (rejectRate > 0.1) continue;
-
-    const confidence = accepted / totalLabeled;
-    if (confidence < 0.95) continue;
-
-    // Cap at 0.99 — 1.0 is reserved for user-confirmed labels
-    const cappedConfidence = Math.min(confidence, 0.99);
-
+    const cappedConfidence = evaluateSignal(signal);
+    if (cappedConfidence === null) continue;
     await applyLabel(
       transaction_id,
       userId,
-      label_category_id,
-      label_budget_id,
+      signal.label_category_id,
+      signal.label_budget_id,
       cappedConfidence,
     );
+    suggested++;
+  }
 
+  // Pass 2: split transactions. Shares `merchantCache` so a split whose parent
+  // was just scored above doesn't re-hit the DB. Closes #334.
+  const unlabeledSplits = await fetchUnlabeledSplits(userId);
+  for (const { split_transaction_id, merchant_name } of unlabeledSplits) {
+    const signal = await lookupSignal(merchant_name);
+    if (!signal) continue;
+    const cappedConfidence = evaluateSignal(signal);
+    if (cappedConfidence === null) continue;
+    await applyLabelToSplit(
+      split_transaction_id,
+      userId,
+      signal.label_category_id,
+      signal.label_budget_id,
+      cappedConfidence,
+    );
     suggested++;
   }
 

--- a/src/server/lib/postgres/models/split_transaction.ts
+++ b/src/server/lib/postgres/models/split_transaction.ts
@@ -4,6 +4,7 @@ import {
   isNullableString,
   isNullableNumber,
   isNullableBoolean,
+  isUndefined,
 } from "common";
 import {
   SPLIT_TRANSACTION_ID,
@@ -16,6 +17,7 @@ import {
   LABEL_BUDGET_ID,
   LABEL_CATEGORY_ID,
   LABEL_MEMO,
+  LABEL_CATEGORY_CONFIDENCE,
   UPDATED,
   IS_DELETED,
   SPLIT_TRANSACTIONS,
@@ -34,6 +36,9 @@ const splitTxSchema = {
   [LABEL_BUDGET_ID]: "UUID",
   [LABEL_CATEGORY_ID]: "UUID",
   [LABEL_MEMO]: "TEXT",
+  // Mirrors the same column on `transactions`. Required for the two-pass
+  // auto-suggest engine to write per-split suggestions (closes #334).
+  [LABEL_CATEGORY_CONFIDENCE]: "FLOAT",
   [UPDATED]: "TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP",
   [IS_DELETED]: "BOOLEAN DEFAULT FALSE",
 };
@@ -52,6 +57,7 @@ export class SplitTransactionModel extends Model<JSONSplitTransaction, SplitTxSc
   declare label_budget_id: string | null;
   declare label_category_id: string | null;
   declare label_memo: string | null;
+  declare label_category_confidence: number | null;
   declare updated: string | null;
   declare is_deleted: boolean;
 
@@ -66,6 +72,7 @@ export class SplitTransactionModel extends Model<JSONSplitTransaction, SplitTxSc
     label_budget_id: isNullableString,
     label_category_id: isNullableString,
     label_memo: isNullableString,
+    label_category_confidence: isNullableNumber,
     updated: isNullableString,
     is_deleted: isNullableBoolean,
   };
@@ -86,6 +93,7 @@ export class SplitTransactionModel extends Model<JSONSplitTransaction, SplitTxSc
         budget_id: this.label_budget_id,
         category_id: this.label_category_id,
         memo: this.label_memo,
+        category_confidence: this.label_category_confidence,
       },
     };
   }
@@ -102,6 +110,8 @@ export class SplitTransactionModel extends Model<JSONSplitTransaction, SplitTxSc
       if (tx.label.budget_id !== undefined) r.label_budget_id = tx.label.budget_id;
       if (tx.label.category_id !== undefined) r.label_category_id = tx.label.category_id;
       if (tx.label.memo !== undefined) r.label_memo = tx.label.memo;
+      if (!isUndefined(tx.label.category_confidence))
+        r.label_category_confidence = tx.label.category_confidence;
     }
     return r;
   }


### PR DESCRIPTION
Closes #334.

## Why

Phase 2's `runAutoSuggestions` only walked `transactionsTable`, never `split_transactions`. A user splitting a transaction had to manually re-categorize each split even though the parent already wore a grey-dot suggestion. Surfaced during PR #332 review (Discord, May 11, 2026).

## What

Implements **option 1 from the issue body** — a two-pass run that reuses the existing scoring logic:

- After the existing per-user transactions pass, a second pass walks the user's unlabeled `split_transactions`.
- Splits inherit `merchant_name` from their parent via a JOIN on `(transaction_id, user_id)`, so a split scores against the same merchant signal as its parent.
- The per-user `merchantCache` is shared across both passes — a parent and its splits hit the cache once, not twice. Verified by the new "reuses the merchant cache" test.

## Required DB column

`split_transactions.label_category_confidence` (FLOAT, nullable) — mirrors the same column on `transactions`. The framework's auto-migration handles the ADD COLUMN on first boot of any deployment that already has the table.

## Files

- `src/server/lib/postgres/models/split_transaction.ts` — schema + Model + toJSON + fromJSON now carry `label_category_confidence`.
- `src/server/lib/compute-tools/auto-suggest.ts`:
  - `processUserSuggestions` factored: scoring helper `evaluateSignal` shared between passes, cache lookup via `lookupSignal`, two for-loops back-to-back.
  - New ports `defaultFetchUnlabeledSplits` (raw `pool.query` with the JOIN — `splitTransactionsTable.query` can't express it) and `defaultApplyLabelToSplit` (standard `splitTransactionsTable.update`).
  - `runAutoSuggestions` gains two new parameters with defaults; existing 5-arg callers keep working.
- `auto-suggest.test.ts`:
  - 9 existing tests updated to pass empty mock split ports (otherwise the second pass silently hit the real DB pool).
  - 3 new tests covering the splits path: applies, cache shared across passes, gates also skip splits.

## Verification

- `bun run typecheck` clean.
- `bun test src/server/lib/compute-tools/auto-suggest.test.ts` → **12/12 pass**.
- `bun test src/server` → **288/288 pass**.

## Out of scope

- The rejected-suggestions-aren't-tracked bug (#333) — separate fix; touches the same scoring path but at a different angle.
- UI changes for splits — the grey-dot logic in `TransactionRow.tsx` already handles `SplitTransaction` (Phase 3 added this), so as soon as the server writes a suggestion to a split row, the UI shows it. No client change in this PR.

## E2E

Will land in a follow-up comment once the per-PR sandbox is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)