### PR TITLE
test: extract Bearer-auth gate from start.ts + integration coverage (Closes #343)

### DIFF
--- a/src/server/lib/bearer-auth.test.ts
+++ b/src/server/lib/bearer-auth.test.ts
@@ -1,0 +1,204 @@
+import { describe, test, expect, mock } from "bun:test";
+import { resolveBearerAuth } from "./bearer-auth";
+import type { ResolvedApiKey } from "./postgres/repositories/api_keys";
+import type { MaskedUser } from "./postgres/models/user";
+
+const aliceUser: MaskedUser = { user_id: "u-1", username: "alice" };
+const aliceKey: ResolvedApiKey = {
+  key_id: "k-1",
+  user_id: "u-1",
+  scopes: ["transactions:suggest"],
+};
+
+const makeDeps = ({
+  resolved,
+  user,
+}: {
+  resolved: ResolvedApiKey | null;
+  user: MaskedUser | undefined;
+}) => {
+  const verifyApiKey = mock(async (_plaintext: string) => resolved);
+  const getMaskedUserById = mock(async (_id: string) => user);
+  return { verifyApiKey, getMaskedUserById };
+};
+
+describe("resolveBearerAuth — short-circuit gates (verifyApiKey must NOT be called)", () => {
+  test("returns null when cookie session is present", async () => {
+    const deps = makeDeps({ resolved: aliceKey, user: aliceUser });
+    const result = await resolveBearerAuth(
+      {
+        authorizationHeader: "Bearer bk_xxxx",
+        hasCookieSession: true,
+        requiredScope: "transactions:suggest",
+      },
+      deps,
+    );
+    expect(result).toBeNull();
+    expect(deps.verifyApiKey).not.toHaveBeenCalled();
+    expect(deps.getMaskedUserById).not.toHaveBeenCalled();
+  });
+
+  test("returns null when matched route has no requiredScope", async () => {
+    const deps = makeDeps({ resolved: aliceKey, user: aliceUser });
+    const result = await resolveBearerAuth(
+      {
+        authorizationHeader: "Bearer bk_xxxx",
+        hasCookieSession: false,
+        requiredScope: undefined,
+      },
+      deps,
+    );
+    expect(result).toBeNull();
+    expect(deps.verifyApiKey).not.toHaveBeenCalled();
+  });
+
+  test("returns null when Authorization header is absent", async () => {
+    const deps = makeDeps({ resolved: aliceKey, user: aliceUser });
+    const result = await resolveBearerAuth(
+      {
+        authorizationHeader: undefined,
+        hasCookieSession: false,
+        requiredScope: "transactions:suggest",
+      },
+      deps,
+    );
+    expect(result).toBeNull();
+    expect(deps.verifyApiKey).not.toHaveBeenCalled();
+  });
+
+  test("returns null for non-Bearer scheme (Basic auth)", async () => {
+    const deps = makeDeps({ resolved: aliceKey, user: aliceUser });
+    const result = await resolveBearerAuth(
+      {
+        authorizationHeader: "Basic dXNlcjpwYXNz",
+        hasCookieSession: false,
+        requiredScope: "transactions:suggest",
+      },
+      deps,
+    );
+    expect(result).toBeNull();
+    expect(deps.verifyApiKey).not.toHaveBeenCalled();
+  });
+
+  test("returns null for empty Bearer token", async () => {
+    const deps = makeDeps({ resolved: aliceKey, user: aliceUser });
+    const result = await resolveBearerAuth(
+      {
+        authorizationHeader: "Bearer    ",
+        hasCookieSession: false,
+        requiredScope: "transactions:suggest",
+      },
+      deps,
+    );
+    expect(result).toBeNull();
+    // We do reach the `slice` step but immediately bail on the trimmed empty
+    // string — verifyApiKey must not be called with "".
+    expect(deps.verifyApiKey).not.toHaveBeenCalled();
+  });
+
+  test("treats Authorization header as array — takes the first entry", async () => {
+    const deps = makeDeps({ resolved: aliceKey, user: aliceUser });
+    await resolveBearerAuth(
+      {
+        authorizationHeader: ["Bearer bk_xxxx", "Bearer bk_other"],
+        hasCookieSession: false,
+        requiredScope: "transactions:suggest",
+      },
+      deps,
+    );
+    expect(deps.verifyApiKey).toHaveBeenCalledWith("bk_xxxx");
+  });
+});
+
+describe("resolveBearerAuth — key resolution", () => {
+  test("returns null when verifyApiKey returns null (invalid/revoked/expired key)", async () => {
+    const deps = makeDeps({ resolved: null, user: aliceUser });
+    const result = await resolveBearerAuth(
+      {
+        authorizationHeader: "Bearer bk_invalid",
+        hasCookieSession: false,
+        requiredScope: "transactions:suggest",
+      },
+      deps,
+    );
+    expect(result).toBeNull();
+    expect(deps.verifyApiKey).toHaveBeenCalledTimes(1);
+    expect(deps.getMaskedUserById).not.toHaveBeenCalled();
+  });
+
+  test("returns null when key lacks the required scope", async () => {
+    const deps = makeDeps({
+      resolved: { key_id: "k-1", user_id: "u-1", scopes: ["other:scope"] },
+      user: aliceUser,
+    });
+    const result = await resolveBearerAuth(
+      {
+        authorizationHeader: "Bearer bk_xxxx",
+        hasCookieSession: false,
+        requiredScope: "transactions:suggest",
+      },
+      deps,
+    );
+    expect(result).toBeNull();
+    expect(deps.verifyApiKey).toHaveBeenCalledTimes(1);
+    // Don't waste a user lookup if scope is missing
+    expect(deps.getMaskedUserById).not.toHaveBeenCalled();
+  });
+
+  test("returns null when the resolved user_id no longer exists", async () => {
+    const deps = makeDeps({ resolved: aliceKey, user: undefined });
+    const result = await resolveBearerAuth(
+      {
+        authorizationHeader: "Bearer bk_xxxx",
+        hasCookieSession: false,
+        requiredScope: "transactions:suggest",
+      },
+      deps,
+    );
+    expect(result).toBeNull();
+    expect(deps.getMaskedUserById).toHaveBeenCalledWith("u-1");
+  });
+
+  test("returns the user when all checks pass", async () => {
+    const deps = makeDeps({ resolved: aliceKey, user: aliceUser });
+    const result = await resolveBearerAuth(
+      {
+        authorizationHeader: "Bearer bk_xxxx",
+        hasCookieSession: false,
+        requiredScope: "transactions:suggest",
+      },
+      deps,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.user).toEqual(aliceUser);
+  });
+
+  test("passes the trimmed plaintext (after 'Bearer ') to verifyApiKey", async () => {
+    const deps = makeDeps({ resolved: aliceKey, user: aliceUser });
+    await resolveBearerAuth(
+      {
+        authorizationHeader: "Bearer   bk_padded_token  ",
+        hasCookieSession: false,
+        requiredScope: "transactions:suggest",
+      },
+      deps,
+    );
+    expect(deps.verifyApiKey).toHaveBeenCalledWith("bk_padded_token");
+  });
+
+  test("requires an exact scope match — does not treat scopes as hierarchical", async () => {
+    const deps = makeDeps({
+      resolved: { key_id: "k-1", user_id: "u-1", scopes: ["transactions"] },
+      user: aliceUser,
+    });
+    const result = await resolveBearerAuth(
+      {
+        authorizationHeader: "Bearer bk_xxxx",
+        hasCookieSession: false,
+        requiredScope: "transactions:suggest",
+      },
+      deps,
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/src/server/lib/bearer-auth.ts
+++ b/src/server/lib/bearer-auth.ts
@@ -1,0 +1,66 @@
+import { verifyApiKey as defaultVerifyApiKey } from "./postgres/repositories/api_keys";
+import { getMaskedUserById as defaultGetMaskedUserById } from "./postgres/repositories/users";
+import type { ResolvedApiKey } from "./postgres/repositories/api_keys";
+import type { MaskedUser } from "./postgres/models/user";
+
+export interface BearerAuthInput {
+  authorizationHeader: string | string[] | undefined;
+  hasCookieSession: boolean;
+  requiredScope: string | undefined;
+}
+
+export interface BearerAuthResult {
+  user: MaskedUser;
+}
+
+export type VerifyApiKeyFn = (plaintext: string) => Promise<ResolvedApiKey | null>;
+export type GetMaskedUserByIdFn = (user_id: string) => Promise<MaskedUser | undefined>;
+
+export interface BearerAuthDeps {
+  verifyApiKey?: VerifyApiKeyFn;
+  getMaskedUserById?: GetMaskedUserByIdFn;
+}
+
+const BEARER_PREFIX = "Bearer ";
+
+/**
+ * Resolve Authorization: Bearer credentials against the API-key store.
+ *
+ * Returns the resolved MaskedUser when (and only when):
+ * - No cookie session is present (cookie auth always wins)
+ * - The matched route declares a `requiredScope`
+ * - The Authorization header is a well-formed Bearer token
+ * - `verifyApiKey` returns a non-null, non-revoked, non-expired record
+ * - The resolved scopes include the route's `requiredScope`
+ * - The user_id maps to an existing MaskedUser
+ *
+ * Returns `null` for every other case. Callers should treat `null` as
+ * "no bearer credentials applied" and continue to the normal auth check.
+ */
+export const resolveBearerAuth = async (
+  input: BearerAuthInput,
+  deps: BearerAuthDeps = {},
+): Promise<BearerAuthResult | null> => {
+  if (input.hasCookieSession) return null;
+  if (!input.requiredScope) return null;
+
+  const raw = Array.isArray(input.authorizationHeader)
+    ? input.authorizationHeader[0]
+    : input.authorizationHeader;
+  if (typeof raw !== "string" || !raw.startsWith(BEARER_PREFIX)) return null;
+
+  const plaintext = raw.slice(BEARER_PREFIX.length).trim();
+  if (!plaintext) return null;
+
+  const verify = deps.verifyApiKey ?? defaultVerifyApiKey;
+  const getUser = deps.getMaskedUserById ?? defaultGetMaskedUserById;
+
+  const resolved = await verify(plaintext);
+  if (!resolved) return null;
+  if (!resolved.scopes.includes(input.requiredScope)) return null;
+
+  const user = await getUser(resolved.user_id);
+  if (!user) return null;
+
+  return { user };
+};

--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -13,9 +13,8 @@ import {
   stopRateLimitCleanup,
   pool,
   getClientIp,
-  verifyApiKey,
-  getMaskedUserById,
 } from "server";
+import { resolveBearerAuth } from "server/lib/bearer-auth";
 import type { MaskedUser } from "server/lib/postgres/models/user";
 import type { SessionData } from "server/lib/postgres/models/session";
 import * as routes from "server/routes";
@@ -319,20 +318,14 @@ const server = Bun.serve({
     // Bearer auth: only attempted when the matched route declares a
     // requiredScope, and only as a fallback when no cookie session is
     // present. Cookie sessions remain authoritative for everything.
-    if (!session.user && matchedRoute?.requiredScope) {
-      const auth = headers["authorization"];
-      const authHeader = Array.isArray(auth) ? auth[0] : auth;
-      if (typeof authHeader === "string" && authHeader.startsWith("Bearer ")) {
-        const plaintext = authHeader.slice(7).trim();
-        const resolved = await verifyApiKey(plaintext);
-        if (resolved && resolved.scopes.includes(matchedRoute.requiredScope)) {
-          const user = await getMaskedUserById(resolved.user_id);
-          if (user) {
-            session.user = user;
-            (session as Session)._bearer = true;
-          }
-        }
-      }
+    const bearerResult = await resolveBearerAuth({
+      authorizationHeader: headers["authorization"],
+      hasCookieSession: !!session.user,
+      requiredScope: matchedRoute?.requiredScope,
+    });
+    if (bearerResult) {
+      session.user = bearerResult.user;
+      (session as Session)._bearer = true;
     }
 
     // Auth check — reject unauthenticated requests except on public paths


### PR DESCRIPTION
## Summary

PR #314 added an API-key Bearer-auth fallback inside `src/server/start.ts:319-343`, but there's no companion `start.test.ts`. The only Bearer-related test pre-PR was metadata-only:

```ts
// src/server/routes/accounts/post-suggest-category.test.ts:80
test("declares requiredScope = transactions:suggest", () => {
  expect(postSuggestCategoryRoute.requiredScope).toBe("transactions:suggest");
});
```

This left all the trust decisions on a security-critical path unexercised.

## Approach

Option 1 from #343: extract the gate logic into a pure function and unit-test it (same pattern `api_keys.test.ts` already uses). The new module is `src/server/lib/bearer-auth.ts` exporting `resolveBearerAuth(input, deps)`. `start.ts` calls it with positional input + default dependencies — behavior is unchanged.

## Test coverage added (12 tests, 24 assertions)

Every previously-untested branch from #343 is now exercised:

**Short-circuit gates** (`verifyApiKey` must NOT be called):
- Cookie session present (cookie auth always wins)
- Matched route has no `requiredScope`
- Authorization header absent
- Non-Bearer scheme (Basic)
- Empty/whitespace-only Bearer token
- Authorization header array — takes first entry

**Key resolution gates**:
- `verifyApiKey` returns null (revoked/expired/invalid)
- Resolved key's `scopes` lack the route's `requiredScope`
- Resolved `user_id` no longer maps to a `MaskedUser`

**Happy path**:
- Valid Bearer + matching scope + existing user → returns `{ user }`
- Padded `Bearer   <token>  ` is trimmed before `verifyApiKey`
- Scope is an exact-string match — `transactions` does NOT satisfy `transactions:suggest`

## Behavior preservation

The refactor is a pure extraction. The same conditions that produced `session.user = ...` + `_bearer = true` in the original code still do so in `start.ts:319-329`. The dependency-injection seam in `BearerAuthDeps` only activates in tests — production calls `resolveBearerAuth(input)` with no deps, so the default `verifyApiKey` and `getMaskedUserById` are used.

## E2E verification

- [x] `bun test src/server/lib/bearer-auth.test.ts` — 12/12 pass
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run dev` boots; `/api/health` → 200; `/api/users/me` (no auth) → 401 "Not authenticated."; `POST /api/suggest-category` with `Authorization: Bearer bk_invalidkey` → 401 "Not authenticated." (same response as pre-PR)
- [x] No new regressions in the full `bun test` run (the 12 pre-existing `holdings.test.ts` failures on `upstream/main` are unchanged)

## Out of scope

- The `/api/api-keys` CRUD routes — already covered by `api_keys.test.ts`.
- The `_bearer` flag's persistSession skip — already exercised by inspection in `start.ts:107-109`; covered indirectly by the "no Set-Cookie when _bearer is true" semantics (no test added for it here since the persistence code path is in `start.ts` and stays uncovered until/unless we boot a real server in CI).
- A bare integration test that boots `Bun.serve` on an ephemeral port — option 2 from #343. Deferred; option 1 covers the gate's correctness with no DB dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)