### PR TITLE
refactor(transfers): use Table.softDelete in removeTransferPair

### DIFF
--- a/src/server/lib/postgres/repositories/transfers.ts
+++ b/src/server/lib/postgres/repositories/transfers.ts
@@ -4,6 +4,7 @@ import {
   MaskedUser,
   TransactionModel,
   TransactionPairModel,
+  transactionPairsTable,
   TRANSACTIONS,
   TRANSACTION_PAIRS,
   USER_ID,
@@ -131,11 +132,5 @@ export const removeTransferPair = async (
   user: MaskedUser,
   pair_id: string,
 ): Promise<void> => {
-  await pool.query(
-    `UPDATE ${TRANSACTION_PAIRS}
-     SET ${IS_DELETED} = TRUE, updated = CURRENT_TIMESTAMP
-     WHERE ${PAIR_ID} = $1
-       AND ${USER_ID} = $2`,
-    [pair_id, user.user_id],
-  );
+  await transactionPairsTable.softDelete(pair_id, user.user_id);
 };


### PR DESCRIPTION
## Summary

`removeTransferPair` in `src/server/lib/postgres/repositories/transfers.ts` (introduced in #305) was issuing a raw `UPDATE transaction_pairs SET is_deleted = TRUE, updated = CURRENT_TIMESTAMP WHERE pair_id = $1 AND user_id = $2`. That exact shape is what `Table.softDelete(primaryKeyValue, userId?)` builds via `buildSoftDelete` in `database.ts`.

Per Hoie's coding-rule guidance:
- **May 8** (#300, `r3210737318`): *"This query looks like standard pattern that `Table.query` / `Table.update` could handle. Using direct SQL for standard pattern is coding rule violation."*
- **May 10** (#472, `r3214995446`): *"Can we do `Table.updateWhere`?"* — same direction for UPDATE-with-filter shapes.

Replacement is a single call:

```ts
await transactionPairsTable.softDelete(pair_id, user.user_id);
```

The generated SQL is identical (`UPDATE transaction_pairs SET is_deleted = TRUE, updated = CURRENT_TIMESTAMP WHERE pair_id = $1 AND user_id = $2 RETURNING pair_id`), so no behaviour change.

## What's NOT changed

The other raw `pool.query` calls in `transfers.ts` are left as-is — each has a predicate the current `Table.*` surface can't express:

| Function | Why raw SQL stays |
|---|---|
| `getTransferPairs` | Two-step query (filter pairs by user → fetch transactions by `ANY($2::text[])`) — no `Table.query` shape for `IN`-with-array |
| `pairTransactions` | `INSERT ... ON CONFLICT (a, b) DO UPDATE SET ... CASE WHEN is_deleted = TRUE` — `Table.upsert` doesn't expose conditional `DO UPDATE` |
| `confirmTransferPair` | `WHERE ... AND (is_deleted IS NULL OR is_deleted = FALSE)` — `Table.update`'s `additionalWhere` is fixed to `user_id`, doesn't compose with the is_deleted guard |

Filing the wider refactor (`Table.update` extension to support arbitrary additional-WHERE composition) is out of scope for this PR — this is the surgical win that requires no framework change.

## Verification

- `bun run typecheck` — clean.
- `bun run lint` — clean (no warnings).
- `bun test src/server/lib/postgres/repositories/transfers.test.ts` — **11/11 pass**. The existing assertion (`sql.toContain("UPDATE transaction_pairs")`, `sql.toContain("is_deleted = TRUE")`, values contain `"pair-1"` + `"usr-1"`) all still match the SQL built by `buildSoftDelete`.
- `bun test src/server` — **285/285 pass**. No regressions across the server suite.

E2E not required: this is a server-side refactor in the repository layer with no behavioural change (same SQL, same parameters, same rowCount semantics). The route handler `delete-transfer.ts` discards the return value, so the boolean → void shape is invisible to callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)