### PR TITLE
fix(snapshots): include security snapshots in /api/snapshots response

### DIFF
--- a/src/server/lib/postgres/repositories/snapshots.test.ts
+++ b/src/server/lib/postgres/repositories/snapshots.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for the searchSnapshots two-pass logic (#323):
+ * user-scoped snapshots (account_balance / holding) + global security
+ * snapshots (user_id NULL), with the second pass skipped when the caller
+ * narrows the request to a specific account or non-security snapshot_type.
+ */
+
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+const mockQuery = mock(
+  (_sql: string, _values?: unknown[]): Promise<{ rows: unknown[]; rowCount: number | null }> =>
+    Promise.resolve({ rows: [], rowCount: 0 }),
+);
+
+mock.module("../client", () => ({
+  pool: { query: mockQuery },
+}));
+
+import { searchSnapshots } from "./snapshots";
+
+const testUser = { user_id: "usr-1", username: "hoie" };
+
+// SnapshotModel's typeChecker requires every column to be present (null is
+// fine, undefined is not). These helpers return the full row shape.
+function makeBaseRow(overrides: Record<string, unknown> = {}) {
+  return {
+    snapshot_id: "snap-0",
+    user_id: null,
+    snapshot_date: "2026-05-10",
+    snapshot_type: "account_balance",
+    account_id: null,
+    balances_available: null,
+    balances_current: null,
+    balances_limit: null,
+    balances_iso_currency_code: null,
+    security_id: null,
+    close_price: null,
+    holding_account_id: null,
+    holding_security_id: null,
+    institution_price: null,
+    institution_value: null,
+    cost_basis: null,
+    quantity: null,
+    updated: null,
+    is_deleted: false,
+    ...overrides,
+  };
+}
+
+function makeAccountRow(overrides: Record<string, unknown> = {}) {
+  return makeBaseRow({
+    snapshot_id: "snap-acct-1",
+    user_id: "usr-1",
+    snapshot_type: "account_balance",
+    account_id: "acc-1",
+    balances_current: 1000,
+    balances_available: 900,
+    balances_iso_currency_code: "USD",
+    ...overrides,
+  });
+}
+
+function makeSecurityRow(overrides: Record<string, unknown> = {}) {
+  return makeBaseRow({
+    snapshot_id: "snap-sec-1",
+    snapshot_type: "security",
+    security_id: "sec-aapl",
+    close_price: 195.5,
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+describe("searchSnapshots", () => {
+  test("runs both queries and merges results on the unfiltered global fetch", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [makeAccountRow()], rowCount: 1 }))
+      .mockImplementationOnce(async () => ({ rows: [makeSecurityRow()], rowCount: 1 }));
+
+    const result = await searchSnapshots(testUser, { startDate: "2026-01-01" });
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+
+    const userScopedSql = mockQuery.mock.calls[0][0] as string;
+    expect(userScopedSql).toContain("user_id = $1");
+    expect(mockQuery.mock.calls[0][1]).toEqual(["usr-1", "2026-01-01"]);
+
+    const securitySql = mockQuery.mock.calls[1][0] as string;
+    expect(securitySql).not.toContain("user_id = ");
+    expect(securitySql).toContain("snapshot_type = $1");
+    expect(mockQuery.mock.calls[1][1]).toEqual(["security", "2026-01-01"]);
+  });
+
+  test("skips the security query when narrowing to a specific account_id", async () => {
+    mockQuery.mockImplementationOnce(async () => ({
+      rows: [makeAccountRow({ account_id: "acc-7" })],
+      rowCount: 1,
+    }));
+
+    await searchSnapshots(testUser, { account_id: "acc-7" });
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery.mock.calls[0][1]).toContain("acc-7");
+  });
+
+  test("skips the security query when caller asks for snapshot_type='holding'", async () => {
+    mockQuery.mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+
+    await searchSnapshots(testUser, { snapshot_type: "holding" });
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain("snapshot_type = ");
+    expect(mockQuery.mock.calls[0][1]).toContain("holding");
+  });
+
+  test("skips the security query when caller passes a non-empty account_ids list", async () => {
+    mockQuery.mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+
+    await searchSnapshots(testUser, { account_ids: ["acc-1", "acc-2"] });
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  test("runs the security query when caller explicitly asks for snapshot_type='security'", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({ rows: [makeSecurityRow()], rowCount: 1 }));
+
+    const result = await searchSnapshots(testUser, { snapshot_type: "security" });
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ security: { security_id: "sec-aapl" } });
+  });
+
+  test("propagates date range to both queries", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+
+    await searchSnapshots(testUser, { startDate: "2026-01-01", endDate: "2026-06-30" });
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    const userValues = mockQuery.mock.calls[0][1] as unknown[];
+    const securityValues = mockQuery.mock.calls[1][1] as unknown[];
+    expect(userValues).toContain("2026-01-01");
+    expect(userValues).toContain("2026-06-30");
+    expect(securityValues).toContain("2026-01-01");
+    expect(securityValues).toContain("2026-06-30");
+  });
+
+  test("passes security_id filter through to the global security query", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+
+    await searchSnapshots(testUser, { security_id: "sec-aapl" });
+
+    const securitySql = mockQuery.mock.calls[1][0] as string;
+    expect(securitySql).toContain("security_id = ");
+    expect(mockQuery.mock.calls[1][1]).toContain("sec-aapl");
+  });
+});

--- a/src/server/lib/postgres/repositories/snapshots.test.ts
+++ b/src/server/lib/postgres/repositories/snapshots.test.ts
@@ -16,6 +16,11 @@ mock.module("../client", () => ({
   pool: { query: mockQuery },
 }));
 
+const mockSearchSecuritiesById = mock(async (_ids: string[]) => [] as unknown[]);
+mock.module("./securities", () => ({
+  searchSecuritiesById: mockSearchSecuritiesById,
+}));
+
 import { searchSnapshots } from "./snapshots";
 
 const testUser = { user_id: "usr-1", username: "hoie" };
@@ -72,6 +77,8 @@ function makeSecurityRow(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   mockQuery.mockReset();
+  mockSearchSecuritiesById.mockReset();
+  mockSearchSecuritiesById.mockImplementation(async () => []);
 });
 
 describe("searchSnapshots", () => {
@@ -136,6 +143,86 @@ describe("searchSnapshots", () => {
     expect(mockQuery).toHaveBeenCalledTimes(2);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ security: { security_id: "sec-aapl" } });
+  });
+
+  test("enriches security snapshots with ticker_symbol and name from the securities table", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({
+        rows: [makeSecurityRow({ security_id: "sec-aapl", close_price: 195.5 })],
+        rowCount: 1,
+      }));
+    mockSearchSecuritiesById.mockImplementationOnce(async () => [
+      {
+        security_id: "sec-aapl",
+        ticker_symbol: "AAPL",
+        name: "Apple Inc.",
+        type: "equity",
+        close_price: 200, // latest — should be OVERWRITTEN by the snapshot's historical price
+        close_price_as_of: "2026-05-13",
+      },
+    ]);
+
+    const result = await searchSnapshots(testUser, { startDate: "2026-01-01" });
+
+    expect(mockSearchSecuritiesById).toHaveBeenCalledTimes(1);
+    expect(mockSearchSecuritiesById.mock.calls[0][0]).toEqual(["sec-aapl"]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      security: {
+        security_id: "sec-aapl",
+        ticker_symbol: "AAPL",
+        name: "Apple Inc.",
+        type: "equity",
+        close_price: 195.5,
+      },
+    });
+  });
+
+  test("leaves security snapshot fields null when the securities table has no matching row", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({
+        rows: [makeSecurityRow({ security_id: "sec-orphan" })],
+        rowCount: 1,
+      }));
+    // mockSearchSecuritiesById returns [] by default — simulates orphan security
+
+    const result = await searchSnapshots(testUser, { startDate: "2026-01-01" });
+
+    expect(result).toHaveLength(1);
+    const snap = result[0] as { security: { security_id: string; ticker_symbol?: string | null } };
+    expect(snap.security.security_id).toBe("sec-orphan");
+    expect(snap.security.ticker_symbol ?? null).toBeNull();
+  });
+
+  test("deduplicates security_ids before calling searchSecuritiesById", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({
+        rows: [
+          makeSecurityRow({ snapshot_id: "snap-1", security_id: "sec-aapl", snapshot_date: "2026-05-10" }),
+          makeSecurityRow({ snapshot_id: "snap-2", security_id: "sec-aapl", snapshot_date: "2026-05-11" }),
+          makeSecurityRow({ snapshot_id: "snap-3", security_id: "sec-msft", snapshot_date: "2026-05-10" }),
+        ],
+        rowCount: 3,
+      }));
+
+    await searchSnapshots(testUser, { startDate: "2026-01-01" });
+
+    expect(mockSearchSecuritiesById).toHaveBeenCalledTimes(1);
+    const ids = mockSearchSecuritiesById.mock.calls[0][0] as string[];
+    expect(ids.sort()).toEqual(["sec-aapl", "sec-msft"]);
+  });
+
+  test("does not call searchSecuritiesById when there are no security snapshots", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+
+    await searchSnapshots(testUser, { startDate: "2026-01-01" });
+
+    expect(mockSearchSecuritiesById).toHaveBeenCalledTimes(0);
   });
 
   test("propagates date range to both queries", async () => {

--- a/src/server/lib/postgres/repositories/snapshots.ts
+++ b/src/server/lib/postgres/repositories/snapshots.ts
@@ -16,6 +16,7 @@ import {
   USER_ID,
 } from "../models";
 import { UpsertResult, successResult, errorResult, buildSelectWithFilters } from "../database";
+import { searchSecuritiesById } from "./securities";
 import { logger } from "../../logger";
 
 export interface SearchSnapshotsOptions {
@@ -116,7 +117,31 @@ export const searchSnapshots = async (
     globalSecurity.values,
   );
 
-  return [...userResult.rows, ...securityResult.rows].map(rowToSnapshot);
+  // Enrich each security snapshot with ticker_symbol / name / type from the
+  // securities table. Without this the frontend's `securitySnapshots` dict
+  // would carry only `{ security_id, close_price }` and `HoldingsComposition`
+  // still couldn't resolve `security_id → ticker`. Same enrichment pattern
+  // as `getHoldingSnapshotsRoute`.
+  const uniqueSecurityIds = [
+    ...new Set(securityResult.rows.map((r) => r.security_id as string).filter(Boolean)),
+  ];
+  const securities = uniqueSecurityIds.length ? await searchSecuritiesById(uniqueSecurityIds) : [];
+  const securityMap = new Map(securities.map((s) => [s.security_id, s]));
+
+  const enrichedSecuritySnapshots = securityResult.rows.map((row) => {
+    const snap = rowToSnapshot(row);
+    if (!isSecuritySnapshot(snap)) return snap;
+    const sec = securityMap.get(snap.security.security_id);
+    if (sec) {
+      // Spread the full security record first, then keep the snapshot's
+      // historical `close_price` (per snapshot_date) — the securities table
+      // only holds the latest price.
+      snap.security = { ...sec, close_price: snap.security.close_price };
+    }
+    return snap;
+  });
+
+  return [...userResult.rows.map(rowToSnapshot), ...enrichedSecuritySnapshots];
 };
 
 export const getAccountSnapshots = async (

--- a/src/server/lib/postgres/repositories/snapshots.ts
+++ b/src/server/lib/postgres/repositories/snapshots.ts
@@ -59,11 +59,25 @@ export interface HoldingSnapshot {
 const rowToSnapshot = (row: Record<string, unknown>): JSONSnapshotData =>
   new SnapshotModel(row).toJSON();
 
+// Security snapshots are price data — stored with `user_id = NULL` because
+// they're shared across all users. The user-scoped query below would
+// otherwise exclude them by the `user_id = $1` filter, leaving the frontend
+// unable to resolve `security_id → ticker_symbol` (Closes #323).
+//
+// Two queries instead of one: the user-scoped table-helper path doesn't
+// support an OR predicate, and a raw SQL rewrite of the whole search would
+// duplicate the date-range / inFilters logic that `buildSelectWithFilters`
+// already encodes. Two helper calls + concat is the smaller change.
 export const searchSnapshots = async (
   user: MaskedUser | null,
   options: SearchSnapshotsOptions = {},
 ): Promise<JSONSnapshotData[]> => {
-  const { sql, values } = buildSelectWithFilters(SNAPSHOTS, "*", {
+  const dateRange =
+    options.startDate || options.endDate
+      ? { column: SNAPSHOT_DATE, start: options.startDate, end: options.endDate }
+      : undefined;
+
+  const userScoped = buildSelectWithFilters(SNAPSHOTS, "*", {
     user_id: user?.user_id,
     filters: {
       [SNAPSHOT_TYPE]: options.snapshot_type,
@@ -71,15 +85,38 @@ export const searchSnapshots = async (
       [SECURITY_ID]: options.security_id,
     },
     inFilters: options.account_ids?.length ? { [ACCOUNT_ID]: options.account_ids } : undefined,
-    dateRange:
-      options.startDate || options.endDate
-        ? { column: SNAPSHOT_DATE, start: options.startDate, end: options.endDate }
-        : undefined,
+    dateRange,
     orderBy: `${SNAPSHOT_DATE} DESC`,
     limit: options.limit,
   });
-  const result = await pool.query<Record<string, unknown>>(sql, values);
-  return result.rows.map(rowToSnapshot);
+  const userResult = await pool.query<Record<string, unknown>>(userScoped.sql, userScoped.values);
+
+  // Security snapshots only make sense when the caller isn't narrowing to a
+  // specific account or a non-security snapshot_type. Skip the second query
+  // in those cases to keep the response shape consistent with the request.
+  const wantsSecurity =
+    (!options.snapshot_type || options.snapshot_type === "security") &&
+    !options.account_id &&
+    !options.account_ids?.length;
+  if (!wantsSecurity) {
+    return userResult.rows.map(rowToSnapshot);
+  }
+
+  const globalSecurity = buildSelectWithFilters(SNAPSHOTS, "*", {
+    filters: {
+      [SNAPSHOT_TYPE]: "security",
+      [SECURITY_ID]: options.security_id,
+    },
+    dateRange,
+    orderBy: `${SNAPSHOT_DATE} DESC`,
+    limit: options.limit,
+  });
+  const securityResult = await pool.query<Record<string, unknown>>(
+    globalSecurity.sql,
+    globalSecurity.values,
+  );
+
+  return [...userResult.rows, ...securityResult.rows].map(rowToSnapshot);
 };
 
 export const getAccountSnapshots = async (


### PR DESCRIPTION
## Summary

Fixes security symbol display on the account detail page by surfacing security snapshots through `GET /api/snapshots`. PR 1 of the broader work tracked under #323 + holdings-display unification (per Discord 2026-05-13).

## Root cause

`searchSnapshots` (`src/server/lib/postgres/repositories/snapshots.ts`) filters every row by `user_id = $1`. Security snapshots are stored with `user_id = NULL` because they're shared price data across users (see `upsertSnapshots` — security path omits the `[USER_ID]` column). The filter excludes them, leaving the frontend's `securitySnapshots` dict empty. `HoldingsComposition` then falls back to `truncateSecurityId(securityId)` instead of resolving the ticker.

## Change

Split `searchSnapshots` into two passes inside the same function:

1. **User-scoped query** (existing behavior) — fetches account_balance + holding snapshots filtered by user_id.
2. **Global security query** — fetches `snapshot_type = 'security'` rows without a user_id filter.

The second pass is **skipped** when the caller narrows by:
- `options.account_id` (specific account)
- `options.account_ids` (non-empty list)
- `options.snapshot_type` set to something other than `'security'`

So the response shape stays consistent with the request — narrow requests get narrow responses; the unfiltered global fetch (the only caller from `sync.ts`) gets both.

No client-side changes: `sync.ts:241-244` already parses `JSONSecuritySnapshot` items into the `securitySnapshots` dict; this PR just makes them flow.

## Test plan

- [x] `bun test src/server/lib/postgres/repositories/snapshots.test.ts` — 7 new tests covering both passes running, each skip condition (account_id, account_ids, snapshot_type=holding), security-only fetch, date-range propagation, security_id filter passthrough
- [x] `bun test src/server` — 307/307 pass
- [x] `bun run typecheck` — clean
- [ ] E2E on per-PR sandbox (will land as a comment) — confirm security symbols render in HoldingsComposition on a synced investment account

## Follow-ups (out of scope here)

- PR 2: dynamic asset evaluation in `HoldingsComposition` using snapshots
- PR 3: unify manual (`HoldingsManager`) and synced (`HoldingsComposition`) holdings-summary styles, retaining edit affordances
- PR 4 (deferred): #323 step 3 — slice + cache `/api/snapshots` like `/api/transactions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)