### PR TITLE
feat(holdings): block direct balances.current edits when holdings exist

### DIFF
--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -100,8 +100,21 @@ export const AccountProperties = ({ account }: Props) => {
   };
 
   const latestViewDate = new ViewDate(viewDate.getInterval());
+
+  // Block direct balance edits when holdings exist on this account — total
+  // should be derived from `Σ(holdings)` + cash, with the user editing cash
+  // as a holding rather than the account total. Server enforces the same
+  // rule in post-account.ts / post-snapshot.ts.
+  const accountHasHoldings = useMemo(() => {
+    for (const snap of data.holdingSnapshots.values()) {
+      if (snap.holding.account_id === account_id) return true;
+    }
+    return false;
+  }, [account_id, data.holdingSnapshots]);
+
   const isBalanceInputDisabled =
-    !isManualAccount && viewDate.getEndDate() >= latestViewDate.getEndDate();
+    accountHasHoldings ||
+    (!isManualAccount && viewDate.getEndDate() >= latestViewDate.getEndDate());
 
   return (
     <div className="AccountProperties Properties">

--- a/src/server/routes/accounts/post-account.test.ts
+++ b/src/server/routes/accounts/post-account.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for POST /api/account — focused on the new "block balances.current
+ * edit when holdings exist" guard added 2026-05-13.
+ *
+ * Mocking strategy mirrors `post-suggest-category.test.ts`: monkey-patch the
+ * small surface we exercise (`holdingsTable.query` for the holdings probe
+ * and `accountsTable.update` for the upsert path), restore in afterAll.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+
+import { accountsTable, holdingsTable } from "server";
+import { postAccountRoute } from "./post-account";
+
+const originalHoldingsQuery = holdingsTable.query.bind(holdingsTable);
+const originalAccountsUpdate = accountsTable.update.bind(accountsTable);
+
+// holdingsTable.query returns model instances whose .toJSON() yields a
+// JSONHolding. The route only cares about `.length`, so any object with a
+// stub .toJSON() works.
+const makeHoldingModel = (row: Record<string, unknown>) => ({ toJSON: () => row });
+const mockHoldingsQuery = mock(
+  async (_filters: unknown): Promise<Array<{ toJSON: () => unknown }>> => [],
+);
+const mockAccountsUpdate = mock(async (_id: unknown, _data: unknown) => ({ account_id: "acc-1" }));
+
+(holdingsTable as unknown as { query: typeof mockHoldingsQuery }).query = mockHoldingsQuery;
+(accountsTable as unknown as { update: typeof mockAccountsUpdate }).update = mockAccountsUpdate;
+
+afterAll(() => {
+  (holdingsTable as unknown as { query: typeof originalHoldingsQuery }).query = originalHoldingsQuery;
+  (accountsTable as unknown as { update: typeof originalAccountsUpdate }).update = originalAccountsUpdate;
+});
+
+beforeEach(() => {
+  mockHoldingsQuery.mockReset();
+  mockAccountsUpdate.mockReset();
+  mockHoldingsQuery.mockImplementation(async () => []);
+  mockAccountsUpdate.mockImplementation(async () => ({ account_id: "acc-1" }));
+});
+
+function makeReq(body: unknown, userId = "u-1") {
+  return {
+    method: "POST",
+    path: "/account",
+    url: "http://x/api/account",
+    headers: {},
+    query: {},
+    body,
+    session: {
+      id: "s-1",
+      user: { user_id: userId, username: "test" },
+      regenerate() {},
+      destroy() {},
+    },
+    ip: "127.0.0.1",
+  } as unknown as Parameters<typeof postAccountRoute.execute>[0];
+}
+
+const fakeRes = () =>
+  ({
+    statusCode: 200,
+    headersSent: false,
+    status() {
+      return this;
+    },
+    write() {
+      return true;
+    },
+    end() {},
+  }) as unknown as Parameters<typeof postAccountRoute.execute>[1];
+
+describe("post-account: holdings-aware balance edit guard", () => {
+  test("rejects balances.current edit when the account has any holding", async () => {
+    mockHoldingsQuery.mockImplementationOnce(async () => [
+      makeHoldingModel({ holding_id: "h-1", account_id: "acc-1", security_id: "sec-1" }),
+    ]);
+
+    const result = await postAccountRoute.execute(
+      makeReq({ account_id: "acc-1", balances: { current: 1000 } }),
+      fakeRes(),
+    );
+
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/holdings exist/i);
+    expect(mockAccountsUpdate).toHaveBeenCalledTimes(0);
+  });
+
+  test("allows balances.current edit when the account has no holdings", async () => {
+    mockHoldingsQuery.mockImplementationOnce(async () => []);
+    mockAccountsUpdate.mockImplementationOnce(async () => ({ account_id: "acc-2" }));
+
+    const result = await postAccountRoute.execute(
+      makeReq({ account_id: "acc-2", balances: { current: 500 } }),
+      fakeRes(),
+    );
+
+    expect(result?.status).toBe("success");
+    expect(mockAccountsUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test("allows non-balance edits (e.g. rename) even when holdings exist", async () => {
+    mockHoldingsQuery.mockImplementationOnce(async () => [
+      { holding_id: "h-1", account_id: "acc-3", security_id: "sec-1" },
+    ]);
+    mockAccountsUpdate.mockImplementationOnce(async () => ({ account_id: "acc-3" }));
+
+    const result = await postAccountRoute.execute(
+      makeReq({ account_id: "acc-3", custom_name: "Renamed" }),
+      fakeRes(),
+    );
+
+    // No `balances` in the body → the guard's branch never fires.
+    expect(result?.status).toBe("success");
+    expect(mockAccountsUpdate).toHaveBeenCalledTimes(1);
+    // We also expect the holdings probe to be skipped because the body has
+    // no `balances.current` to validate.
+    expect(mockHoldingsQuery).toHaveBeenCalledTimes(0);
+  });
+
+  test("does not probe holdings when balances is present but lacks `current`", async () => {
+    mockHoldingsQuery.mockImplementationOnce(async () => [
+      { holding_id: "h-1", account_id: "acc-4", security_id: "sec-1" },
+    ]);
+    mockAccountsUpdate.mockImplementationOnce(async () => ({ account_id: "acc-4" }));
+
+    // E.g. caller updating only `iso_currency_code` inside balances.
+    const result = await postAccountRoute.execute(
+      makeReq({ account_id: "acc-4", balances: { iso_currency_code: "USD" } }),
+      fakeRes(),
+    );
+
+    expect(result?.status).toBe("success");
+    expect(mockHoldingsQuery).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/server/routes/accounts/post-account.ts
+++ b/src/server/routes/accounts/post-account.ts
@@ -1,4 +1,11 @@
-import { Route, updateAccounts, requireBodyObject, requireStringField, validationError } from "server";
+import {
+  Route,
+  updateAccounts,
+  requireBodyObject,
+  requireStringField,
+  validationError,
+  getHoldingsByAccount,
+} from "server";
 import type { PartialAccount } from "server";
 import { logger } from "server/lib/logger";
 
@@ -22,6 +29,21 @@ export const postAccountRoute = new Route<AccountPostResponse>("POST", "/account
 
   const idResult = requireStringField(body, "account_id");
   if (!idResult.success) return validationError(idResult.error!);
+
+  // Block direct edits to `balances.current` when the account already has
+  // holdings — total should be derived from the holdings table (including a
+  // cash-type holding for uninvested cash). Per Hoie 2026-05-13: "when
+  // there are holdings, don't allow direct updates to the account total.
+  // Instead allow them to update the cash amount in the holdings summary."
+  const balancesIn = body.balances as Record<string, unknown> | undefined;
+  if (balancesIn && "current" in balancesIn) {
+    const holdings = await getHoldingsByAccount(user, idResult.data!);
+    if (holdings.length > 0) {
+      return validationError(
+        "Account total cannot be edited directly when holdings exist. Update the cash row in Holdings Composition instead.",
+      );
+    }
+  }
 
   try {
     const response = await updateAccounts(user, [body as PartialAccount]);

--- a/src/server/routes/accounts/post-snapshot.ts
+++ b/src/server/routes/accounts/post-snapshot.ts
@@ -1,5 +1,11 @@
 import { JSONAccount, getSquashedDateString, JSONSnapshot, LocalDate } from "common";
-import { Route, upsertSnapshots, requireBodyObject, validationError } from "server";
+import {
+  Route,
+  upsertSnapshots,
+  requireBodyObject,
+  validationError,
+  getHoldingsByAccount,
+} from "server";
 import { logger } from "server/lib/logger";
 
 export interface SnapshotPostResponse {
@@ -28,6 +34,19 @@ export const postSnapshotRoute = new Route<SnapshotPostResponse>(
 
     // TODO: Snapshot can be holding or security snapshot as well
     const account: JSONAccount = body.account as JSONAccount;
+
+    // Block historical-balance edits when the account has holdings — the
+    // account total should reconcile against `Σ(holdings)` + cash, so a
+    // direct balances.current write would diverge from the holdings view
+    // for that date. Same rule as `post-account.ts`.
+    if (account?.account_id && account?.balances && "current" in account.balances) {
+      const holdings = await getHoldingsByAccount(user, account.account_id);
+      if (holdings.length > 0) {
+        return validationError(
+          "Account total snapshot cannot be edited directly when holdings exist. Update the cash row in Holdings Composition instead.",
+        );
+      }
+    }
     const snapshotData = body.snapshot as Record<string, unknown>;
     const date = snapshotData.date ? new LocalDate(snapshotData.date as string) : new Date();
     const snapshot: JSONSnapshot = {


### PR DESCRIPTION
## Summary

PR 3b of the holdings-display work. Per Hoie 2026-05-13: *"when there are holdings, don't allow direct updates to the account total. Instead allow them to update the cash amount in the holdings summary."* This PR is the safety gate enforcing that — both server and client refuse the direct account-total path on accounts that already have holdings, so the displayed total stays the derived `Σ(holdings) + cash` reconciliation that the holdings view promises.

The cash-as-holding storage itself (option B from the design thread — a synthetic USD holding rather than a derived virtual field) is already supported by the existing `/api/snapshots/holding` route: a manual user can type `ticker=USD` and the backend treats it as any other security. The cash row's clickable-to-edit affordance is part of PR 3a (#351).

## Changes

### Server

- **`POST /api/account`** (`post-account.ts`) — if the body has `balances.current` AND `getHoldingsByAccount(user, account_id).length > 0`, return a validationError. Non-balance edits (rename, hide toggle, etc.) and balance updates that touch other fields (e.g. `iso_currency_code`) still pass through, so the guard is narrow.
- **`POST /api/snapshot`** (`post-snapshot.ts`) — same shape, for historical-balance snapshot edits. If the snapshot's account carries `balances.current` and the account has holdings, reject. Same error message for consistency.

### Client

- **`AccountProperties`** computes `accountHasHoldings` by scanning the in-memory `data.holdingSnapshots` dictionary for `holding.account_id === account_id`. When true, the existing `isBalanceInputDisabled` flag flips on, so the `DynamicCapacityInput` for "`<viewDate>` balance" renders disabled. No new component, no layout shift.

## Test plan

- [x] `bun test src/server` — 304/304 pass (4 new in `post-account.test.ts`: reject on holding + balance.current, allow on no holdings, allow on non-balance edits, skip the probe when `balances` lacks `current`)
- [x] `bun run test:client` — 162/162 pass
- [x] `bun run typecheck` — clean
- [ ] E2E on per-PR sandbox: a manual account with at least one holding renders the `<viewDate> balance` input as disabled; a curl POST against `/api/account` with `{balances: {current: X}}` returns a validation error. Synced accounts without holdings unaffected. Will land as a comment.

## Follow-ups

- The synthetic inferred-cash row in `HoldingsComposition` (PR 2a, #349) is not yet clickable-to-persist as a real cash holding. That UX flourish — clicking the synthetic row to open a pre-filled `HOLDING_DETAIL` with `ticker=USD` + the inferred quantity — would be a small follow-up after PR 3a (#351) and this PR both land.
- PR 4 (deferred): #323 step 3 — slice + cache `/api/snapshots`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)