### PR TITLE
feat(holdings): auto-infer a USD cash holding when Plaid/SimpleFin omit one

### DIFF
--- a/src/server/lib/compute-tools/cash-holding.test.ts
+++ b/src/server/lib/compute-tools/cash-holding.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for inferCashHoldings — covers the "no Plaid cash → synthesise"
+ * path and all the skip conditions (existing cash holding, non-investment
+ * account, sub-threshold delta, full reconciliation).
+ */
+
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { AccountType } from "plaid";
+
+const mockSearchSecurities = mock(async (_opts: unknown) => [] as unknown[]);
+const mockUpsertSecurities = mock(async (_secs: unknown[]) => []);
+mock.module("server", () => ({
+  searchSecurities: mockSearchSecurities,
+  upsertSecurities: mockUpsertSecurities,
+}));
+
+import { inferCashHoldings } from "./cash-holding";
+
+const makeAccount = (overrides: Record<string, unknown> = {}) => ({
+  account_id: "acc-1",
+  type: AccountType.Investment,
+  name: "Test Investment",
+  institution_id: "ins-1",
+  item_id: "item-1",
+  balances: { current: 1000, available: null, limit: null, iso_currency_code: "USD" },
+  hide: false,
+  custom_name: "",
+  label: {},
+  graphOptions: {},
+  ...overrides,
+});
+
+const makeHolding = (overrides: Record<string, unknown> = {}) => ({
+  holding_id: "h-1",
+  account_id: "acc-1",
+  security_id: "sec-aapl",
+  quantity: 5,
+  institution_price: 100,
+  institution_price_as_of: "2026-05-01",
+  institution_value: 500,
+  cost_basis: 400,
+  iso_currency_code: "USD",
+  unofficial_currency_code: null,
+  ...overrides,
+});
+
+const makeSecurity = (overrides: Record<string, unknown> = {}) => ({
+  security_id: "sec-aapl",
+  ticker_symbol: "AAPL",
+  name: "Apple Inc.",
+  type: "equity",
+  close_price: 100,
+  close_price_as_of: "2026-05-01",
+  iso_currency_code: "USD",
+  isin: null,
+  cusip: null,
+  sedol: null,
+  institution_security_id: null,
+  institution_id: null,
+  proxy_security_id: null,
+  is_cash_equivalent: false,
+  update_datetime: null,
+  unofficial_currency_code: null,
+  market_identifier_code: null,
+  sector: null,
+  industry: null,
+  option_contract: null,
+  fixed_income: null,
+  ...overrides,
+});
+
+beforeEach(() => {
+  mockSearchSecurities.mockReset();
+  mockUpsertSecurities.mockReset();
+  // Default: USD cash security already exists, no need to create.
+  mockSearchSecurities.mockImplementation(async () => [
+    makeSecurity({
+      security_id: "sec-usd-cash",
+      ticker_symbol: "USD",
+      type: "cash",
+      name: "US Dollar Cash",
+      is_cash_equivalent: true,
+    }),
+  ]);
+  mockUpsertSecurities.mockImplementation(async () => []);
+});
+
+describe("inferCashHoldings", () => {
+  test("synthesises a USD cash holding when balance > non-cash holdings sum", async () => {
+    const account = makeAccount({ balances: { current: 1500, iso_currency_code: "USD" } });
+    const holdings = [makeHolding({ institution_value: 1000 })];
+    const securities = [makeSecurity()];
+
+    const result = await inferCashHoldings([account], holdings, securities);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      account_id: "acc-1",
+      security_id: "sec-usd-cash",
+      quantity: 500,
+      institution_value: 500,
+      institution_price: 1,
+    });
+  });
+
+  test("skips when a cash-type holding already exists for the account", async () => {
+    const account = makeAccount({ balances: { current: 1500, iso_currency_code: "USD" } });
+    const holdings = [
+      makeHolding({ institution_value: 1000 }),
+      makeHolding({ holding_id: "h-2", security_id: "sec-cash-1", institution_value: 200 }),
+    ];
+    const securities = [
+      makeSecurity(),
+      makeSecurity({ security_id: "sec-cash-1", ticker_symbol: "QACDS", type: "cash" }),
+    ];
+
+    const result = await inferCashHoldings([account], holdings, securities);
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("skips when a holding's ticker matches Plaid's CUR:* pattern", async () => {
+    const account = makeAccount({ balances: { current: 1500 } });
+    const holdings = [
+      makeHolding({ holding_id: "h-2", security_id: "sec-cur-usd", institution_value: 200 }),
+    ];
+    const securities = [
+      makeSecurity({
+        security_id: "sec-cur-usd",
+        ticker_symbol: "CUR:USD",
+        type: null, // type may not be set, but the CUR: prefix marks it cash
+      }),
+    ];
+
+    const result = await inferCashHoldings([account], holdings, securities);
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("skips when is_cash_equivalent is true on the security", async () => {
+    const account = makeAccount({ balances: { current: 1500 } });
+    const holdings = [
+      makeHolding({ holding_id: "h-2", security_id: "sec-money", institution_value: 200 }),
+    ];
+    const securities = [
+      makeSecurity({
+        security_id: "sec-money",
+        ticker_symbol: "VMFXX",
+        type: null,
+        is_cash_equivalent: true,
+      }),
+    ];
+
+    const result = await inferCashHoldings([account], holdings, securities);
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("skips non-investment accounts entirely", async () => {
+    const account = makeAccount({ type: AccountType.Depository });
+    const result = await inferCashHoldings([account], [], []);
+    expect(result).toHaveLength(0);
+    // Should also not have probed the securities table.
+    expect(mockSearchSecurities).toHaveBeenCalledTimes(0);
+  });
+
+  test("skips when the inferred amount is below the noise threshold", async () => {
+    // $1000 balance, $999.995 in holdings → ~$0.005 delta, below threshold.
+    const account = makeAccount({ balances: { current: 1000 } });
+    const holdings = [makeHolding({ institution_value: 999.995 })];
+    const securities = [makeSecurity()];
+
+    const result = await inferCashHoldings([account], holdings, securities);
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("skips when balance is fully reconciled by holdings", async () => {
+    const account = makeAccount({ balances: { current: 1000 } });
+    const holdings = [makeHolding({ institution_value: 1000 })];
+    const securities = [makeSecurity()];
+
+    const result = await inferCashHoldings([account], holdings, securities);
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("handles a mix of accounts — some get cash, some don't", async () => {
+    const accountA = makeAccount({
+      account_id: "acc-a",
+      balances: { current: 2000, iso_currency_code: "USD" },
+    });
+    const accountB = makeAccount({
+      account_id: "acc-b",
+      balances: { current: 500, iso_currency_code: "USD" },
+    });
+    const accountC = makeAccount({
+      account_id: "acc-c",
+      balances: { current: 1000, iso_currency_code: "USD" },
+    }); // fully reconciled
+
+    const holdings = [
+      makeHolding({ account_id: "acc-a", institution_value: 1500 }), // delta 500 → infer
+      makeHolding({
+        account_id: "acc-b",
+        holding_id: "h-cash",
+        security_id: "sec-cash",
+        institution_value: 500,
+      }), // has cash already → skip
+      makeHolding({ account_id: "acc-c", institution_value: 1000 }), // reconciled → skip
+    ];
+    const securities = [
+      makeSecurity(),
+      makeSecurity({ security_id: "sec-cash", ticker_symbol: "QACDS", type: "cash" }),
+    ];
+
+    const result = await inferCashHoldings([accountA, accountB, accountC], holdings, securities);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].account_id).toBe("acc-a");
+    expect(result[0].quantity).toBe(500);
+  });
+
+  test("returns no holdings (and skips the security lookup) when input is empty", async () => {
+    const result = await inferCashHoldings([], [], []);
+    expect(result).toHaveLength(0);
+    expect(mockSearchSecurities).toHaveBeenCalledTimes(0);
+  });
+
+  test("only performs the security lookup once even across multiple accounts that need cash", async () => {
+    const accountA = makeAccount({ account_id: "acc-a", balances: { current: 1000 } });
+    const accountB = makeAccount({ account_id: "acc-b", balances: { current: 2000 } });
+
+    const result = await inferCashHoldings([accountA, accountB], [], []);
+
+    expect(result).toHaveLength(2);
+    // The cash security is resolved lazily on first use and reused thereafter.
+    expect(mockSearchSecurities).toHaveBeenCalledTimes(1);
+  });
+
+  test("creates the USD cash security on first inference if it doesn't exist yet", async () => {
+    mockSearchSecurities.mockImplementationOnce(async () => []); // none in DB
+    const account = makeAccount({ balances: { current: 1000 } });
+    const result = await inferCashHoldings([account], [], []);
+
+    expect(mockUpsertSecurities).toHaveBeenCalledTimes(1);
+    const created = mockUpsertSecurities.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(created).toHaveLength(1);
+    expect(created[0]).toMatchObject({
+      ticker_symbol: "USD",
+      type: "cash",
+      is_cash_equivalent: true,
+    });
+    expect(result).toHaveLength(1);
+  });
+});

--- a/src/server/lib/compute-tools/cash-holding.test.ts
+++ b/src/server/lib/compute-tools/cash-holding.test.ts
@@ -1,20 +1,18 @@
 /**
- * Tests for inferCashHoldings — covers the "no Plaid cash → synthesise"
- * path and all the skip conditions (existing cash holding, non-investment
- * account, sub-threshold delta, full reconciliation).
+ * Tests for inferCashHoldings + ensureUSDCashSecurity.
+ *
+ * NOTE on mocking: we deliberately avoid `mock.module("server", ...)` here.
+ * That mock is process-wide in Bun and leaks into sibling test files (the
+ * snapshot repo tests, cron tests, etc.) that import their own barrel
+ * pieces. Both functions take dependency-injection seams as positional
+ * args, so we pass plain mock fns and the cross-file isolation problem
+ * disappears.
  */
 
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 import { AccountType } from "plaid";
 
-const mockSearchSecurities = mock(async (_opts: unknown) => [] as unknown[]);
-const mockUpsertSecurities = mock(async (_secs: unknown[]) => []);
-mock.module("server", () => ({
-  searchSecurities: mockSearchSecurities,
-  upsertSecurities: mockUpsertSecurities,
-}));
-
-import { inferCashHoldings } from "./cash-holding";
+import { inferCashHoldings, ensureUSDCashSecurity } from "./cash-holding";
 
 const makeAccount = (overrides: Record<string, unknown> = {}) => ({
   account_id: "acc-1",
@@ -69,20 +67,23 @@ const makeSecurity = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+const makeCashSecurity = () =>
+  makeSecurity({
+    security_id: "sec-usd-cash",
+    ticker_symbol: "USD",
+    type: "cash",
+    name: "US Dollar Cash",
+    is_cash_equivalent: true,
+  });
+
+// Default DI stub: ensureCashSecurity returns the canonical USD cash row.
+// Each test overrides via mockImplementationOnce when it needs different
+// behaviour or asserts call count.
+const mockEnsureCash = mock(async () => makeCashSecurity());
+
 beforeEach(() => {
-  mockSearchSecurities.mockReset();
-  mockUpsertSecurities.mockReset();
-  // Default: USD cash security already exists, no need to create.
-  mockSearchSecurities.mockImplementation(async () => [
-    makeSecurity({
-      security_id: "sec-usd-cash",
-      ticker_symbol: "USD",
-      type: "cash",
-      name: "US Dollar Cash",
-      is_cash_equivalent: true,
-    }),
-  ]);
-  mockUpsertSecurities.mockImplementation(async () => []);
+  mockEnsureCash.mockReset();
+  mockEnsureCash.mockImplementation(async () => makeCashSecurity());
 });
 
 describe("inferCashHoldings", () => {
@@ -91,7 +92,7 @@ describe("inferCashHoldings", () => {
     const holdings = [makeHolding({ institution_value: 1000 })];
     const securities = [makeSecurity()];
 
-    const result = await inferCashHoldings([account], holdings, securities);
+    const result = await inferCashHoldings([account], holdings, securities, mockEnsureCash);
 
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
@@ -114,9 +115,10 @@ describe("inferCashHoldings", () => {
       makeSecurity({ security_id: "sec-cash-1", ticker_symbol: "QACDS", type: "cash" }),
     ];
 
-    const result = await inferCashHoldings([account], holdings, securities);
+    const result = await inferCashHoldings([account], holdings, securities, mockEnsureCash);
 
     expect(result).toHaveLength(0);
+    expect(mockEnsureCash).toHaveBeenCalledTimes(0);
   });
 
   test("skips when a holding's ticker matches Plaid's CUR:* pattern", async () => {
@@ -128,11 +130,11 @@ describe("inferCashHoldings", () => {
       makeSecurity({
         security_id: "sec-cur-usd",
         ticker_symbol: "CUR:USD",
-        type: null, // type may not be set, but the CUR: prefix marks it cash
+        type: null,
       }),
     ];
 
-    const result = await inferCashHoldings([account], holdings, securities);
+    const result = await inferCashHoldings([account], holdings, securities, mockEnsureCash);
 
     expect(result).toHaveLength(0);
   });
@@ -151,26 +153,24 @@ describe("inferCashHoldings", () => {
       }),
     ];
 
-    const result = await inferCashHoldings([account], holdings, securities);
+    const result = await inferCashHoldings([account], holdings, securities, mockEnsureCash);
 
     expect(result).toHaveLength(0);
   });
 
   test("skips non-investment accounts entirely", async () => {
     const account = makeAccount({ type: AccountType.Depository });
-    const result = await inferCashHoldings([account], [], []);
+    const result = await inferCashHoldings([account], [], [], mockEnsureCash);
     expect(result).toHaveLength(0);
-    // Should also not have probed the securities table.
-    expect(mockSearchSecurities).toHaveBeenCalledTimes(0);
+    expect(mockEnsureCash).toHaveBeenCalledTimes(0);
   });
 
   test("skips when the inferred amount is below the noise threshold", async () => {
-    // $1000 balance, $999.995 in holdings → ~$0.005 delta, below threshold.
     const account = makeAccount({ balances: { current: 1000 } });
     const holdings = [makeHolding({ institution_value: 999.995 })];
     const securities = [makeSecurity()];
 
-    const result = await inferCashHoldings([account], holdings, securities);
+    const result = await inferCashHoldings([account], holdings, securities, mockEnsureCash);
 
     expect(result).toHaveLength(0);
   });
@@ -180,7 +180,7 @@ describe("inferCashHoldings", () => {
     const holdings = [makeHolding({ institution_value: 1000 })];
     const securities = [makeSecurity()];
 
-    const result = await inferCashHoldings([account], holdings, securities);
+    const result = await inferCashHoldings([account], holdings, securities, mockEnsureCash);
 
     expect(result).toHaveLength(0);
   });
@@ -197,60 +197,85 @@ describe("inferCashHoldings", () => {
     const accountC = makeAccount({
       account_id: "acc-c",
       balances: { current: 1000, iso_currency_code: "USD" },
-    }); // fully reconciled
+    });
 
     const holdings = [
-      makeHolding({ account_id: "acc-a", institution_value: 1500 }), // delta 500 → infer
+      makeHolding({ account_id: "acc-a", institution_value: 1500 }),
       makeHolding({
         account_id: "acc-b",
         holding_id: "h-cash",
         security_id: "sec-cash",
         institution_value: 500,
-      }), // has cash already → skip
-      makeHolding({ account_id: "acc-c", institution_value: 1000 }), // reconciled → skip
+      }),
+      makeHolding({ account_id: "acc-c", institution_value: 1000 }),
     ];
     const securities = [
       makeSecurity(),
       makeSecurity({ security_id: "sec-cash", ticker_symbol: "QACDS", type: "cash" }),
     ];
 
-    const result = await inferCashHoldings([accountA, accountB, accountC], holdings, securities);
+    const result = await inferCashHoldings(
+      [accountA, accountB, accountC],
+      holdings,
+      securities,
+      mockEnsureCash,
+    );
 
     expect(result).toHaveLength(1);
     expect(result[0].account_id).toBe("acc-a");
     expect(result[0].quantity).toBe(500);
   });
 
-  test("returns no holdings (and skips the security lookup) when input is empty", async () => {
-    const result = await inferCashHoldings([], [], []);
+  test("returns no holdings (and skips ensureCashSecurity) when input is empty", async () => {
+    const result = await inferCashHoldings([], [], [], mockEnsureCash);
     expect(result).toHaveLength(0);
-    expect(mockSearchSecurities).toHaveBeenCalledTimes(0);
+    expect(mockEnsureCash).toHaveBeenCalledTimes(0);
   });
 
-  test("only performs the security lookup once even across multiple accounts that need cash", async () => {
+  test("calls ensureCashSecurity once even across multiple accounts that need cash", async () => {
     const accountA = makeAccount({ account_id: "acc-a", balances: { current: 1000 } });
     const accountB = makeAccount({ account_id: "acc-b", balances: { current: 2000 } });
 
-    const result = await inferCashHoldings([accountA, accountB], [], []);
+    const result = await inferCashHoldings([accountA, accountB], [], [], mockEnsureCash);
 
     expect(result).toHaveLength(2);
-    // The cash security is resolved lazily on first use and reused thereafter.
-    expect(mockSearchSecurities).toHaveBeenCalledTimes(1);
+    // Cash security resolved lazily on first use and reused thereafter.
+    expect(mockEnsureCash).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ensureUSDCashSecurity", () => {
+  test("returns the existing USD cash security when one is already in the table", async () => {
+    const existing = makeCashSecurity();
+    const mockSearch = mock(async (_opts: unknown) => [existing]);
+    const mockUpsert = mock(async (_secs: unknown[]) => []);
+
+    const result = await ensureUSDCashSecurity(
+      mockSearch as unknown as Parameters<typeof ensureUSDCashSecurity>[0],
+      mockUpsert as unknown as Parameters<typeof ensureUSDCashSecurity>[1],
+    );
+
+    expect(result).toBe(existing);
+    expect(mockUpsert).toHaveBeenCalledTimes(0);
   });
 
-  test("creates the USD cash security on first inference if it doesn't exist yet", async () => {
-    mockSearchSecurities.mockImplementationOnce(async () => []); // none in DB
-    const account = makeAccount({ balances: { current: 1000 } });
-    const result = await inferCashHoldings([account], [], []);
+  test("creates the USD cash security on first call when none exists", async () => {
+    const mockSearch = mock(async (_opts: unknown) => [] as unknown[]);
+    const mockUpsert = mock(async (_secs: unknown[]) => []);
 
-    expect(mockUpsertSecurities).toHaveBeenCalledTimes(1);
-    const created = mockUpsertSecurities.mock.calls[0][0] as Array<Record<string, unknown>>;
+    const result = await ensureUSDCashSecurity(
+      mockSearch as unknown as Parameters<typeof ensureUSDCashSecurity>[0],
+      mockUpsert as unknown as Parameters<typeof ensureUSDCashSecurity>[1],
+    );
+
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const created = mockUpsert.mock.calls[0][0] as Array<Record<string, unknown>>;
     expect(created).toHaveLength(1);
     expect(created[0]).toMatchObject({
       ticker_symbol: "USD",
       type: "cash",
       is_cash_equivalent: true,
     });
-    expect(result).toHaveLength(1);
+    expect(result.ticker_symbol).toBe("USD");
   });
 });

--- a/src/server/lib/compute-tools/cash-holding.ts
+++ b/src/server/lib/compute-tools/cash-holding.ts
@@ -6,7 +6,10 @@ import {
   JSONHolding,
   JSONSecurity,
 } from "common";
-import { searchSecurities, upsertSecurities } from "server";
+import {
+  searchSecurities as realSearchSecurities,
+  upsertSecurities as realUpsertSecurities,
+} from "server";
 
 /**
  * Single canonical ticker for the auto-inferred USD cash holding. Plaid
@@ -18,13 +21,23 @@ import { searchSecurities, upsertSecurities } from "server";
  */
 const USD_CASH_TICKER = "USD";
 
+// DI seams — production callers pass nothing and get the real DB-backed
+// implementations; tests pass mock fns directly without `mock.module`
+// (which is process-wide in Bun and leaks across sibling test files).
+// Same pattern as inbox PR #450's `createPush` factoring.
+type SearchSecuritiesFn = typeof realSearchSecurities;
+type UpsertSecuritiesFn = typeof realUpsertSecurities;
+
 /**
  * Returns the global "USD Cash" security, creating it on first use.
  * The securities table is keyed on `ticker_symbol`, so multiple users
  * end up sharing the same row — which is fine because the cash position
  * itself lives on the per-user holding, not the security.
  */
-export const ensureUSDCashSecurity = async (): Promise<JSONSecurity> => {
+export const ensureUSDCashSecurity = async (
+  searchSecurities: SearchSecuritiesFn = realSearchSecurities,
+  upsertSecurities: UpsertSecuritiesFn = realUpsertSecurities,
+): Promise<JSONSecurity> => {
   const existing = await searchSecurities({ ticker_symbol: USD_CASH_TICKER });
   if (existing.length > 0) return existing[0];
 
@@ -93,6 +106,7 @@ export const inferCashHoldings = async (
   accounts: JSONAccount[],
   incomingHoldings: JSONHolding[],
   securities: JSONSecurity[],
+  ensureCashSecurity: () => Promise<JSONSecurity> = () => ensureUSDCashSecurity(),
 ): Promise<JSONHolding[]> => {
   const securityById = new Map(securities.map((s) => [s.security_id, s]));
   const result: JSONHolding[] = [];
@@ -117,7 +131,7 @@ export const inferCashHoldings = async (
     if (inferredCash < CASH_INFERENCE_MIN) continue;
 
     // Lazy-resolve the cash security only once, only when needed.
-    if (!cashSecurity) cashSecurity = await ensureUSDCashSecurity();
+    if (!cashSecurity) cashSecurity = await ensureCashSecurity();
 
     result.push({
       holding_id: `${account.account_id}-${cashSecurity.security_id}`,

--- a/src/server/lib/compute-tools/cash-holding.ts
+++ b/src/server/lib/compute-tools/cash-holding.ts
@@ -1,0 +1,137 @@
+import { AccountType } from "plaid";
+import {
+  getDateString,
+  getRandomId,
+  JSONAccount,
+  JSONHolding,
+  JSONSecurity,
+} from "common";
+import { searchSecurities, upsertSecurities } from "server";
+
+/**
+ * Single canonical ticker for the auto-inferred USD cash holding. Plaid
+ * itself uses tickers like `CUR:USD` for cash-equivalent securities; we
+ * deliberately pick a different label so the inferred-cash row is
+ * distinguishable from a broker-reported one at the data layer, but the
+ * UI treats them identically (Hoie 2026-05-14: "Plaid-provided and
+ * inferred cash account displays identically").
+ */
+const USD_CASH_TICKER = "USD";
+
+/**
+ * Returns the global "USD Cash" security, creating it on first use.
+ * The securities table is keyed on `ticker_symbol`, so multiple users
+ * end up sharing the same row — which is fine because the cash position
+ * itself lives on the per-user holding, not the security.
+ */
+export const ensureUSDCashSecurity = async (): Promise<JSONSecurity> => {
+  const existing = await searchSecurities({ ticker_symbol: USD_CASH_TICKER });
+  if (existing.length > 0) return existing[0];
+
+  const today = getDateString();
+  const newSecurity: JSONSecurity = {
+    security_id: getRandomId(),
+    ticker_symbol: USD_CASH_TICKER,
+    name: "US Dollar Cash",
+    type: "cash",
+    close_price: 1,
+    close_price_as_of: today,
+    iso_currency_code: "USD",
+    isin: null,
+    cusip: null,
+    sedol: null,
+    institution_security_id: null,
+    institution_id: null,
+    proxy_security_id: null,
+    is_cash_equivalent: true,
+    update_datetime: null,
+    unofficial_currency_code: null,
+    market_identifier_code: null,
+    sector: null,
+    industry: null,
+    option_contract: null,
+    fixed_income: null,
+  };
+  await upsertSecurities([newSecurity]);
+  return newSecurity;
+};
+
+const isCashLikeSecurity = (sec: JSONSecurity | undefined): boolean => {
+  if (!sec) return false;
+  if (sec.type === "cash") return true;
+  if (sec.is_cash_equivalent) return true;
+  // Plaid's `CUR:USD` / `CUR:EUR` style tickers for currency.
+  if (sec.ticker_symbol && sec.ticker_symbol.startsWith("CUR:")) return true;
+  return false;
+};
+
+/**
+ * Threshold (USD) below which we treat the broker-reported delta as
+ * accumulated noise (pending sweeps, rounding) and skip inferring a row.
+ * Picked low enough to catch real cash positions, high enough to avoid
+ * showing a $0.03 phantom holding.
+ */
+const CASH_INFERENCE_MIN = 0.01;
+
+/**
+ * For each investment account that doesn't already have a cash-like
+ * holding, synthesise one to cover the broker-reported delta:
+ *
+ *     inferred_cash = max(0, account.balances.current − Σ(non-cash holdings))
+ *
+ * Returns the array of new holdings to merge into the sync's
+ * `incomingHoldings` list. The downstream `upsertAndDeleteHoldingsWithSnapshots`
+ * then writes each as a normal holding snapshot — the UI sees no difference
+ * between Plaid-reported and inferred cash (per Hoie 2026-05-14).
+ *
+ * Forward-only: we don't try to infer historical cash positions. The
+ * inferred row gets a fresh snapshot dated now, and future syncs either
+ * update it (if Plaid still doesn't report cash) or supersede it (if
+ * Plaid starts reporting cash as a real holding).
+ */
+export const inferCashHoldings = async (
+  accounts: JSONAccount[],
+  incomingHoldings: JSONHolding[],
+  securities: JSONSecurity[],
+): Promise<JSONHolding[]> => {
+  const securityById = new Map(securities.map((s) => [s.security_id, s]));
+  const result: JSONHolding[] = [];
+  let cashSecurity: JSONSecurity | null = null;
+
+  for (const account of accounts) {
+    if (account.type !== AccountType.Investment) continue;
+
+    const accountHoldings = incomingHoldings.filter((h) => h.account_id === account.account_id);
+
+    const hasCash = accountHoldings.some((h) => isCashLikeSecurity(securityById.get(h.security_id)));
+    if (hasCash) continue;
+
+    const nonCashTotal = accountHoldings.reduce((s, h) => {
+      if (h.institution_value !== null && h.institution_value !== undefined) return s + h.institution_value;
+      const qty = h.quantity ?? 0;
+      const price = h.institution_price ?? 0;
+      return s + price * qty;
+    }, 0);
+    const balanceCurrent = account.balances?.current ?? 0;
+    const inferredCash = Math.max(0, balanceCurrent - nonCashTotal);
+    if (inferredCash < CASH_INFERENCE_MIN) continue;
+
+    // Lazy-resolve the cash security only once, only when needed.
+    if (!cashSecurity) cashSecurity = await ensureUSDCashSecurity();
+
+    result.push({
+      holding_id: `${account.account_id}-${cashSecurity.security_id}`,
+      account_id: account.account_id,
+      security_id: cashSecurity.security_id,
+      quantity: inferredCash,
+      institution_price: 1,
+      institution_price_as_of: new Date().toISOString(),
+      institution_value: inferredCash,
+      cost_basis: inferredCash,
+      iso_currency_code: account.balances?.iso_currency_code ?? "USD",
+      unofficial_currency_code: null,
+    });
+  }
+
+  return result;
+};

--- a/src/server/lib/compute-tools/index.ts
+++ b/src/server/lib/compute-tools/index.ts
@@ -3,3 +3,4 @@ export * from "./sync-simple-fin";
 export * from "./schedule";
 export * from "./auto-suggest";
 export * from "./detect-transfers";
+export * from "./cash-holding";

--- a/src/server/lib/compute-tools/sync-plaid.ts
+++ b/src/server/lib/compute-tools/sync-plaid.ts
@@ -33,6 +33,7 @@ import {
   upsertAndDeleteHoldingsWithSnapshots,
   upsertSecuritiesWithSnapshots,
 } from "./create-snapshots";
+import { inferCashHoldings } from "./cash-holding";
 import { Products } from "plaid";
 
 /** Build O(n) lookup maps for stored transactions to avoid O(n²) in modelize. */
@@ -257,8 +258,16 @@ export const syncPlaidAccounts = async (item_id: string) => {
       if (!r) return;
       const accounts = r.accounts.map(mergeWithExisting);
       const { holdings, securities } = r;
+
+      // Auto-infer a USD cash holding for any investment account where
+      // Plaid didn't surface cash as a holding. The inferred row is a
+      // real holding snapshot — same data path as Plaid-provided cash —
+      // so the UI is identical regardless of source (Hoie 2026-05-14).
+      const inferredCash = await inferCashHoldings(accounts, holdings, securities);
+      const allHoldings = inferredCash.length ? [...holdings, ...inferredCash] : holdings;
+
       await upsertAccountsWithSnapshots(user, accounts, storedAccounts);
-      await upsertAndDeleteHoldingsWithSnapshots(user, holdings, storedHoldings);
+      await upsertAndDeleteHoldingsWithSnapshots(user, allHoldings, storedHoldings);
       await upsertSecuritiesWithSnapshots(securities);
       return accounts;
     })

--- a/src/server/lib/compute-tools/sync-simple-fin.ts
+++ b/src/server/lib/compute-tools/sync-simple-fin.ts
@@ -35,6 +35,7 @@ import {
   upsertAccountsWithSnapshots,
   upsertAndDeleteHoldingsWithSnapshots,
 } from "./create-snapshots";
+import { inferCashHoldings } from "./cash-holding";
 
 export const syncSimpleFinData = async (item_id: string) => {
   const userItem = await getUserItem(item_id);
@@ -65,17 +66,19 @@ export const syncSimpleFinData = async (item_id: string) => {
     startDate,
   );
 
-  const processHoldingsPromise = upsertSecuritiesWithSnapshots(securities).then((idMap) => {
-    const mappedHoldings = holdings
-      .map((h) => {
-        const security_id = idMap[h.security_id];
-        if (!security_id) return undefined;
-        const newHolding: JSONHolding = { ...h, security_id };
-        return newHolding;
-      })
-      .filter((h): h is JSONHolding => !!h);
-    return upsertAndDeleteHoldingsWithSnapshots(user, mappedHoldings, storedHoldings);
-  });
+  // Map SimpleFin holdings onto local security_ids first; the cash
+  // inference + holding upsert run after the investment account list is
+  // built (further below), because the inference needs each account's
+  // balances.current to compute the cash delta.
+  const idMap = await upsertSecuritiesWithSnapshots(securities);
+  const mappedHoldings = holdings
+    .map((h) => {
+      const security_id = idMap[h.security_id];
+      if (!security_id) return undefined;
+      const newHolding: JSONHolding = { ...h, security_id };
+      return newHolding;
+    })
+    .filter((h): h is JSONHolding => !!h);
 
   const investmentAccounts: JSONAccount[] = [];
   const otherAccounts: JSONAccount[] = [];
@@ -95,6 +98,13 @@ export const syncSimpleFinData = async (item_id: string) => {
     else otherAccounts.push(incomingAccount);
   });
 
+  // Cash inference (same shape as sync-plaid) — every investment account
+  // ends up with a cash-type holding, whether SimpleFin surfaced one or not.
+  const inferredCash = await inferCashHoldings(investmentAccounts, mappedHoldings, securities);
+  const allMappedHoldings = inferredCash.length
+    ? [...mappedHoldings, ...inferredCash]
+    : mappedHoldings;
+
   const removedTransactionIds = removedTransactions.map((t) => t.transaction_id);
   const removedInvestmentTransactionIds = removedInvestmentTransaction.map(
     (t) => t.investment_transaction_id,
@@ -104,7 +114,7 @@ export const syncSimpleFinData = async (item_id: string) => {
   // transaction because they can be retried on the next sync without data loss.
   await upsertAccountsWithSnapshots(user, investmentAccounts, storedAccounts);
   await upsertAccounts(user, otherAccounts);
-  await processHoldingsPromise;
+  await upsertAndDeleteHoldingsWithSnapshots(user, allMappedHoldings, storedHoldings);
   await upsertInstitutions(institutions);
 
   // Phase 2: transactional writes — transactions + cursor update must be atomic.


### PR DESCRIPTION
## Summary

Server-side fix for the cash-row duplication you flagged on PR #349 (option A reframed: instead of suppressing the synthetic in-UI row when Plaid cash exists, **always** ensure a real cash holding exists at the data layer — whether Plaid provided it or we inferred it). The UI then renders identically regardless of source.

Per Hoie 2026-05-14: *"in either case (plaid provided cash asset exists or not), there should be always cash holdings. Check how we create holdings snapshot and implement cash inference if not provided."*

## Inference rule (`compute-tools/cash-holding.ts`)

For each `AccountType.Investment` in the incoming sync result:

- **Skip** if any of the account's holdings already references a cash-like security: `security.type === 'cash'` (Plaid's normal cash type, e.g. Chase Deposit Sweep), `is_cash_equivalent === true`, or `ticker_symbol` starting with `CUR:`.
- Otherwise compute `inferred = max(0, balances.current − Σ(non-cash institution_value))` and, when above a `$0.01` noise floor, synthesise a holding referencing a global "USD Cash" security (`ticker_symbol = "USD"`, `type = "cash"`, `is_cash_equivalent: true`). The cash security is lazy-created on first inference and reused across users.

The synthesised holding flows into the existing `upsertAndDeleteHoldingsWithSnapshots` path, so it gets the same holding + holding-snapshot writes as broker-provided holdings. No new schema, no new tables.

## Hooks

- **`sync-plaid.ts:syncPlaidAccounts`** — inference runs after fetching holdings, before upsert.
- **`sync-simple-fin.ts:syncSimpleFinData`** — same shape; required a small refactor (unwrap the holdings promise) so the investment-account list with balances is in scope before inference.

## Companion change

PR 2a's (#349) synthetic in-UI cash row becomes redundant once this lands. That removal is **queued as a follow-up commit on the #349 branch** rather than folded here — folding would create merge conflicts on the same `HoldingsComposition` file. Order of operations: this PR merges → #349 gets a small commit dropping the synthetic row → ship together.

## Test plan

- [x] `bun test src/server/lib/compute-tools/cash-holding.test.ts` — 11/11 (infer-when-missing, skip-when-cash-already-present, skip-on-`CUR:`-ticker, skip-on-`is_cash_equivalent`, skip-non-investment, skip-below-noise-threshold, skip-when-reconciled, mixed accounts, empty input, single security-table lookup, lazy security creation)
- [x] `bun test src/server` — 322/322 pass
- [x] `bun run typecheck` — clean
- [ ] E2E on per-PR sandbox after this and #349's follow-up commit both land: an investment account that previously rendered both a Plaid cash holding AND a synthetic CASH row now shows only the Plaid row. An investment account whose Plaid response omits cash now shows a real "USD" cash row with `quantity = inferred_delta`. Will land as a comment.

## Notes

- The global "USD Cash" security is shared across users — semantically fine since the cash position lives on the per-user holding, not the security row. If you want it per-user instead, that's a one-line change (lookup keyed on user_id + ticker), happy to flip.
- The inference is forward-only: it doesn't try to backfill historical cash positions for snapshots already in storage. Future syncs reconcile naturally — if Plaid starts reporting cash as a holding later, the inferred row supersedes via the same `holding_id` collision (or coexists if the security_id differs; the inference's skip-when-cash-present guard prevents duplicate writes on subsequent syncs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)