### PR TITLE
chore(env): document LOG_LEVEL override in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ ADMIN_PASSWORD=qwert12345
 # Optional: set server timezone (defaults to America/Los_Angeles)
 # APP_TIMEZONE=UTC
 
+# Optional: log verbosity. One of debug | info | warn | error.
+# Default: info (or error when NODE_ENV=test). See src/server/lib/logger.ts.
+# LOG_LEVEL=info
+
 PLAID_CLIENT_ID=000000000
 PLAID_SECRET_PRODUCTION=000000000
 PLAID_SECRET_DEVELOPMENT=000000000


### PR DESCRIPTION
## Summary

`LOG_LEVEL` is read in `src/server/lib/logger.ts:44` (`getLogLevel()` honours `process.env.LOG_LEVEL` if it matches `debug | info | warn | error`) and again on line 102 (gates stack-trace output to debug-only). It was missing from `.env.example`, so devs had no way to discover the override without reading the source.

Add as a commented-out default. Default behaviour unchanged — `getLogLevel()` still falls back to `"info"` (or `"error"` when `NODE_ENV=test`) when `LOG_LEVEL` is unset.

Found via daily-ops Sweep 6 (env-var/source vs `.env.example` reconciliation).

## Test plan

- [x] No source change — only `.env.example` touched.
- [x] Verified default-fallback path in `logger.ts:44-49` is unchanged: `process.env.LOG_LEVEL` still treated as optional.
- [x] No CI-relevant files changed; `bun typecheck` / `bun test` not applicable to a `.env.example`-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
