### PR TITLE
fix(snapshots): emit synthetic security_snapshot for orphan (cash) securities in /api/snapshots

### DIFF
--- a/src/server/lib/postgres/repositories/snapshots.test.ts
+++ b/src/server/lib/postgres/repositories/snapshots.test.ts
@@ -75,6 +75,20 @@ function makeSecurityRow(overrides: Record<string, unknown> = {}) {
   });
 }
 
+function makeHoldingRow(overrides: Record<string, unknown> = {}) {
+  return makeBaseRow({
+    snapshot_id: "snap-hold-1",
+    user_id: "usr-1",
+    snapshot_type: "holding",
+    holding_account_id: "acc-1",
+    holding_security_id: "sec-qacds",
+    institution_price: 1,
+    institution_value: 234622,
+    quantity: 234622,
+    ...overrides,
+  });
+}
+
 beforeEach(() => {
   mockQuery.mockReset();
   mockSearchSecuritiesById.mockReset();
@@ -251,5 +265,81 @@ describe("searchSnapshots", () => {
     const securitySql = mockQuery.mock.calls[1][0] as string;
     expect(securitySql).toContain("security_id = ");
     expect(mockQuery.mock.calls[1][1]).toContain("sec-aapl");
+  });
+
+  test("emits a synthetic security_snapshot for any holding's security that has no price snapshot", async () => {
+    // User-scoped query returns a holding for sec-qacds; security query
+    // returns nothing for that id. The orphan-fill pass should look up
+    // sec-qacds via searchSecuritiesById and emit a synthetic snapshot
+    // so the frontend can identify it as cash via the `type` field.
+    mockQuery
+      .mockImplementationOnce(async () => ({
+        rows: [makeHoldingRow({ holding_security_id: "sec-qacds" })],
+        rowCount: 1,
+      }))
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+
+    // No priced-security rows exist, so the priced-enrichment pass skips
+    // the lookup. The orphan-fill pass is the only call.
+    mockSearchSecuritiesById.mockImplementationOnce(async (ids: string[]) => {
+      expect(ids).toEqual(["sec-qacds"]);
+      return [
+        {
+          security_id: "sec-qacds",
+          ticker_symbol: "QACDS",
+          name: "Chase Deposit Sweep",
+          type: "cash",
+          close_price: 1,
+          close_price_as_of: "2026-05-14",
+        },
+      ];
+    });
+
+    const result = await searchSnapshots(testUser);
+
+    // Holding snapshot + synthetic security snapshot.
+    expect(result).toHaveLength(2);
+
+    const securityEntry = result.find(
+      (r): r is { snapshot: { snapshot_id: string }; security: { security_id: string; type?: string | null } } =>
+        typeof r === "object" && r !== null && "security" in r,
+    );
+    expect(securityEntry).toBeDefined();
+    expect(securityEntry!.security.security_id).toBe("sec-qacds");
+    expect(securityEntry!.security.type).toBe("cash");
+    expect(securityEntry!.snapshot.snapshot_id).toBe("__orphan-security__sec-qacds");
+  });
+
+  test("does not emit an orphan security_snapshot when the holding's security already has a price snapshot", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({
+        rows: [makeHoldingRow({ holding_security_id: "sec-aapl" })],
+        rowCount: 1,
+      }))
+      .mockImplementationOnce(async () => ({
+        rows: [makeSecurityRow({ security_id: "sec-aapl" })],
+        rowCount: 1,
+      }));
+    mockSearchSecuritiesById.mockImplementationOnce(async () => [
+      {
+        security_id: "sec-aapl",
+        ticker_symbol: "AAPL",
+        name: "Apple Inc.",
+        type: "equity",
+        close_price: 195,
+      },
+    ]);
+
+    const result = await searchSnapshots(testUser);
+
+    // Holding + enriched security (1 each) — no orphan duplication.
+    expect(result).toHaveLength(2);
+    const securityEntries = result.filter(
+      (r) => typeof r === "object" && r !== null && "security" in r,
+    );
+    expect(securityEntries).toHaveLength(1);
+    // The single security entry should be the real (non-orphan) one.
+    const onlySec = securityEntries[0] as { snapshot: { snapshot_id: string } };
+    expect(onlySec.snapshot.snapshot_id).not.toContain("__orphan-security__");
   });
 });

--- a/src/server/lib/postgres/repositories/snapshots.ts
+++ b/src/server/lib/postgres/repositories/snapshots.ts
@@ -141,7 +141,52 @@ export const searchSnapshots = async (
     return snap;
   });
 
-  return [...userResult.rows.map(rowToSnapshot), ...enrichedSecuritySnapshots];
+  // Holdings can reference securities that have no price snapshot — cash
+  // sweeps / money-market funds are the common case (polygon doesn't
+  // price them so no snapshot pipeline runs). The frontend needs the
+  // security's `type` (and `is_cash_equivalent`) to render those rows
+  // correctly (e.g. suppressing Unrealized G/L on cash). Emit a
+  // synthetic security_snapshot per orphan security so it appears in the
+  // frontend's `securitySnapshots` dict alongside the priced ones.
+  // Closes the cash-G/L-on-`kZrEbX` bug Hoie 2026-05-14.
+  const holdingSnapshotRows = userResult.rows.filter(
+    (r) => r.snapshot_type === "holding" && r.holding_security_id,
+  );
+  const orphanSecuritySnapshots = await buildOrphanSecuritySnapshots(
+    holdingSnapshotRows,
+    securityMap,
+  );
+
+  return [
+    ...userResult.rows.map(rowToSnapshot),
+    ...enrichedSecuritySnapshots,
+    ...orphanSecuritySnapshots,
+  ];
+};
+
+const buildOrphanSecuritySnapshots = async (
+  holdingRows: Record<string, unknown>[],
+  alreadyEnrichedSecurityMap: Map<string, { security_id: string }>,
+): Promise<JSONSnapshotData[]> => {
+  const referencedIds = new Set(
+    holdingRows.map((r) => r.holding_security_id as string).filter(Boolean),
+  );
+  // Strip the ones we already emitted via the security-snapshot pass.
+  for (const id of alreadyEnrichedSecurityMap.keys()) referencedIds.delete(id);
+  if (referencedIds.size === 0) return [];
+
+  const securities = await searchSecuritiesById([...referencedIds]);
+  return securities.map((sec) => {
+    // No real snapshot exists — use a deterministic synthetic snapshot_id
+    // so duplicate calls don't churn React keys, and a sentinel date.
+    return {
+      snapshot: {
+        snapshot_id: `__orphan-security__${sec.security_id}`,
+        date: new Date().toISOString(),
+      },
+      security: { ...sec, close_price: null },
+    } as JSONSnapshotData;
+  });
 };
 
 export const getAccountSnapshots = async (


### PR DESCRIPTION
## Summary

The cash-G/L bug Hoie flagged on PR #349 (kZrEbX QACDS showing a phantom Unrealized G/L) — server-side half of the fix.

## Root cause

Cash-type securities (Chase Deposit Sweep / QACDS, money-market funds / VMFXX, currency / CUR:USD) never get a polygon-fed price snapshot — polygon doesn't price them. Result: the snapshots table has zero `snapshot_type='security'` rows for them.

`searchSnapshots` only ever emitted `JSONSecuritySnapshot` records for securities that had a snapshot. The frontend's `securitySnapshots` dict therefore had no idea those securities existed — no `type`, no `is_cash_equivalent`, no name. So when `getHoldingsValueData` tried to identify cash holdings (companion fix on PR #349's branch: derive `cashSecurityIds` from `securitySnapshots`), the cash holdings flew under the radar and `inferCostBasis` ran over Plaid's deposit/withdrawal investment_transactions, producing a phantom basis with `unrealizedGain ≈ 0`-but-not-quite (the `$[redacted]` figure Hoie saw on the JP Morgan account).

## Fix

After the priced-security enrichment pass, scan the user's holding snapshots for any `holding_security_id` that hasn't been enriched yet. Look them up via `searchSecuritiesById` and emit a synthetic `JSONSecuritySnapshot` per orphan security:

```ts
{
  snapshot: {
    snapshot_id: `__orphan-security__${security_id}`, // deterministic, React-key-stable
    date: <now>,
  },
  security: { ...sec, close_price: null }, // no price data, full metadata
}
```

The orphan id prefix makes them easy to spot in dev tools and impossible to confuse with a real polygon snapshot.

## Test plan

- [x] `bun test src/server/lib/postgres/repositories/snapshots.test.ts` — 13/13 (2 new: orphan-emitted-when-no-price, no-duplication-when-already-priced)
- [x] `bun test src/server` — 325/325
- [x] `bun run typecheck` — clean
- [ ] E2E on the per-PR sandbox + PR #349's branch rebased on top → confirm `kZrEbX` row renders `—` for G/L

## Companion

PR #349 has a follow-up commit (`9e29bf4`) on its branch that consumes the new orphan-security signal: in `getHoldingsValueData`, builds `cashSecurityIds` from `securitySnapshots` and forces `costBasis = null` for matching holdings (which makes `unrealizedGain` a null getter and the row's G/L column render as "—"). Once this PR lands, that PR-349 commit closes the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

*[Edited 2026-06-28: redacted dollar figures via a retroactive sweep after the daily-security-review's body-scan + shorthand-currency regex gap (found via issue #381 — see channel 1520705621228388514). Original detail removed.]*
