### PR TITLE
feat(snapshots): slice GET /api/snapshots month-by-month

### DIFF
--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -15,6 +15,7 @@ import {
   AccountsGetResponse,
   SplitTransactionsGetResponse,
   ChartsGetResponse,
+  SnapshotsGetResponse,
 } from "server";
 import {
   Account,
@@ -216,35 +217,88 @@ const fetchSnapshots = async (
     securitySnapshots: new SecuritySnapshotDictionary(),
   };
 
-  const params = new URLSearchParams();
-  const endDate = new Date();
-  endDate.setDate(endDate.getDate() + 2);
-  if (startDate) params.append("start-date", getDateString(startDate));
-  params.append("end-date", getDateString(endDate));
-  const path = "/api/snapshots?" + params.toString();
+  const ingestSnapshot = (snapshot: JSONSnapshotData) => {
+    if ("account" in snapshot) {
+      const account = accounts.get(snapshot.account.account_id) || {};
+      snapshot.account = { ...account, ...snapshot.account };
+      const newSnapshot = new AccountSnapshot(snapshot);
+      result.accountSnapshots.set(newSnapshot.snapshot.id, newSnapshot);
+    } else if ("holding" in snapshot) {
+      const newSnapshot = new HoldingSnapshot(snapshot);
+      result.holdingSnapshots.set(newSnapshot.snapshot.id, newSnapshot);
+    } else if ("security" in snapshot) {
+      const newSnapshot = new SecuritySnapshot(snapshot);
+      result.securitySnapshots.set(newSnapshot.snapshot.id, newSnapshot);
+    }
+  };
 
-  await call
-    .get(path)
-    .then(({ body }) => {
-      if (!body) return;
-      const snapshots = body as JSONSnapshotData[];
+  // Mirror fetchTransactions (Closes #323): slice the full date window into
+  // month-sized chunks, fetched per-account for user-scoped snapshots and
+  // once-per-month for shared security snapshots. Older months go through
+  // `cachedCall` so they only hit the network on first load; the most
+  // recent month always re-fetches so today's data stays fresh.
+  const snapshotsApiPath = "/api/snapshots";
+  const viewDate = new ViewDate("month");
+  const twoMonthAgoViewDate = viewDate.clone().previous().previous();
+  let oldestDate = twoMonthAgoViewDate.previous().getStartDate();
+  oldestDate = startDate && startDate < oldestDate ? startDate : oldestDate;
 
-      snapshots.forEach((snapshot) => {
-        if ("account" in snapshot) {
-          const account = accounts.get(snapshot.account.account_id) || {};
-          snapshot.account = { ...account, ...snapshot.account };
-          const newSnapshot = new AccountSnapshot(snapshot);
-          result.accountSnapshots.set(newSnapshot.snapshot.id, newSnapshot);
-        } else if ("holding" in snapshot) {
-          const newSnapshot = new HoldingSnapshot(snapshot);
-          result.holdingSnapshots.set(newSnapshot.snapshot.id, newSnapshot);
-        } else if ("security" in snapshot) {
-          const newSnapshot = new SecuritySnapshot(snapshot);
-          result.securitySnapshots.set(newSnapshot.snapshot.id, newSnapshot);
+  const promises: Promise<void>[] = [];
+
+  while (oldestDate < viewDate.getStartDate()) {
+    const monthStart = viewDate.getStartDate();
+    const monthEnd = viewDate.clone().next().getStartDate();
+    const startStr = getDateString(monthStart);
+    const endStr = getDateString(monthEnd);
+    const isRecent = new Date().getTime() - monthEnd.getTime() < THIRTY_DAYS;
+
+    accounts?.forEach((a) => {
+      const params = new URLSearchParams();
+      params.append("start-date", startStr);
+      params.append("end-date", endStr);
+      params.append("account-id", a.id);
+      const path = snapshotsApiPath + "?" + params.toString();
+
+      const fetchForAccount = async () => {
+        let response: ApiResponse<SnapshotsGetResponse> | void;
+        if (isRecent) {
+          response = await call.get<SnapshotsGetResponse>(path).catch(console.error);
+        } else {
+          response = await cachedCall<SnapshotsGetResponse>(path).catch(console.error);
         }
-      });
-    })
-    .catch(console.error);
+        if (!response?.body) return;
+        response.body.forEach(ingestSnapshot);
+      };
+
+      promises.push(fetchForAccount());
+    });
+
+    // Security snapshots are user-id=NULL (shared) and aren't returned by
+    // the account-scoped queries above. One slice per month, cached for
+    // older months — keeps the per-account URL space cleanly cache-keyed
+    // and avoids re-pulling the full price history on every page load.
+    const securityParams = new URLSearchParams();
+    securityParams.append("start-date", startStr);
+    securityParams.append("end-date", endStr);
+    securityParams.append("snapshot-type", "security");
+    const securityPath = snapshotsApiPath + "?" + securityParams.toString();
+
+    const fetchSecurities = async () => {
+      let response: ApiResponse<SnapshotsGetResponse> | void;
+      if (isRecent) {
+        response = await call.get<SnapshotsGetResponse>(securityPath).catch(console.error);
+      } else {
+        response = await cachedCall<SnapshotsGetResponse>(securityPath).catch(console.error);
+      }
+      if (!response?.body) return;
+      response.body.forEach(ingestSnapshot);
+    };
+    promises.push(fetchSecurities());
+
+    viewDate.previous();
+  }
+
+  await Promise.all(promises);
 
   return result;
 };

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -52,6 +52,27 @@ import {
   indexedDb,
 } from "client";
 
+// Bounded worker pool. Browsers cap concurrent fetches per origin (~6 on
+// HTTP/1.1) and queueing hundreds of `fetch`/`cache.add` calls at once
+// triggers ERR_INSUFFICIENT_RESOURCES — which silently aborts `cache.add`
+// and defeats the Cache API benefit for older months. Run a small N at a
+// time so every cache write actually completes.
+const SNAPSHOT_FETCH_CONCURRENCY = 6;
+
+const runWithConcurrency = async (
+  tasks: Array<() => Promise<void>>,
+  limit: number,
+): Promise<void> => {
+  let next = 0;
+  const workers = Array.from({ length: Math.min(limit, tasks.length) }, async () => {
+    while (next < tasks.length) {
+      const idx = next++;
+      await tasks[idx]();
+    }
+  });
+  await Promise.all(workers);
+};
+
 const getOldestTransactionDate = async (): Promise<Date | undefined> => {
   const response = await call
     .get<OldestTransactionDateGetResponse>("/api/oldest-transaction-date")
@@ -243,7 +264,7 @@ const fetchSnapshots = async (
   let oldestDate = twoMonthAgoViewDate.previous().getStartDate();
   oldestDate = startDate && startDate < oldestDate ? startDate : oldestDate;
 
-  const promises: Promise<void>[] = [];
+  const tasks: Array<() => Promise<void>> = [];
 
   while (oldestDate < viewDate.getStartDate()) {
     const monthStart = viewDate.getStartDate();
@@ -259,7 +280,7 @@ const fetchSnapshots = async (
       params.append("account-id", a.id);
       const path = snapshotsApiPath + "?" + params.toString();
 
-      const fetchForAccount = async () => {
+      tasks.push(async () => {
         let response: ApiResponse<SnapshotsGetResponse> | void;
         if (isRecent) {
           response = await call.get<SnapshotsGetResponse>(path).catch(console.error);
@@ -268,9 +289,7 @@ const fetchSnapshots = async (
         }
         if (!response?.body) return;
         response.body.forEach(ingestSnapshot);
-      };
-
-      promises.push(fetchForAccount());
+      });
     });
 
     // Security snapshots are user-id=NULL (shared) and aren't returned by
@@ -283,7 +302,7 @@ const fetchSnapshots = async (
     securityParams.append("snapshot-type", "security");
     const securityPath = snapshotsApiPath + "?" + securityParams.toString();
 
-    const fetchSecurities = async () => {
+    tasks.push(async () => {
       let response: ApiResponse<SnapshotsGetResponse> | void;
       if (isRecent) {
         response = await call.get<SnapshotsGetResponse>(securityPath).catch(console.error);
@@ -292,13 +311,12 @@ const fetchSnapshots = async (
       }
       if (!response?.body) return;
       response.body.forEach(ingestSnapshot);
-    };
-    promises.push(fetchSecurities());
+    });
 
     viewDate.previous();
   }
 
-  await Promise.all(promises);
+  await runWithConcurrency(tasks, SNAPSHOT_FETCH_CONCURRENCY);
 
   return result;
 };

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -6,6 +6,7 @@ import {
   JSONInstitution,
   JSONSnapshotData,
   LocalDate,
+  Queue,
 } from "common";
 import {
   BudgetsGetResponse,
@@ -52,26 +53,12 @@ import {
   indexedDb,
 } from "client";
 
-// Bounded worker pool. Browsers cap concurrent fetches per origin (~6 on
-// HTTP/1.1) and queueing hundreds of `fetch`/`cache.add` calls at once
-// triggers ERR_INSUFFICIENT_RESOURCES — which silently aborts `cache.add`
-// and defeats the Cache API benefit for older months. Run a small N at a
-// time so every cache write actually completes.
-const SNAPSHOT_FETCH_CONCURRENCY = 6;
-
-const runWithConcurrency = async (
-  tasks: Array<() => Promise<void>>,
-  limit: number,
-): Promise<void> => {
-  let next = 0;
-  const workers = Array.from({ length: Math.min(limit, tasks.length) }, async () => {
-    while (next < tasks.length) {
-      const idx = next++;
-      await tasks[idx]();
-    }
-  });
-  await Promise.all(workers);
-};
+// Browsers cap concurrent fetches per origin (~6 on HTTP/1.1) and queueing
+// hundreds of `fetch`/`cache.add` calls at once triggers
+// ERR_INSUFFICIENT_RESOURCES — which silently aborts `cache.add` and defeats
+// the Cache API benefit for older months. Gate snapshot fetches through a
+// shared Queue so at most 6 are in flight at any time.
+const snapshotFetchQueue = new Queue({ maxInflight: 6 });
 
 const getOldestTransactionDate = async (): Promise<Date | undefined> => {
   const response = await call
@@ -86,9 +73,16 @@ interface FetchTransactionsResult {
   investmentTransactions: InvestmentTransactionDictionary;
 }
 
+interface FetchRange {
+  /** Inclusive lower bound on the month start date — loop stops when viewDate < this. */
+  from: Date;
+  /** Exclusive upper bound on the month start date — loop starts at this month-1. */
+  until: Date;
+}
+
 const fetchTransactions = async (
   accounts: AccountDictionary,
-  startDate?: Date,
+  range: FetchRange,
 ): Promise<FetchTransactionsResult> => {
   const result = {
     transactions: new TransactionDictionary(),
@@ -97,13 +91,12 @@ const fetchTransactions = async (
 
   const transactionsApiPath = "/api/transactions";
   const viewDate = new ViewDate("month");
-  const twoMonthAgoViewDate = viewDate.clone().previous().previous();
-  let oldestDate = twoMonthAgoViewDate.previous().getStartDate();
-  oldestDate = startDate && startDate < oldestDate ? startDate : oldestDate;
+  // Walk back to the first month whose start < range.until.
+  while (viewDate.getStartDate() >= range.until) viewDate.previous();
 
   const promises: Promise<void>[] = [];
 
-  while (oldestDate < viewDate.getStartDate()) {
+  while (range.from < viewDate.getStartDate()) {
     accounts?.forEach((a) => {
       const params = new URLSearchParams();
       const startDate = viewDate.getStartDate();
@@ -230,7 +223,7 @@ interface FetchSnapshotsResult {
 
 const fetchSnapshots = async (
   accounts: AccountDictionary,
-  startDate?: Date,
+  range: FetchRange,
 ): Promise<FetchSnapshotsResult> => {
   const result = {
     accountSnapshots: new AccountSnapshotDictionary(),
@@ -260,13 +253,11 @@ const fetchSnapshots = async (
   // recent month always re-fetches so today's data stays fresh.
   const snapshotsApiPath = "/api/snapshots";
   const viewDate = new ViewDate("month");
-  const twoMonthAgoViewDate = viewDate.clone().previous().previous();
-  let oldestDate = twoMonthAgoViewDate.previous().getStartDate();
-  oldestDate = startDate && startDate < oldestDate ? startDate : oldestDate;
+  while (viewDate.getStartDate() >= range.until) viewDate.previous();
 
-  const tasks: Array<() => Promise<void>> = [];
+  const promises: Promise<void>[] = [];
 
-  while (oldestDate < viewDate.getStartDate()) {
+  while (range.from < viewDate.getStartDate()) {
     const monthStart = viewDate.getStartDate();
     const monthEnd = viewDate.clone().next().getStartDate();
     const startStr = getDateString(monthStart);
@@ -280,16 +271,18 @@ const fetchSnapshots = async (
       params.append("account-id", a.id);
       const path = snapshotsApiPath + "?" + params.toString();
 
-      tasks.push(async () => {
-        let response: ApiResponse<SnapshotsGetResponse> | void;
-        if (isRecent) {
-          response = await call.get<SnapshotsGetResponse>(path).catch(console.error);
-        } else {
-          response = await cachedCall<SnapshotsGetResponse>(path).catch(console.error);
-        }
-        if (!response?.body) return;
-        response.body.forEach(ingestSnapshot);
-      });
+      promises.push(
+        snapshotFetchQueue.add(async () => {
+          let response: ApiResponse<SnapshotsGetResponse> | void;
+          if (isRecent) {
+            response = await call.get<SnapshotsGetResponse>(path).catch(console.error);
+          } else {
+            response = await cachedCall<SnapshotsGetResponse>(path).catch(console.error);
+          }
+          if (!response?.body) return;
+          response.body.forEach(ingestSnapshot);
+        }),
+      );
     });
 
     // Security snapshots are user-id=NULL (shared) and aren't returned by
@@ -302,21 +295,23 @@ const fetchSnapshots = async (
     securityParams.append("snapshot-type", "security");
     const securityPath = snapshotsApiPath + "?" + securityParams.toString();
 
-    tasks.push(async () => {
-      let response: ApiResponse<SnapshotsGetResponse> | void;
-      if (isRecent) {
-        response = await call.get<SnapshotsGetResponse>(securityPath).catch(console.error);
-      } else {
-        response = await cachedCall<SnapshotsGetResponse>(securityPath).catch(console.error);
-      }
-      if (!response?.body) return;
-      response.body.forEach(ingestSnapshot);
-    });
+    promises.push(
+      snapshotFetchQueue.add(async () => {
+        let response: ApiResponse<SnapshotsGetResponse> | void;
+        if (isRecent) {
+          response = await call.get<SnapshotsGetResponse>(securityPath).catch(console.error);
+        } else {
+          response = await cachedCall<SnapshotsGetResponse>(securityPath).catch(console.error);
+        }
+        if (!response?.body) return;
+        response.body.forEach(ingestSnapshot);
+      }),
+    );
 
     viewDate.previous();
   }
 
-  await runWithConcurrency(tasks, SNAPSHOT_FETCH_CONCURRENCY);
+  await Promise.all(promises);
 
   return result;
 };
@@ -402,61 +397,149 @@ export const useSync = () => {
         })
         .catch(console.error);
 
+      // --- Stage 1: non-historical data (paint as soon as it lands).
+      // Accounts/items, budgets/sections/categories, charts, institutions —
+      // none of these are time-partitioned, so they finish quickly and let
+      // the UI render the navigation + summary widgets before the heavy
+      // snapshot/transaction fetches complete.
       const oldestDatePromise = getOldestTransactionDate();
-      const transactionsPromise = Promise.all([accountsPromise, oldestDatePromise]).then(
-        ([{ accounts }, oldestDate]) => fetchTransactions(accounts, oldestDate),
-      );
-      const splitTransactionsPromise = fetchSplitTransactions();
-      const snapshotsPromise = Promise.all([accountsPromise, oldestDatePromise]).then(
-        ([{ accounts }, oldestDate]) => fetchSnapshots(accounts, oldestDate),
-      );
       const budgetsPromise = fetchBudgets();
       const chartsPromise = fetchCharts();
       const institutionsPromise = accountsPromise.then((r) => fetchInstitutions(r.accounts));
 
       const [
         { accounts, items },
-        { transactions, investmentTransactions },
-        { splitTransactions },
-        { accountSnapshots, holdingSnapshots, securitySnapshots },
         { budgets, sections, categories },
         { charts },
         { institutions },
       ] = await Promise.all([
         accountsPromise,
-        transactionsPromise,
-        splitTransactionsPromise,
-        snapshotsPromise,
         budgetsPromise,
         chartsPromise,
         institutionsPromise,
       ]);
 
-      const newData = new Data({
+      const stage1 = new Data({
         accounts,
         items,
-        transactions,
-        splitTransactions,
-        investmentTransactions,
-        accountSnapshots,
-        holdingSnapshots,
-        securitySnapshots,
         budgets,
         sections,
         categories,
         charts,
         institutions,
       });
+      stage1.status.isInit = true;
+      stage1.status.isLoading = true;
+      stage1.status.isError = false;
+      setData(stage1);
 
-      newData.status.isInit = true;
-      newData.status.isLoading = false;
-      newData.status.isError = false;
+      // --- Stage 2: the most recent 2 months of historical data.
+      // The current month + previous month covers what the active
+      // dashboard / transactions table renders by default, so paint that
+      // as soon as it's available rather than blocking on the full
+      // history. Bounds are exclusive on both ends, matching the original
+      // single-pass loop's `while (oldestDate < viewDate.getStartDate())`
+      // semantics — months M with recentFrom < M.start < recentUntil are
+      // fetched (i.e. current + previous).
+      const currentViewDate = new ViewDate("month");
+      const recentFrom = currentViewDate.clone().previous().previous().getStartDate();
+      const recentUntil = currentViewDate.clone().next().getStartDate();
+      const recentRange: FetchRange = { from: recentFrom, until: recentUntil };
 
-      setData(newData);
+      const [
+        { transactions: recentTransactions, investmentTransactions: recentInvestmentTransactions },
+        { splitTransactions },
+        {
+          accountSnapshots: recentAccountSnapshots,
+          holdingSnapshots: recentHoldingSnapshots,
+          securitySnapshots: recentSecuritySnapshots,
+        },
+      ] = await Promise.all([
+        fetchTransactions(accounts, recentRange),
+        fetchSplitTransactions(),
+        fetchSnapshots(accounts, recentRange),
+      ]);
+
+      const stage2 = new Data({
+        accounts,
+        items,
+        budgets,
+        sections,
+        categories,
+        charts,
+        institutions,
+        transactions: recentTransactions,
+        investmentTransactions: recentInvestmentTransactions,
+        splitTransactions,
+        accountSnapshots: recentAccountSnapshots,
+        holdingSnapshots: recentHoldingSnapshots,
+        securitySnapshots: recentSecuritySnapshots,
+      });
+      stage2.status.isInit = true;
+      stage2.status.isLoading = true;
+      stage2.status.isError = false;
+      setData(stage2);
+
+      // --- Stage 3: everything older. Fetch the rest of the historical
+      // window (oldestTransactionDate → the month right before stage 2's
+      // window) and merge it into the dictionaries from stage 2.
+      // `olderUntil = 1-month-ago start` is exclusive — the older fetch
+      // covers months M with olderFrom < M.start < olderUntil, which
+      // begins one month earlier than stage 2's window so the two stages
+      // tile cleanly with no overlap and no gap.
+      const oldestDate = await oldestDatePromise;
+      const defaultFrom = currentViewDate.clone().previous().previous().previous().getStartDate();
+      const olderFrom = oldestDate && oldestDate < defaultFrom ? oldestDate : defaultFrom;
+      const olderUntil = currentViewDate.clone().previous().getStartDate();
+
+      const olderRange: FetchRange = { from: olderFrom, until: olderUntil };
+
+      const finalData = new Data({
+        accounts,
+        items,
+        budgets,
+        sections,
+        categories,
+        charts,
+        institutions,
+        transactions: recentTransactions,
+        investmentTransactions: recentInvestmentTransactions,
+        splitTransactions,
+        accountSnapshots: recentAccountSnapshots,
+        holdingSnapshots: recentHoldingSnapshots,
+        securitySnapshots: recentSecuritySnapshots,
+      });
+
+      if (olderFrom < olderUntil) {
+        const [
+          { transactions: olderTransactions, investmentTransactions: olderInvestmentTransactions },
+          {
+            accountSnapshots: olderAccountSnapshots,
+            holdingSnapshots: olderHoldingSnapshots,
+            securitySnapshots: olderSecuritySnapshots,
+          },
+        ] = await Promise.all([
+          fetchTransactions(accounts, olderRange),
+          fetchSnapshots(accounts, olderRange),
+        ]);
+
+        olderTransactions.forEach((t, id) => finalData.transactions.set(id, t));
+        olderInvestmentTransactions.forEach((t, id) =>
+          finalData.investmentTransactions.set(id, t),
+        );
+        olderAccountSnapshots.forEach((s, id) => finalData.accountSnapshots.set(id, s));
+        olderHoldingSnapshots.forEach((s, id) => finalData.holdingSnapshots.set(id, s));
+        olderSecuritySnapshots.forEach((s, id) => finalData.securitySnapshots.set(id, s));
+      }
+
+      finalData.status.isInit = true;
+      finalData.status.isLoading = false;
+      finalData.status.isError = false;
+      setData(finalData);
 
       indexedDb
         .clearAllData()
-        .then(() => indexedDb.saveAllData(newData))
+        .then(() => indexedDb.saveAllData(finalData))
         .catch(console.error);
     } catch (err) {
       console.error(err);

--- a/src/common/utils/Queue.test.ts
+++ b/src/common/utils/Queue.test.ts
@@ -55,4 +55,54 @@ describe("Queue", () => {
     // is what we're asserting — both runs returned without waiting.
     expect(true).toBe(true);
   });
+
+  it("caps concurrent in-flight tasks at maxInflight", async () => {
+    const q = new Queue({ maxInflight: 2 });
+    let inflight = 0;
+    let peak = 0;
+    const releasers: Array<() => void> = [];
+    const task = () =>
+      new Promise<void>((resolve) => {
+        inflight++;
+        peak = Math.max(peak, inflight);
+        releasers.push(() => {
+          inflight--;
+          resolve();
+        });
+      });
+
+    const runs = [q.add(task), q.add(task), q.add(task), q.add(task)];
+    // Yield so the queue can spin up its first 2 workers.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(inflight).toBe(2);
+    expect(peak).toBe(2);
+
+    // Release one slot — the next queued task should pick it up.
+    releasers.shift()!();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(inflight).toBe(2);
+    expect(peak).toBe(2);
+
+    // Drain the rest. Yield between releases so newly-started tasks have
+    // a chance to push their own releaser before the next drain step.
+    while (releasers.length) {
+      releasers.shift()!();
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    await Promise.all(runs);
+    expect(inflight).toBe(0);
+    expect(peak).toBe(2);
+  });
+
+  it("propagates task errors without leaking an in-flight slot", async () => {
+    const q = new Queue({ maxInflight: 1 });
+    await expect(
+      q.add(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    // If the slot leaked, this second add() would hang forever.
+    const out = await q.add(async () => "ok");
+    expect(out).toBe("ok");
+  });
 });

--- a/src/common/utils/Queue.ts
+++ b/src/common/utils/Queue.ts
@@ -1,36 +1,59 @@
 /**
- * Rate-limited async work queue. Lets at most `capacity` tasks complete
- * inside any sliding `windowMs` window. Tasks are added via `queue.add(fn)`
- * and execute as soon as a slot is available; callers `await` the result.
+ * Async work queue with two independent gates. Tasks are added via
+ * `queue.add(fn)` and execute as soon as both gates allow it; callers
+ * `await` the result.
  *
- * Used for paid / rate-limited external APIs (e.g. Polygon free-tier =
- * 5/min). Cache hits and other no-op work should NOT route through here —
- * only the operation that actually consumes a slot.
+ * Gates:
+ * - `capacity` (per `windowMs`) — sliding-window rate limit. Up to
+ *   `capacity` tasks may START inside any `windowMs` window. Built for
+ *   paid / rate-limited external APIs (e.g. Polygon free-tier = 5/min).
+ *   Cache hits and other no-op work should NOT route through here — only
+ *   the operation that actually consumes a slot. `capacity <= 0` disables
+ *   the rate gate.
+ * - `maxInflight` — concurrency cap. At most `maxInflight` tasks run
+ *   simultaneously. Built for browser fetch storms where queueing hundreds
+ *   of `fetch`/`cache.add` calls at once triggers
+ *   `ERR_INSUFFICIENT_RESOURCES` and silently aborts cache writes.
+ *   `maxInflight <= 0` (or unset) disables the concurrency gate.
  *
- * `capacity` may be a static number or a getter; the getter is re-evaluated
- * on every `add()` so env-driven caps can change at runtime (tests do this).
- * `capacity <= 0` disables the gate.
+ * `capacity` and `maxInflight` may each be a static number or a getter;
+ * getters are re-evaluated on every `add()` so env-driven caps can change
+ * at runtime (tests do this).
  */
 export interface QueueOptions {
-  capacity: number | (() => number);
+  capacity?: number | (() => number);
   windowMs?: number;
+  maxInflight?: number | (() => number);
 }
 
 export class Queue {
   private readonly getCapacity: () => number;
   private readonly windowMs: number;
+  private readonly getMaxInflight: () => number;
   private readonly timestamps: number[] = [];
+  private inflight = 0;
+  private readonly inflightWaiters: Array<() => void> = [];
 
   constructor(options: QueueOptions) {
-    const { capacity, windowMs = 60_000 } = options;
+    const { capacity = 0, windowMs = 60_000, maxInflight = 0 } = options;
     this.getCapacity = typeof capacity === "function" ? capacity : () => capacity;
     this.windowMs = windowMs;
+    this.getMaxInflight = typeof maxInflight === "function" ? maxInflight : () => maxInflight;
   }
 
   async add<T>(task: () => Promise<T>): Promise<T> {
-    const cap = this.getCapacity();
-    if (cap <= 0) return task();
+    await this.waitForRateSlot();
+    await this.acquireInflight();
+    try {
+      return await task();
+    } finally {
+      this.releaseInflight();
+    }
+  }
 
+  private async waitForRateSlot(): Promise<void> {
+    const cap = this.getCapacity();
+    if (cap <= 0) return;
     while (true) {
       const now = Date.now();
       const cutoff = now - this.windowMs;
@@ -39,7 +62,7 @@ export class Queue {
       }
       if (this.timestamps.length < cap) {
         this.timestamps.push(now);
-        return task();
+        return;
       }
       const oldest = this.timestamps[0]!;
       const sleepMs = Math.max(10, oldest + this.windowMs - now);
@@ -47,8 +70,27 @@ export class Queue {
     }
   }
 
+  private async acquireInflight(): Promise<void> {
+    const max = this.getMaxInflight();
+    if (max <= 0) return;
+    while (this.inflight >= max) {
+      await new Promise<void>((resolve) => this.inflightWaiters.push(resolve));
+    }
+    this.inflight++;
+  }
+
+  private releaseInflight(): void {
+    const max = this.getMaxInflight();
+    if (max <= 0) return;
+    this.inflight--;
+    const next = this.inflightWaiters.shift();
+    if (next) next();
+  }
+
   /** Test-only: drain the in-memory slot record. */
   reset(): void {
     this.timestamps.length = 0;
+    this.inflight = 0;
+    this.inflightWaiters.length = 0;
   }
 }

--- a/src/server/routes/accounts/get-snapshots.ts
+++ b/src/server/routes/accounts/get-snapshots.ts
@@ -3,6 +3,9 @@ import { Route, searchSnapshots, SearchSnapshotsOptions, optionalQueryString, va
 
 export type SnapshotsGetResponse = JSONSnapshotData[];
 
+const SNAPSHOT_TYPES = ["account_balance", "holding", "security"] as const;
+type SnapshotType = (typeof SNAPSHOT_TYPES)[number];
+
 export const getSnapshotsRoute = new Route<SnapshotsGetResponse>(
   "GET",
   "/snapshots",
@@ -27,11 +30,20 @@ export const getSnapshotsRoute = new Route<SnapshotsGetResponse>(
     const securityResult = optionalQueryString(req, "security-id");
     if (!securityResult.success) return validationError(securityResult.error!);
 
+    const typeResult = optionalQueryString(req, "snapshot-type");
+    if (!typeResult.success) return validationError(typeResult.error!);
+    if (typeResult.data && !SNAPSHOT_TYPES.includes(typeResult.data as SnapshotType)) {
+      return validationError(
+        `snapshot-type must be one of: ${SNAPSHOT_TYPES.join(", ")}`,
+      );
+    }
+
     const options: SearchSnapshotsOptions = {};
     if (startResult.data) options.startDate = startResult.data;
     if (endResult.data) options.endDate = endResult.data;
     if (accountResult.data) options.account_id = accountResult.data;
     if (securityResult.data) options.security_id = securityResult.data;
+    if (typeResult.data) options.snapshot_type = typeResult.data as SnapshotType;
 
     const snapshots = await searchSnapshots(user, options);
 


### PR DESCRIPTION
Closes #323 (step 3)

Steps 1 and 2 of #323 already shipped in #348 (security data in `/api/snapshots` + client IndexedDB + React state). This PR is step 3: mirror the per-month + per-account slicing & caching that the transactions sync already uses.

## Summary
- `fetchSnapshots` in `src/client/lib/hooks/sync.ts` is rewritten to mirror `fetchTransactions`: loop month-by-month from the current `ViewDate` back to `oldestTransactionDate`, issuing one request per (month, account) tuple for user-scoped account_balance + holding snapshots and one request per month for shared security snapshots.
- Months ending more than `THIRTY_DAYS` ago go through `cachedCall` (browser Cache API), so they're hit at most once across the user's lifetime. The current month always re-fetches so today's data stays fresh.
- Extend `GET /api/snapshots` with a `snapshot-type` query string (`account_balance | holding | security`, validated server-side) so the per-month security-only slice doesn't drag in the full user-scoped history.

## Why per-month + per-account
Previously, sync issued a single `GET /api/snapshots?start-date=<oldest>&end-date=<today+2>` request. As the issue notes, that single call already crosses 500ms and only grows with holding/snapshot count. Slicing month-by-month:
- Keeps any single network round-trip bounded by one month of data per account.
- Lets the browser Cache API skip past months entirely on subsequent loads (the URL is the cache key, identical month/account URLs hit cache instantly).
- Matches the access pattern `fetchTransactions` already validates in prod, so the dev story stays consistent.

## Test plan
- [x] `bun run tsc --noEmit` passes
- [x] `bun test` shows no new failures (19 pre-existing failures reproduce identically on upstream/main)
- [ ] Sandbox E2E: load the app, network tab shows one `/api/snapshots?...&account-id=…` per (month, account) + one `/api/snapshots?...&snapshot-type=security` per month; second load serves older months from cache; UI renders holdings, snapshots, and securities identically to the pre-slice path.