### PR TITLE
test(api-keys): add route coverage for POST/GET/DELETE /api-keys

### DIFF
--- a/src/server/routes/api-keys/delete-api-key.test.ts
+++ b/src/server/routes/api-keys/delete-api-key.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for DELETE /api/api-keys (Closes #358 — DELETE coverage).
+ *
+ * Mocks `pool.query` because `revokeApiKey` issues a single UPDATE there.
+ * The cross-user ownership check is enforced at the SQL level by the
+ * `WHERE user_id = $2` clause; these tests pin the route contract and
+ * verify the session user_id reaches the query unchanged (never a
+ * client-supplied value).
+ */
+
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+
+import { pool } from "server/lib/postgres/client";
+import { deleteApiKeyRoute } from "./delete-api-key";
+
+const originalQuery = pool.query.bind(pool);
+
+const mockQuery = mock(
+  (_sql: string, _values?: unknown[]): Promise<{ rows: unknown[]; rowCount: number | null }> =>
+    Promise.resolve({ rows: [], rowCount: 0 }),
+);
+
+(pool as unknown as { query: typeof mockQuery }).query = mockQuery;
+
+afterAll(() => {
+  (pool as unknown as { query: typeof originalQuery }).query = originalQuery;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+function makeReq(
+  query: Record<string, unknown>,
+  opts: { user?: { user_id: string; username: string } | null } = {},
+) {
+  const user =
+    opts.user === undefined ? { user_id: "u-1", username: "test" } : opts.user;
+  return {
+    method: "DELETE",
+    path: "/api-keys",
+    url: "http://x/api/api-keys",
+    headers: {},
+    query,
+    body: undefined,
+    session: {
+      id: "s-1",
+      user: user ?? undefined,
+      regenerate() {},
+      destroy() {},
+    },
+    ip: "127.0.0.1",
+  } as unknown as Parameters<typeof deleteApiKeyRoute.execute>[0];
+}
+
+const fakeRes = () =>
+  ({
+    statusCode: 200,
+    headersSent: false,
+    status() {
+      return this;
+    },
+    write() {
+      return true;
+    },
+    end() {},
+  }) as unknown as Parameters<typeof deleteApiKeyRoute.execute>[1];
+
+describe("delete-api-key", () => {
+  test("rejects unauthenticated requests", async () => {
+    const result = await deleteApiKeyRoute.execute(
+      makeReq({ key_id: "k-1" }, { user: null }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/not authenticated/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("rejects missing key_id query param", async () => {
+    const result = await deleteApiKeyRoute.execute(makeReq({}), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("returns failed when no rows are updated (not found / wrong owner / already revoked)", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const result = await deleteApiKeyRoute.execute(
+      makeReq({ key_id: "k-missing" }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/not found or already revoked/);
+  });
+
+  test("happy path returns { revoked: true } and pins user_id into the WHERE clause", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ key_id: "k-1" }], rowCount: 1 });
+    const result = await deleteApiKeyRoute.execute(makeReq({ key_id: "k-1" }), fakeRes());
+    expect(result?.status).toBe("success");
+    expect(result?.body).toEqual({ revoked: true });
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, values] = mockQuery.mock.calls[0];
+    expect(sql).toMatch(/WHERE key_id = \$1 AND user_id = \$2 AND revoked_at IS NULL/);
+    expect(values).toEqual(["k-1", "u-1"]);
+  });
+
+  test("cross-user revoke: the route always uses the *session* user_id, never a client-supplied value", async () => {
+    // User A attempts to revoke a key that belongs to User B. The session
+    // user (u-A) is the only value the route will accept for user_id, even
+    // if a future request body somehow tried to override it.
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const result = await deleteApiKeyRoute.execute(
+      makeReq({ key_id: "k-belongs-to-B" }, { user: { user_id: "u-A", username: "a" } }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    const [, values] = mockQuery.mock.calls[0];
+    expect(values).toEqual(["k-belongs-to-B", "u-A"]);
+  });
+});

--- a/src/server/routes/api-keys/get-api-keys.test.ts
+++ b/src/server/routes/api-keys/get-api-keys.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for GET /api/api-keys (Closes #358 — GET coverage).
+ *
+ * Mocks `pool.query` because that's what `listApiKeys` calls directly.
+ * Pattern: same monkey-patch-then-restore approach used in
+ * `accounts/post-suggest-category.test.ts`.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+
+import { pool } from "server/lib/postgres/client";
+import { getApiKeysRoute } from "./get-api-keys";
+
+const originalQuery = pool.query.bind(pool);
+
+const mockQuery = mock(
+  (_sql: string, _values?: unknown[]): Promise<{ rows: unknown[]; rowCount: number | null }> =>
+    Promise.resolve({ rows: [], rowCount: 0 }),
+);
+
+(pool as unknown as { query: typeof mockQuery }).query = mockQuery;
+
+afterAll(() => {
+  (pool as unknown as { query: typeof originalQuery }).query = originalQuery;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+function makeReq(opts: { user?: { user_id: string; username: string } | null } = {}) {
+  const user =
+    opts.user === undefined ? { user_id: "u-1", username: "test" } : opts.user;
+  return {
+    method: "GET",
+    path: "/api-keys",
+    url: "http://x/api/api-keys",
+    headers: {},
+    query: {},
+    body: undefined,
+    session: {
+      id: "s-1",
+      user: user ?? undefined,
+      regenerate() {},
+      destroy() {},
+    },
+    ip: "127.0.0.1",
+  } as unknown as Parameters<typeof getApiKeysRoute.execute>[0];
+}
+
+const fakeRes = () =>
+  ({
+    statusCode: 200,
+    headersSent: false,
+    status() {
+      return this;
+    },
+    write() {
+      return true;
+    },
+    end() {},
+  }) as unknown as Parameters<typeof getApiKeysRoute.execute>[1];
+
+describe("get-api-keys", () => {
+  test("rejects unauthenticated requests", async () => {
+    const result = await getApiKeysRoute.execute(makeReq({ user: null }), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/not authenticated/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("happy path scopes the SELECT to the caller's user_id", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          key_id: "k-1",
+          user_id: "u-1",
+          name: "laptop",
+          key_prefix: "bk_abc123",
+          scopes: ["transactions:suggest"],
+          created_at: "2026-05-01T00:00:00.000Z",
+          last_used_at: null,
+          revoked_at: null,
+          expires_at: null,
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const result = await getApiKeysRoute.execute(makeReq(), fakeRes());
+    expect(result?.status).toBe("success");
+    expect(result?.body?.api_keys).toHaveLength(1);
+    expect(result?.body?.api_keys[0].key_id).toBe("k-1");
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, values] = mockQuery.mock.calls[0];
+    expect(sql).toMatch(/WHERE user_id = \$1 AND revoked_at IS NULL/);
+    expect(values).toEqual(["u-1"]);
+  });
+
+  test("response surface omits key_hash and revoked_at (contract enforced by SELECT projection)", async () => {
+    // The repo's SELECT deliberately omits key_hash, and the listApiKeys
+    // helper sets `key_hash: ""` on the model before .toJSON() so the
+    // hash never enters the response. Pin that contract here.
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          key_id: "k-1",
+          user_id: "u-1",
+          name: "laptop",
+          key_prefix: "bk_abc123",
+          scopes: ["transactions:suggest"],
+          created_at: "2026-05-01T00:00:00.000Z",
+          last_used_at: null,
+          revoked_at: null,
+          expires_at: null,
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const result = await getApiKeysRoute.execute(makeReq(), fakeRes());
+    const row = result?.body?.api_keys[0] as Record<string, unknown> | undefined;
+    expect(row).toBeDefined();
+    // key_hash never leaves the server with real content.
+    expect(row?.key_hash === undefined || row?.key_hash === "" || row?.key_hash === null).toBe(
+      true,
+    );
+  });
+
+  test("empty result returns success with empty array", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const result = await getApiKeysRoute.execute(makeReq(), fakeRes());
+    expect(result?.status).toBe("success");
+    expect(result?.body?.api_keys).toEqual([]);
+  });
+});

--- a/src/server/routes/api-keys/post-api-keys.test.ts
+++ b/src/server/routes/api-keys/post-api-keys.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for POST /api/api-keys (Closes #358 — POST coverage).
+ *
+ * Mocking pattern: monkey-patch `apiKeysTable.insert` (the lowest-level
+ * write the route's `createApiKey` helper performs), following the same
+ * approach as `accounts/post-suggest-category.test.ts`. Avoids
+ * `mock.module("server", ...)` because Bun's module mock is process-wide
+ * and leaks into sibling test files in the same run.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+
+import { apiKeysTable } from "server/lib/postgres/models";
+import { postApiKeysRoute } from "./post-api-keys";
+
+const originalInsert = apiKeysTable.insert.bind(apiKeysTable);
+
+const mockInsert = mock(
+  async (
+    _row: unknown,
+    _returning?: string[],
+  ): Promise<Record<string, unknown> | null> => ({ key_id: "k-1" }),
+);
+
+(apiKeysTable as unknown as { insert: typeof mockInsert }).insert = mockInsert;
+
+afterAll(() => {
+  (apiKeysTable as unknown as { insert: typeof originalInsert }).insert = originalInsert;
+});
+
+beforeEach(() => {
+  mockInsert.mockReset();
+  mockInsert.mockResolvedValue({ key_id: "k-1" });
+});
+
+function makeReq(body: unknown, opts: { user?: { user_id: string; username: string } | null } = {}) {
+  const user =
+    opts.user === undefined ? { user_id: "u-1", username: "test" } : opts.user;
+  return {
+    method: "POST",
+    path: "/api-keys",
+    url: "http://x/api/api-keys",
+    headers: {},
+    query: {},
+    body,
+    session: {
+      id: "s-1",
+      user: user ?? undefined,
+      regenerate() {},
+      destroy() {},
+    },
+    ip: "127.0.0.1",
+  } as unknown as Parameters<typeof postApiKeysRoute.execute>[0];
+}
+
+const fakeRes = () =>
+  ({
+    statusCode: 200,
+    headersSent: false,
+    status() {
+      return this;
+    },
+    write() {
+      return true;
+    },
+    end() {},
+  }) as unknown as Parameters<typeof postApiKeysRoute.execute>[1];
+
+describe("post-api-keys", () => {
+  test("rejects unauthenticated requests", async () => {
+    const result = await postApiKeysRoute.execute(makeReq({}, { user: null }), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/not authenticated/);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  test("rejects missing body", async () => {
+    const result = await postApiKeysRoute.execute(makeReq(null), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/Body must be JSON/);
+  });
+
+  test("rejects missing name", async () => {
+    const result = await postApiKeysRoute.execute(
+      makeReq({ scopes: ["transactions:suggest"] }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/name is required/);
+  });
+
+  test("rejects empty/whitespace name", async () => {
+    const result = await postApiKeysRoute.execute(
+      makeReq({ name: "   ", scopes: ["transactions:suggest"] }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/name is required/);
+  });
+
+  test("rejects non-string name", async () => {
+    const result = await postApiKeysRoute.execute(
+      makeReq({ name: 42, scopes: ["transactions:suggest"] }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/name is required/);
+  });
+
+  test("rejects name longer than 255 chars", async () => {
+    const result = await postApiKeysRoute.execute(
+      makeReq({ name: "x".repeat(256), scopes: ["transactions:suggest"] }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/255 characters/);
+  });
+
+  test("rejects missing scopes array", async () => {
+    const result = await postApiKeysRoute.execute(makeReq({ name: "k" }), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/scopes must be a non-empty string array/);
+  });
+
+  test("rejects empty scopes array", async () => {
+    const result = await postApiKeysRoute.execute(
+      makeReq({ name: "k", scopes: [] }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/scopes must be a non-empty string array/);
+  });
+
+  test("rejects non-string-array scopes", async () => {
+    const result = await postApiKeysRoute.execute(
+      makeReq({ name: "k", scopes: [1, 2] }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/scopes must be a non-empty string array/);
+  });
+
+  test("rejects unknown scope", async () => {
+    const result = await postApiKeysRoute.execute(
+      makeReq({ name: "k", scopes: ["foo:bar"] }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/Unknown scope: foo:bar/);
+  });
+
+  test("rejects non-string expires_at", async () => {
+    const result = await postApiKeysRoute.execute(
+      makeReq({ name: "k", scopes: ["transactions:suggest"], expires_at: 12345 }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/expires_at must be an ISO timestamp string/);
+  });
+
+  test("rejects unparseable expires_at", async () => {
+    const result = await postApiKeysRoute.execute(
+      makeReq({ name: "k", scopes: ["transactions:suggest"], expires_at: "not-a-date" }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/not a valid ISO timestamp/);
+  });
+
+  test("rejects expires_at in the past", async () => {
+    const result = await postApiKeysRoute.execute(
+      makeReq({
+        name: "k",
+        scopes: ["transactions:suggest"],
+        expires_at: "2000-01-01T00:00:00.000Z",
+      }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/must be in the future/);
+  });
+
+  test("happy path returns key_id + prefix + plaintext, trimmed name", async () => {
+    mockInsert.mockResolvedValueOnce({ key_id: "k-42" });
+
+    const result = await postApiKeysRoute.execute(
+      makeReq({ name: "  laptop  ", scopes: ["transactions:suggest"] }),
+      fakeRes(),
+    );
+
+    expect(result?.status).toBe("success");
+    expect(result?.body?.key_id).toBe("k-42");
+    // Plaintext is generated client-side here; verify the bk_ scheme is preserved.
+    expect(result?.body?.plaintext.startsWith("bk_")).toBe(true);
+    expect(result?.body?.prefix).toBe(result!.body!.plaintext.slice(0, 11));
+
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const [row] = mockInsert.mock.calls[0] as [Record<string, unknown>, string[]];
+    expect(row.user_id).toBe("u-1");
+    expect(row.name).toBe("laptop");
+    expect(row.scopes).toEqual(["transactions:suggest"]);
+    expect(row.expires_at).toBeNull();
+  });
+
+  test("plaintext is generated each request and never persisted", async () => {
+    mockInsert.mockResolvedValueOnce({ key_id: "k-1" });
+    const result = await postApiKeysRoute.execute(
+      makeReq({ name: "k", scopes: ["transactions:suggest"] }),
+      fakeRes(),
+    );
+    const plaintext = result?.body?.plaintext;
+    expect(plaintext).toBeDefined();
+
+    const [row] = mockInsert.mock.calls[0] as [Record<string, unknown>, string[]];
+    // The DB row stores a hash + prefix; the raw plaintext must never be persisted.
+    expect(Object.values(row).some((v) => v === plaintext)).toBe(false);
+    expect(row.key_hash).toBeDefined();
+    expect(row.key_prefix).toBe(plaintext!.slice(0, 11));
+  });
+
+  test("happy path normalizes a valid future expires_at to ISO", async () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
+    const result = await postApiKeysRoute.execute(
+      makeReq({ name: "k", scopes: ["transactions:suggest"], expires_at: future }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("success");
+    const [row] = mockInsert.mock.calls[0] as [Record<string, unknown>, string[]];
+    expect(row.expires_at).toBe(future);
+  });
+
+  test("insert returning null surfaces as a Route-layer failure", async () => {
+    // `createApiKey` throws when `apiKeysTable.insert` resolves to null.
+    // The Route layer catches the throw and returns an error envelope —
+    // pin that the failure is surfaced (not silently turned into success).
+    mockInsert.mockResolvedValueOnce(null);
+    const result = await postApiKeysRoute.execute(
+      makeReq({ name: "k", scopes: ["transactions:suggest"] }),
+      fakeRes(),
+    );
+    expect(result?.status).not.toBe("success");
+  });
+});


### PR DESCRIPTION
Closes #358

## Summary
The `src/server/routes/api-keys/` directory had zero tests despite handling security-critical key issuance, listing, and revocation. This PR adds 26 tests covering every branch in the three route handlers. All three files reach 100% line + function coverage.

| File | Before | After |
|---|---|---|
| `post-api-keys.ts` | 0% | 100% |
| `get-api-keys.ts` | 0% | 100% |
| `delete-api-key.ts` | 0% | 100% |

## Branches covered (from the issue checklist)

### `POST /api-keys` — all 10 listed branches
1. Unauthenticated → `failed` ✓
2. `body == null` → `failed: Body must be JSON` ✓
3. Missing / empty / non-string `name` ✓
4. `name.length > 255` ✓
5. Missing / empty / non-array `scopes` ✓
6. Unknown scope ✓
7. `expires_at` non-string ✓
8. `expires_at` not parseable ✓
9. `expires_at` in the past ✓
10. Happy path (bk_ prefix, trim, single-show plaintext, ISO normalization) ✓

Bonus: `apiKeysTable.insert` returning null surfaces as a non-success envelope (not a swallowed success).

### `GET /api-keys`
1. Unauthenticated → `failed` ✓
2. Happy path → user-scoped `WHERE user_id = $1 AND revoked_at IS NULL` ✓
3. Response surface omits `key_hash` (the `Omit<…>` contract is pinned at runtime) ✓
4. Empty result envelope ✓

### `DELETE /api-keys`
1. Unauthenticated → `failed` ✓
2. Missing `key_id` query param → `failed` ✓
3. `revokeApiKey` returns false → `failed: Key not found or already revoked` ✓
4. Happy path → `{ revoked: true }` ✓
5. Cross-user ownership: the route always uses the *session* `user_id` in the WHERE clause, never a client-supplied value ✓

## Mocking pattern
Follows `accounts/post-suggest-category.test.ts`: monkey-patch the lowest-level dependency the route exercises (`apiKeysTable.insert` for POST, `pool.query` for GET/DELETE), restore in `afterAll`. Avoids `mock.module(...)` because Bun's module mock is process-wide and leaks into sibling test files in the same `bun test` run.

## Test plan
- [x] `bun test src/server/routes/api-keys` → 26 pass, 0 fail
- [x] `bun test` (full suite) → 519 pass (+26 over upstream), same 19 pre-existing failures, no new failures
- [x] `bun run tsc --noEmit` → clean
- [x] Coverage: `bun test src/server/routes/api-keys --coverage` shows all three route files at 100% line + function

Non-functional change (test-only), no sandbox spin needed.