### PR TITLE
docs(holdings): update price resolution to match most-recent-wins semantics

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@ Core models are defined in `src/common/models/`:
 - **Transaction** — a financial transaction
 - **Budget / BudgetFamily** — budget plans and groupings
 - **Item** — a connection to a financial institution
-- **Snapshot** — point-in-time record of account balances
+- **Snapshot** — point-in-time record of account balances, holdings, or security prices (discriminated by `snapshot_type`)
 - **Chart** — visualization configuration
 - **TransferPair** — pairs two transactions across accounts as a single transfer (suggested or confirmed)
 

--- a/docs/DESIGN_PATTERNS.md
+++ b/docs/DESIGN_PATTERNS.md
@@ -26,15 +26,17 @@ Budget, Section, and Category entities store scheduled amounts in a `capacities`
 
 `getActiveCapacity()` on `BudgetFamily` returns a default `new Capacity()` (zero amount, no date) when the array is empty. Display logic should handle zero-amount budgets gracefully (e.g., placeholder UI rather than blank cards).
 
-## Balance Calculation: 3-Tier Price Fallback
+## Balance Calculation: Holding Price Resolution
 
-Investment account balances use a prioritized price resolution strategy:
+Investment account balances pick between two recorded prices and fall back to inference only when neither is usable:
 
-1. **Institution price** — brokerage-reported price (most authoritative)
-2. **Security snapshot** — market data from Polygon API
-3. **Inferred price** — calculated from `institution_value / quantity`
+1. **Institution price** — brokerage-reported price on the holding snapshot itself
+2. **Security snapshot** — market data from Polygon (or any source written to `security_snapshots`)
+3. **Inferred price** — `institution_value / quantity`, used only when neither source above has a usable price
 
-Always use `getAccountBalance(account)` instead of accessing `account.balances.current` directly — it handles investment accounts correctly using this fallback chain.
+When both an institution price and a security snapshot exist, whichever was **recorded later wins**, with the security snapshot winning on a tie (so a fresh Polygon refresh between Plaid syncs supersedes a stale `institution_price`, and manual accounts — which never carry `institution_price` — always use the security snapshot). The security side never consumes a future snapshot: at view-date `YYYY-MM`, the most recent entry whose `yearMonth` is on or before `YYYY-MM` is used.
+
+Always use `getAccountBalance(account)` instead of accessing `account.balances.current` directly — it handles investment accounts correctly using this resolution.
 
 See `src/client/lib/hooks/calculation/holdings.ts` for the `getPriceForHolding` implementation.
 


### PR DESCRIPTION
## Summary

`docs/DESIGN_PATTERNS.md` described the holding price strategy as a strict 3-tier fallback (institution → security snapshot → inferred) with institution price as *"most authoritative"*. Post-#349 the actual code in `src/client/lib/hooks/calculation/holdings.ts:99-167` (`getPriceForHolding`) compares the **source dates** of the two recorded prices and picks the more recent one — security snapshot wins on a tie. This was your 2026-05-13 directive and shipped through PRs #349 and #350.

The updated docs now describe:
- The pick-by-source-date semantics with security-wins-on-tie
- The walk-back rule (security snapshot's yearMonth must be ≤ view date)
- Why manual accounts always use the security side (no `institution_price`)
- Inferred fallback only when neither source is usable

Also clarify `docs/ARCHITECTURE.md` "Snapshot" definition: snapshots cover account balances, holdings, AND security prices, discriminated by `snapshot_type`. The previous one-liner listed only account balances.

Pure markdown; no source touched.

## Test plan
- [ ] DESIGN_PATTERNS.md reads correctly against `getPriceForHolding` source
- [ ] ARCHITECTURE.md "Snapshot" line matches `SnapshotModel`'s discriminated union