### PR TITLE
fix(holdings): catch money-market sweeps in cash inference

### DIFF
--- a/src/server/lib/compute-tools/cash-holding.test.ts
+++ b/src/server/lib/compute-tools/cash-holding.test.ts
@@ -158,6 +158,68 @@ describe("inferCashHoldings", () => {
     expect(result).toHaveLength(0);
   });
 
+  // #368: prevent duplicate cash rows when Plaid reports cash via a security
+  // shape that fails the metadata flags (money-market fund / proprietary
+  // sweep). The holding-level heuristic — `institution_price === 1` and a
+  // falsy `cost_basis` — mirrors the FE detector and absorbs these cases.
+  test("skips when a holding has institution_price=1 and falsy cost_basis (money-market / proprietary sweep)", async () => {
+    const account = makeAccount({ balances: { current: 1500, iso_currency_code: "USD" } });
+    const holdings = [
+      makeHolding({ institution_value: 1000 }),
+      makeHolding({
+        holding_id: "h-2",
+        security_id: "sec-vmfxx",
+        quantity: 200,
+        institution_price: 1,
+        institution_value: 200,
+        cost_basis: 0,
+      }),
+    ];
+    const securities = [
+      makeSecurity(),
+      // VMFXX-shape: NOT type=cash, NOT is_cash_equivalent, NOT CUR:* —
+      // the security flags don't say "cash" but the holding clearly is.
+      makeSecurity({
+        security_id: "sec-vmfxx",
+        ticker_symbol: "VMFXX",
+        name: "Vanguard Federal Money Market Fund",
+        type: "etf",
+        is_cash_equivalent: null,
+      }),
+    ];
+
+    const result = await inferCashHoldings([account], holdings, securities, mockEnsureCash);
+
+    expect(result).toHaveLength(0);
+    expect(mockEnsureCash).toHaveBeenCalledTimes(0);
+  });
+
+  test("skips when cost_basis is null (DB-NULL collapse) and institution_price=1", async () => {
+    const account = makeAccount({ balances: { current: 1500 } });
+    const holdings = [
+      makeHolding({
+        holding_id: "h-cash",
+        security_id: "sec-sweep",
+        quantity: 200,
+        institution_price: 1,
+        institution_value: 200,
+        cost_basis: null as unknown as number,
+      }),
+    ];
+    const securities = [
+      makeSecurity({
+        security_id: "sec-sweep",
+        ticker_symbol: "QACDS",
+        type: "etf",
+        is_cash_equivalent: false,
+      }),
+    ];
+
+    const result = await inferCashHoldings([account], holdings, securities, mockEnsureCash);
+
+    expect(result).toHaveLength(0);
+  });
+
   test("skips non-investment accounts entirely", async () => {
     const account = makeAccount({ type: AccountType.Depository });
     const result = await inferCashHoldings([account], [], [], mockEnsureCash);

--- a/src/server/lib/compute-tools/cash-holding.ts
+++ b/src/server/lib/compute-tools/cash-holding.ts
@@ -79,6 +79,23 @@ const isCashLikeSecurity = (sec: JSONSecurity | undefined): boolean => {
 };
 
 /**
+ * Holding-shaped cash detector. Mirrors the FE's `isCash` heuristic
+ * (`HoldingsComposition`): cash holdings always quote `institution_price = 1`
+ * and never carry a real cost basis. This catches money-market funds and
+ * broker-proprietary cash sweeps that don't surface as `type='cash'` /
+ * `is_cash_equivalent` / `CUR:*` at the *security* layer (#368).
+ *
+ * Falsy `cost_basis` covers both DB-NULL and the `?? 0` collapse that
+ * happens on serialisation, so this matches whether the holding came
+ * straight from Plaid or round-tripped through the snapshot model.
+ */
+const isHoldingCashLike = (h: JSONHolding, sec: JSONSecurity | undefined): boolean => {
+  if (isCashLikeSecurity(sec)) return true;
+  if (h.institution_price === 1 && (h.cost_basis === null || h.cost_basis === 0)) return true;
+  return false;
+};
+
+/**
  * Threshold (USD) below which we treat the broker-reported delta as
  * accumulated noise (pending sweeps, rounding) and skip inferring a row.
  * Picked low enough to catch real cash positions, high enough to avoid
@@ -117,7 +134,7 @@ export const inferCashHoldings = async (
 
     const accountHoldings = incomingHoldings.filter((h) => h.account_id === account.account_id);
 
-    const hasCash = accountHoldings.some((h) => isCashLikeSecurity(securityById.get(h.security_id)));
+    const hasCash = accountHoldings.some((h) => isHoldingCashLike(h, securityById.get(h.security_id)));
     if (hasCash) continue;
 
     const nonCashTotal = accountHoldings.reduce((s, h) => {


### PR DESCRIPTION
Closes #368.

## Summary
`isCashLikeSecurity` only matched `type='cash'`, `is_cash_equivalent`, or a `CUR:*` ticker. Money-market funds (VMFXX et al.) and broker proprietary cash sweeps (QACDS et al.) frequently report under `type='etf'` with `is_cash_equivalent=null`, slipping through the security-metadata check. The inference then synthesised a USD-cash holding alongside Plaid's already-cash position, producing the duplicate row Hoie reported.

Added `isHoldingCashLike` — a holding-shaped detector that layers on top of `isCashLikeSecurity` and additionally returns true when `institution_price === 1 && (cost_basis === null || cost_basis === 0)`. That's the same heuristic the FE uses in `getHoldingsValueData` to detect cash, so client and server now agree on what counts.

## Changes
- `src/server/lib/compute-tools/cash-holding.ts` — add `isHoldingCashLike`, use it in the `hasCash` short-circuit instead of `isCashLikeSecurity`.
- `src/server/lib/compute-tools/cash-holding.test.ts` — 2 new tests covering the VMFXX shape (`type='etf'` + falsy `is_cash_equivalent` + `cost_basis: 0`) and the DB-NULL `cost_basis` collapse path.

## Backfill
Existing duplicate rows in prod self-heal on the next Plaid sync: `upsertAndDeleteHoldingsWithSnapshots` writes a zero-quantity snapshot and soft-deletes the orphan inferred holding when its `holding_id` falls out of the incoming set (which it will, now that the new sync's `inferCashHoldings` returns `[]` for affected accounts). The FE filters zero-value rows out of the composition table, so the duplicate stops rendering after one sync. No DB migration needed.

## Verification
- 391/391 server tests pass (14/14 in the cash-holding suite, including the two new cases).
- Typecheck clean, lint clean.
- Sandbox URL delivered via Discord — not posted publicly.

## Test plan
- [ ] Spin sandbox on the branch, check the holdings composition for the Chase/E*TRADE accounts that were showing duplicate cash rows. Only one cash row should render on the current viewDate.
- [ ] Confirm the inferred USD row gets soft-deleted on the next sync (look for a zero-quantity snapshot dated post-deploy in the holding-snapshots store).