### PR TITLE
fix(sync): dedupe Plaid securities before upserting holdings

### DIFF
--- a/src/server/lib/compute-tools/sync-plaid.test.ts
+++ b/src/server/lib/compute-tools/sync-plaid.test.ts
@@ -3,8 +3,9 @@ import {
   buildTransactionLookupMaps,
   findStoredTransaction,
   getPlaidRemovedInvestmentTransactions,
+  remapHoldingsToCanonicalSecurityIds,
 } from "./sync-plaid";
-import type { JSONTransaction, JSONInvestmentTransaction } from "common";
+import type { JSONHolding, JSONTransaction, JSONInvestmentTransaction } from "common";
 
 // Minimal factory helpers
 const makeTx = (overrides: Partial<JSONTransaction>): JSONTransaction =>
@@ -154,5 +155,76 @@ describe("getPlaidRemovedInvestmentTransactions", () => {
     ];
     const result = getPlaidRemovedInvestmentTransactions([], stored);
     expect(result).toHaveLength(2);
+  });
+});
+
+// ─── remapHoldingsToCanonicalSecurityIds ──────────────────────────────────────
+
+const makeHolding = (overrides: Partial<JSONHolding>): JSONHolding =>
+  ({
+    holding_id: "acc-1_plaid-sec",
+    account_id: "acc-1",
+    security_id: "plaid-sec",
+    institution_price: 100,
+    institution_value: 500,
+    cost_basis: 400,
+    quantity: 5,
+    iso_currency_code: "USD",
+    unofficial_currency_code: null,
+    institution_price_as_of: "2026-05-01",
+    ...overrides,
+  } as unknown as JSONHolding);
+
+describe("remapHoldingsToCanonicalSecurityIds", () => {
+  it("rewrites security_id + holding_id when the Plaid ID dedupes to a canonical one (#370)", () => {
+    const holdings = [makeHolding({ holding_id: "acc-1_plaid-sec", security_id: "plaid-sec" })];
+    const idMap = { "plaid-sec": "canonical-sec" };
+    const result = remapHoldingsToCanonicalSecurityIds(holdings, idMap);
+    expect(result).toHaveLength(1);
+    expect(result[0].security_id).toBe("canonical-sec");
+    expect(result[0].holding_id).toBe("acc-1_canonical-sec");
+  });
+
+  it("passes through unchanged when the security_id is already canonical", () => {
+    const original = makeHolding({ holding_id: "acc-1_already-canon", security_id: "already-canon" });
+    const idMap = { "already-canon": "already-canon" };
+    const result = remapHoldingsToCanonicalSecurityIds([original], idMap);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(original); // same reference — no new object allocated
+  });
+
+  it("drops holdings whose security_id is missing from idMap", () => {
+    const holdings = [
+      makeHolding({ holding_id: "acc-1_known", security_id: "known" }),
+      makeHolding({ holding_id: "acc-1_missing", security_id: "missing" }),
+    ];
+    const idMap = { known: "known" };
+    const result = remapHoldingsToCanonicalSecurityIds(holdings, idMap);
+    expect(result).toHaveLength(1);
+    expect(result[0].security_id).toBe("known");
+  });
+
+  it("preserves other holding fields (quantity, cost_basis, prices) across the remap", () => {
+    const holdings = [
+      makeHolding({
+        holding_id: "acc-1_plaid-sec",
+        security_id: "plaid-sec",
+        quantity: 12.5,
+        institution_price: 200,
+        institution_value: 2500,
+        cost_basis: 1800,
+      }),
+    ];
+    const idMap = { "plaid-sec": "canonical-sec" };
+    const [out] = remapHoldingsToCanonicalSecurityIds(holdings, idMap);
+    expect(out).toMatchObject({
+      account_id: "acc-1",
+      security_id: "canonical-sec",
+      holding_id: "acc-1_canonical-sec",
+      quantity: 12.5,
+      institution_price: 200,
+      institution_value: 2500,
+      cost_basis: 1800,
+    });
   });
 });

--- a/src/server/lib/compute-tools/sync-plaid.ts
+++ b/src/server/lib/compute-tools/sync-plaid.ts
@@ -1,5 +1,6 @@
 import {
   JSONAccount,
+  JSONHolding,
   JSONItem,
   ItemProvider,
   RemovedInvestmentTransaction,
@@ -263,12 +264,23 @@ export const syncPlaidAccounts = async (item_id: string) => {
       // Plaid didn't surface cash as a holding. The inferred row is a
       // real holding snapshot — same data path as Plaid-provided cash —
       // so the UI is identical regardless of source (Hoie 2026-05-14).
+      // Inference runs on the *raw* Plaid response so `isCashLikeSecurity`'s
+      // securityById lookup still resolves (Plaid IDs match both ends).
       const inferredCash = await inferCashHoldings(accounts, holdings, securities);
-      const allHoldings = inferredCash.length ? [...holdings, ...inferredCash] : holdings;
 
       await upsertAccountsWithSnapshots(user, accounts, storedAccounts);
+
+      // Dedupe securities first, then remap Plaid holdings to the canonical
+      // security_ids before upserting them. Otherwise holdings get written
+      // with Plaid's pre-dedupe security_ids while `upsertSecuritiesWithSnapshots`
+      // collapses them to existing canonical rows — leaving orphan holdings
+      // pointing at security_ids that have no row in `securities` (#370).
+      // Same shape `sync-simple-fin.ts` already uses.
+      const idMap = await upsertSecuritiesWithSnapshots(securities);
+      const mappedHoldings = remapHoldingsToCanonicalSecurityIds(holdings, idMap);
+
+      const allHoldings = inferredCash.length ? [...mappedHoldings, ...inferredCash] : mappedHoldings;
       await upsertAndDeleteHoldingsWithSnapshots(user, allHoldings, storedHoldings);
-      await upsertSecuritiesWithSnapshots(securities);
 
       return accounts;
     })
@@ -301,3 +313,28 @@ const getOneMonthBefore = (date?: Date) => {
   newDate.setMonth(newDate.getMonth() - 1);
   return newDate;
 };
+
+/**
+ * Remap each holding's `security_id` to the canonical ID from the
+ * security dedupe step. Also rewrites `holding_id` (Plaid format
+ * `${account_id}_${security_id}`) so the holdings table key tracks the
+ * canonical security rather than Plaid's pre-dedupe ID. Holdings whose
+ * security_id is missing from `idMap` are dropped — that shape shouldn't
+ * happen in practice (Plaid always returns securities for the holdings
+ * it reports), but we'd rather skip than write an orphan.
+ *
+ * Lives at module scope so unit tests can exercise the mapping logic in
+ * isolation (#370).
+ */
+export const remapHoldingsToCanonicalSecurityIds = (
+  holdings: JSONHolding[],
+  idMap: Record<string, string>,
+): JSONHolding[] =>
+  holdings
+    .map((h) => {
+      const canonical = idMap[h.security_id];
+      if (!canonical) return undefined;
+      if (canonical === h.security_id) return h;
+      return { ...h, security_id: canonical, holding_id: `${h.account_id}_${canonical}` };
+    })
+    .filter((h): h is JSONHolding => !!h);


### PR DESCRIPTION
Closes #370.

## Why
`sync-plaid` upserted holdings *before* deduping securities (PR #350 + #353 era). `upsertSecuritiesWithSnapshots` then collapsed any Plaid security whose ticker matched an existing canonical row to the canonical `security_id`, but holdings still carried Plaid's pre-dedupe ID — orphan holdings pointing at a `security_id` with no row in the `securities` table. The FE's `isCash` heuristic (price=1, null cost basis) then labels them "Cash" and the user sees duplicate cash rows.

This is what produced the duplicate Hoie reported on 2026-05-15 after #369 merged. My #369 fix addressed a different (also real) corner of the cash-detection space — MM-fund/proprietary-sweep false negatives — but didn't touch the upsert order.

## What
Mirror the shape `sync-simple-fin` already uses:

```ts
const idMap = await upsertSecuritiesWithSnapshots(securities);
const mappedHoldings = remapHoldingsToCanonicalSecurityIds(holdings, idMap);
const allHoldings = inferredCash.length ? [...mappedHoldings, ...inferredCash] : mappedHoldings;
await upsertAndDeleteHoldingsWithSnapshots(user, allHoldings, storedHoldings);
```

The `remapHoldingsToCanonicalSecurityIds` helper is exported so unit tests can exercise it in isolation. It rewrites both `security_id` and the Plaid-format `${account_id}_${security_id}` `holding_id`; passes through holdings whose security_id is already canonical; drops holdings whose security_id is missing from `idMap` (defensive — Plaid always returns securities for the holdings it reports, but we'd rather skip than write an orphan).

Cash inference (`inferCashHoldings`) still runs first against the raw Plaid response so `isCashLikeSecurity` / `isHoldingCashLike` can resolve via Plaid's IDs. Inferred-cash holdings already reference the canonical USD-cash `security_id` (from `ensureUSDCashSecurity`) so they bypass the remap.

## Backfill
Automatic — no migration. On the next Plaid sync after deploy:
1. Plaid returns the same orphan-shaped holding with its pre-dedupe security_id.
2. We dedupe → canonical → remap holdings → upsert under the canonical `holding_id`.
3. The old orphan `holding_id` is no longer in the incoming set, so `upsertAndDeleteHoldingsWithSnapshots`'s "removed" pass writes a zero-quantity snapshot.
4. The FE filters `value === 0` rows out of the composition table → the duplicate row disappears.

## Verification
- `bun test src/server` — 421/421 pass (4 new tests on the remap helper).
- `bun run typecheck`, `bun run lint` — clean.
- Sandbox spin + URL on request via Discord — not posted publicly.

## Sandbox repro of the bug (before fix)
3 orphan-security holdings across the sandbox prod-clone (Chase + 2 others). Chase's holdings table renders `[<ticker>, Cash, Cash]` — confirmed via Playwright.

## Test plan
- [ ] Sandbox spin on this branch, check Chase holdings composition. Until a real Plaid sync runs (sandbox has no Plaid creds), the existing orphan snapshots still display — but the new sync logic is correct. The behavioral E2E is covered by the unit tests on the mapping function + the existing `create-snapshots.test.ts` coverage on the removal pass.
- [ ] After deploy + first prod Plaid sync, confirm the orphan rows clear (one zero-quantity snapshot per orphan, then no row rendered).