### PR TITLE
fix(accounts-donut): mirror per-row gate so change widget matches row sum

### DIFF
--- a/src/client/components/AccountsDonut/BalanceInfo.tsx
+++ b/src/client/components/AccountsDonut/BalanceInfo.tsx
@@ -2,7 +2,6 @@ import { DonutData, useAppContext } from "client";
 import { Changes } from "client/components";
 
 interface Props {
-  balanceTotal: number;
   currencySymbol: string;
   donutData: DonutData[];
   totalCredit: number;
@@ -11,7 +10,6 @@ interface Props {
 }
 
 export const BalanceInfo = ({
-  balanceTotal,
   currencySymbol,
   donutData,
   totalCredit,
@@ -24,17 +22,25 @@ export const BalanceInfo = ({
   const viewDateSpan = Math.max(-viewDate.getSpanFrom(new Date()), 0);
   const previousDate = viewDate.clone().previous().getEndDate();
 
-  const previousAmount = donutData.reduce((a, { id }) => {
+  // Mirror per-row gate (AccountsTable/Balance.tsx: `!!previousAmount`): skip accounts
+  // with no usable previous-period entry on BOTH sides — otherwise the donut counts
+  // those accounts' current balance while the per-row widgets don't, overstating change.
+  let comparableCurrent = 0;
+  let comparablePrevious = 0;
+  for (const { id, value } of donutData) {
     const balanceHistory = balanceData.get(id);
-    if (!balanceHistory) return a;
-    return a + (balanceHistory.get(previousDate) || 0);
-  }, 0);
+    if (!balanceHistory) continue;
+    const prev = balanceHistory.get(previousDate) || 0;
+    if (!prev) continue;
+    comparableCurrent += value;
+    comparablePrevious += prev;
+  }
 
   return (
     <div className="BalanceInfo">
       <Changes
-        currentAmount={balanceTotal}
-        previousAmount={previousAmount}
+        currentAmount={comparableCurrent}
+        previousAmount={comparablePrevious}
         currencySymbol={currencySymbol}
       />
       <div className="label">from&nbsp;last&nbsp;{viewDate.getInterval()}</div>

--- a/src/client/components/AccountsDonut/index.tsx
+++ b/src/client/components/AccountsDonut/index.tsx
@@ -37,7 +37,6 @@ export const AccountsDonut = ({
         </div>
       </div>
       <BalanceInfo
-        balanceTotal={balanceTotal}
         currencySymbol={currencySymbol}
         donutData={donutData}
         totalCredit={totalCredit}


### PR DESCRIPTION
Closes #357

## Summary

`AccountsDonut`'s `BalanceInfo` summed `previousAmount` across **every** donut account (`prev || 0`), while `AccountsTable`'s per-row Changes widget hides itself when `!previousAmount`. The headline "from last month" change therefore included the current balance of accounts with missing/zero previous-period entries on the **current** side but not the **previous** side, overstating the gap by exactly the current balance of any such account.

Per the issue body's repro, the gap was `$[redacted] − $[redacted] = $[redacted]`, which equaled IBM-RBA's current balance — the one asset row with no Changes widget at all.

## Change

`src/client/components/AccountsDonut/BalanceInfo.tsx` now builds `comparableCurrent` / `comparablePrevious` from only the accounts that have a usable previous-period entry, mirroring `AccountsTable/Balance.tsx`'s `!!previousAmount` gate. Both numbers feed `<Changes>` so the donut's headline change shows the same total a user can reconcile by adding the visible per-row widgets in the table.

The donut center's `balanceTotal` label is unchanged — still the full asset total. `balanceTotal` is no longer needed as a `BalanceInfo` prop and is dropped from the interface.

## Math verification (against issue body's reproduction)

Before:
- `currentAmount = balanceTotal` = `$[redacted]` (full asset sum)
- `previousAmount = Σ(prev || 0)` over all 11 asset rows, missing 1 row's prev → underweighted
- Displayed change = `+$[redacted]`

After:
- `comparableCurrent = Σ(value)` over the 10 rows with `prev > 0`
- `comparablePrevious = Σ(prev)` over the same 10 rows
- Displayed change = sum of visible per-row Changes = `+9593.11 − 20704.11 + 4331.77 + 1039.68 + 7031.96 = +$[redacted]`
- IBM-RBA (`prev = 0`) is excluded from both sides; \$[redacted] gap disappears.

## Test plan

- [x] `bun run tsc --noEmit` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — `521 pass / 19 fail`; identical pass count and failure set as `upstream/main` (all 19 pre-existing failures are in `holdings.test.ts` / `inferCostBasis` / security price index, none touch `AccountsDonut`)
- [ ] Sandbox E2E: load `/accounts`, verify donut "from last month" value equals the sum of per-row Changes shown in `AccountsTable` (structural invariant — robust to sandbox numeric scrambling, since scrambling preserves the donut-vs-rows identity)

## Out of scope (flagged in issue, not addressed here)

- `holding_snapshots.institution_value = 0` rows where `institution_price × quantity > 0` — separate root cause
- `AccountsPage` `balanceTotal` using `|| fallback` where `??` would be more precise

---

*[Edited 2026-06-28: redacted dollar figures via a retroactive sweep after the daily-security-review's body-scan + shorthand-currency regex gap (found via issue #381 — see channel 1520705621228388514). Original detail removed.]*
