### PR TITLE
chore(env): document POLYGON_RATE_LIMIT_PER_MIN override in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ PLAID_SECRET_SANDBOX=000000000
 
 POLYGON_API_KEY=000000000
 
+# Optional: cap outbound Polygon requests per minute. Free tier is 5/min;
+# set to 0 to disable the rate-limit gate (paid tiers / tests).
+# Default: 5. See src/server/lib/polygon.ts.
+# POLYGON_RATE_LIMIT_PER_MIN=5
+
 # PostgreSQL Configuration
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432


### PR DESCRIPTION
## Summary

\`process.env.POLYGON_RATE_LIMIT_PER_MIN\` is read in \`src/server/lib/polygon.ts:38\` (default 5; setting to 0 disables the gate) and exercised by \`polygon.test.ts\`. It's documented in the inline comment at \`polygon.ts:30-33\` but **missing from `.env.example`** — devs spinning up the app for a paid Polygon tier (or skipping the gate in a sandbox test) have no hint the knob exists.

Mirrors the recently-merged #360 (LOG_LEVEL). Comment-only block, no behavior change.

## Diff

```
+# Optional: cap outbound Polygon requests per minute. Free tier is 5/min;
+# set to 0 to disable the rate-limit gate (paid tiers / tests).
+# Default: 5. See src/server/lib/polygon.ts.
+# POLYGON_RATE_LIMIT_PER_MIN=5
```

## Test plan

- [x] Source default verified (polygon.ts:35-43): unset or invalid → 5; numeric → floored.
- [x] No new env-var introduced — pure documentation of an existing one.
- [x] Diff is comment-only; no source file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)