### PR TITLE
feat(holdings): Investment Performance widget (cash-excluded MWR + index TWR)

### DIFF
--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -13,6 +13,7 @@ import {
   DynamicCapacityInput,
   Graph,
   HoldingsComposition,
+  PerformanceBenchmark,
   InstitutionSpan,
   MoneyLabel,
   ToggleInput,
@@ -181,6 +182,7 @@ export const AccountProperties = ({ account }: Props) => {
         </>
       )}
       {type === AccountType.Investment && <HoldingsComposition account={account} />}
+      {type === AccountType.Investment && <PerformanceBenchmark account={account} />}
       {!isManualAccount && (
         <>
           <div className="propertyLabel">Balance&nbsp;Graph&nbsp;Options</div>

--- a/src/client/components/PerformanceBenchmark/index.css
+++ b/src/client/components/PerformanceBenchmark/index.css
@@ -1,0 +1,89 @@
+.performanceBenchmark {
+  padding: 0.6em 0.75em;
+  font-size: 0.85em;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4em;
+}
+
+.performanceWindowPicker {
+  display: flex;
+  gap: 0.25em;
+  margin-bottom: 0.3em;
+}
+
+.performanceWindowPicker button {
+  flex: 1;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 0.25em;
+  color: rgba(255, 255, 255, 0.7);
+  padding: 0.25em 0;
+  font-size: 0.85em;
+  cursor: pointer;
+}
+
+.performanceWindowPicker button:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.performanceWindowPicker button.active {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.95);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.performanceRow {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5em;
+  align-items: baseline;
+}
+
+.performanceRow.gap {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding-top: 0.3em;
+  margin-top: 0.1em;
+}
+
+.performanceLabel {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.performanceValues {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.1em;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.performanceValues .cum {
+  font-weight: 600;
+}
+
+.performanceValues .ann {
+  font-size: 0.8em;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.performanceValues.positive {
+  color: #4ade80;
+}
+
+.performanceValues.negative {
+  color: #f87171;
+}
+
+.performanceValues .no-data {
+  color: rgba(255, 255, 255, 0.4);
+  font-style: italic;
+}
+
+.performanceFootnote {
+  font-size: 0.75em;
+  color: rgba(255, 255, 255, 0.4);
+  font-style: italic;
+  margin-top: 0.3em;
+}

--- a/src/client/components/PerformanceBenchmark/index.css
+++ b/src/client/components/PerformanceBenchmark/index.css
@@ -50,6 +50,13 @@
   color: rgba(255, 255, 255, 0.75);
 }
 
+.performanceLabelHint {
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.85em;
+  font-style: italic;
+  margin-left: 0.25em;
+}
+
 .performanceValues {
   display: flex;
   flex-direction: column;

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -7,6 +7,7 @@ import {
   valueAt,
   buildPriceAt,
   findBenchmarkSecurityId,
+  firstPricedSnapshotDate,
   earliestDataDate,
 } from "client/lib/hooks/calculation/benchmark";
 import "./index.css";
@@ -97,22 +98,31 @@ export const PerformanceBenchmark = ({ account }: Props) => {
 
     const mwr = computeMWR({ flows, vStart, vEnd, windowStart, windowEnd });
 
-    // For the benchmark we want STRICT prices (no pre-history fallback) so
-    // we don't show a misleading comparison against a stale earliest-known
-    // price when the window extends before our VOO snapshot history.
+    // Benchmark: prefer strict prices over the user's full window, but if
+    // the user-chosen window predates our VOO snapshot history, narrow the
+    // benchmark window to [first_VOO_snap, windowEnd] so the user still
+    // sees a real comparison number — clearly labeled with the actual
+    // benchmark start date. Hide the gap row when the windows differ since
+    // MWR-over-3Y vs. TWR-over-11mo isn't apples-to-apples.
     const benchmarkSecId = findBenchmarkSecurityId(securitySnapshots, BENCHMARK_TICKER);
     let benchmark: ReturnType<typeof computeBenchmarkTWR> | null = null;
-    let benchmarkWindowMismatch = false;
+    let benchmarkStart: string | null = null;
+    let benchmarkNarrowed = false;
     if (benchmarkSecId) {
-      const priceStart = priceAt(benchmarkSecId, windowStart, { strict: true });
+      const firstSnap = firstPricedSnapshotDate(securitySnapshots, benchmarkSecId);
+      const effectiveStart =
+        firstSnap && firstSnap > windowStart ? firstSnap : windowStart;
+      benchmarkNarrowed = effectiveStart !== windowStart;
+      const priceStart = priceAt(benchmarkSecId, effectiveStart, { strict: true });
       const priceEnd = priceAt(benchmarkSecId, windowEnd, { strict: true });
-      if (priceStart && priceEnd) {
-        benchmark = computeBenchmarkTWR({ priceStart, priceEnd, windowStart, windowEnd });
-      } else if (priceAt(benchmarkSecId, windowEnd) !== null) {
-        // We have end-price but not start-price → window predates our
-        // benchmark snapshot history. Display a "not available for this
-        // window" hint rather than silently dropping the row.
-        benchmarkWindowMismatch = true;
+      if (priceStart && priceEnd && effectiveStart < windowEnd) {
+        benchmark = computeBenchmarkTWR({
+          priceStart,
+          priceEnd,
+          windowStart: effectiveStart,
+          windowEnd,
+        });
+        benchmarkStart = effectiveStart;
       }
     }
 
@@ -120,8 +130,10 @@ export const PerformanceBenchmark = ({ account }: Props) => {
       (new Date(windowEnd).getTime() - new Date(windowStart).getTime()) / (1000 * 60 * 60 * 24 * 365);
     const suppressAnnualized = yearsInWindow < 0.5;
 
+    // Only compare annualized rates when both legs cover the same window.
+    // Otherwise gap is mixing a long-window MWR with a short-window TWR.
     const gap =
-      mwr.annualized !== null && benchmark
+      mwr.annualized !== null && benchmark && !benchmarkNarrowed
         ? mwr.annualized - benchmark.annualized
         : null;
 
@@ -134,7 +146,8 @@ export const PerformanceBenchmark = ({ account }: Props) => {
       mwr,
       benchmark,
       benchmarkAvailable: benchmarkSecId !== null,
-      benchmarkWindowMismatch,
+      benchmarkStart,
+      benchmarkNarrowed,
       gap,
       suppressAnnualized,
       isClamped,
@@ -148,7 +161,8 @@ export const PerformanceBenchmark = ({ account }: Props) => {
     mwr,
     benchmark,
     benchmarkAvailable,
-    benchmarkWindowMismatch,
+    benchmarkStart,
+    benchmarkNarrowed,
     gap,
     suppressAnnualized,
     isClamped,
@@ -188,7 +202,12 @@ export const PerformanceBenchmark = ({ account }: Props) => {
         </div>
 
         <div className="performanceRow">
-          <span className="performanceLabel">{BENCHMARK_TICKER} benchmark</span>
+          <span className="performanceLabel">
+            {BENCHMARK_TICKER} benchmark
+            {benchmarkNarrowed && benchmarkStart && (
+              <span className="performanceLabelHint"> (since {benchmarkStart})</span>
+            )}
+          </span>
           <span className="performanceValues">
             {benchmark ? (
               <>
@@ -199,11 +218,9 @@ export const PerformanceBenchmark = ({ account }: Props) => {
               </>
             ) : (
               <span className="no-data">
-                {benchmarkWindowMismatch
-                  ? "unavailable for this window"
-                  : benchmarkAvailable
-                    ? "no price data"
-                    : `no ${BENCHMARK_TICKER} in this account`}
+                {benchmarkAvailable
+                  ? "no price data"
+                  : `no ${BENCHMARK_TICKER} in this account`}
               </span>
             )}
           </span>

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -131,7 +131,7 @@ export const PerformanceBenchmark = ({ account }: Props) => {
 
   return (
     <>
-      <div className="propertyLabel">Performance</div>
+      <div className="propertyLabel">Investment&nbsp;Performance</div>
       <div className="property performanceBenchmark">
         <div className="performanceWindowPicker">
           {WINDOW_OPTIONS.map((opt) => (
@@ -147,7 +147,7 @@ export const PerformanceBenchmark = ({ account }: Props) => {
         </div>
 
         <div className="performanceRow">
-          <span className="performanceLabel">Your return (MWR)</span>
+          <span className="performanceLabel">Your asset return (MWR)</span>
           <span className="performanceValues">
             {mwr.status === "ok" ? (
               <>
@@ -190,7 +190,7 @@ export const PerformanceBenchmark = ({ account }: Props) => {
         )}
 
         <div className="performanceFootnote">
-          Showing {windowStart} → {windowEnd}
+          Showing {windowStart} → {windowEnd} · asset positions only (cash excluded)
           {isClamped && " · clamped to earliest data"}
           {suppressAnnualized && " · annualized hidden (window <6mo)"}
         </div>

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -97,13 +97,22 @@ export const PerformanceBenchmark = ({ account }: Props) => {
 
     const mwr = computeMWR({ flows, vStart, vEnd, windowStart, windowEnd });
 
+    // For the benchmark we want STRICT prices (no pre-history fallback) so
+    // we don't show a misleading comparison against a stale earliest-known
+    // price when the window extends before our VOO snapshot history.
     const benchmarkSecId = findBenchmarkSecurityId(securitySnapshots, BENCHMARK_TICKER);
     let benchmark: ReturnType<typeof computeBenchmarkTWR> | null = null;
+    let benchmarkWindowMismatch = false;
     if (benchmarkSecId) {
-      const priceStart = priceAt(benchmarkSecId, windowStart);
-      const priceEnd = priceAt(benchmarkSecId, windowEnd);
+      const priceStart = priceAt(benchmarkSecId, windowStart, { strict: true });
+      const priceEnd = priceAt(benchmarkSecId, windowEnd, { strict: true });
       if (priceStart && priceEnd) {
         benchmark = computeBenchmarkTWR({ priceStart, priceEnd, windowStart, windowEnd });
+      } else if (priceAt(benchmarkSecId, windowEnd) !== null) {
+        // We have end-price but not start-price → window predates our
+        // benchmark snapshot history. Display a "not available for this
+        // window" hint rather than silently dropping the row.
+        benchmarkWindowMismatch = true;
       }
     }
 
@@ -125,6 +134,7 @@ export const PerformanceBenchmark = ({ account }: Props) => {
       mwr,
       benchmark,
       benchmarkAvailable: benchmarkSecId !== null,
+      benchmarkWindowMismatch,
       gap,
       suppressAnnualized,
       isClamped,
@@ -138,6 +148,7 @@ export const PerformanceBenchmark = ({ account }: Props) => {
     mwr,
     benchmark,
     benchmarkAvailable,
+    benchmarkWindowMismatch,
     gap,
     suppressAnnualized,
     isClamped,
@@ -188,7 +199,11 @@ export const PerformanceBenchmark = ({ account }: Props) => {
               </>
             ) : (
               <span className="no-data">
-                {benchmarkAvailable ? "no price data" : `no ${BENCHMARK_TICKER} in this account`}
+                {benchmarkWindowMismatch
+                  ? "unavailable for this window"
+                  : benchmarkAvailable
+                    ? "no price data"
+                    : `no ${BENCHMARK_TICKER} in this account`}
               </span>
             )}
           </span>

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -1,0 +1,177 @@
+import { useMemo, useState } from "react";
+import { Account, useAppContext } from "client";
+import {
+  extractCashFlows,
+  computeMWR,
+  computeBenchmarkTWR,
+  valueAt,
+  buildPriceAt,
+  findBenchmarkSecurityId,
+} from "client/lib/hooks/calculation/benchmark";
+import "./index.css";
+
+interface Props {
+  account: Account;
+}
+
+type WindowKey = "1Y" | "3Y" | "All";
+const WINDOW_OPTIONS: WindowKey[] = ["1Y", "3Y", "All"];
+const BENCHMARK_TICKER = "VOO";
+
+const toDateString = (d: Date) => d.toISOString().slice(0, 10);
+
+const formatPct = (n: number | null): string => {
+  if (n === null || !Number.isFinite(n)) return "—";
+  return `${n >= 0 ? "+" : ""}${(n * 100).toFixed(2)}%`;
+};
+
+export const PerformanceBenchmark = ({ account }: Props) => {
+  const { account_id } = account;
+  const { data } = useAppContext();
+  const { investmentTransactions, holdingSnapshots, securitySnapshots } = data;
+
+  const [windowKey, setWindowKey] = useState<WindowKey>("1Y");
+
+  const computed = useMemo(() => {
+    // Find the earliest holding snapshot for this account — that's the
+    // best `window_start` candidate ("All" window) since values before
+    // then are zero from the FE's perspective. For 1Y/3Y windows, clamp
+    // to today − N years, but never earlier than the earliest snapshot.
+    let earliest: string | null = null;
+    holdingSnapshots.forEach((s) => {
+      if (s.holding.account_id !== account_id) return;
+      const d = s.snapshot.date.slice(0, 10);
+      if (!earliest || d < earliest) earliest = d;
+    });
+    if (!earliest) return null;
+
+    const today = new Date();
+    const windowEnd = toDateString(today);
+    const clamp = (target: Date): string => {
+      const t = toDateString(target);
+      return t < earliest! ? earliest! : t;
+    };
+
+    let windowStart: string;
+    if (windowKey === "All") {
+      windowStart = earliest;
+    } else {
+      const years = windowKey === "1Y" ? 1 : 3;
+      const target = new Date(today);
+      target.setFullYear(target.getFullYear() - years);
+      windowStart = clamp(target);
+    }
+
+    const priceAt = buildPriceAt(securitySnapshots);
+    const vStart = valueAt({ date: windowStart, accountId: account_id, holdingSnapshots, priceAt });
+    const vEnd = valueAt({ date: windowEnd, accountId: account_id, holdingSnapshots, priceAt });
+
+    const allFlows = extractCashFlows(investmentTransactions, holdingSnapshots, account_id);
+    const flows = allFlows.filter((f) => f.date > windowStart && f.date <= windowEnd);
+
+    const mwr = computeMWR({ flows, vStart, vEnd, windowStart, windowEnd });
+
+    const benchmarkSecId = findBenchmarkSecurityId(securitySnapshots, BENCHMARK_TICKER);
+    let benchmark: ReturnType<typeof computeBenchmarkTWR> | null = null;
+    if (benchmarkSecId) {
+      const priceStart = priceAt(benchmarkSecId, windowStart);
+      const priceEnd = priceAt(benchmarkSecId, windowEnd);
+      if (priceStart && priceEnd) {
+        benchmark = computeBenchmarkTWR({ priceStart, priceEnd, windowStart, windowEnd });
+      }
+    }
+
+    const yearsInWindow =
+      (new Date(windowEnd).getTime() - new Date(windowStart).getTime()) / (1000 * 60 * 60 * 24 * 365);
+    const suppressAnnualized = yearsInWindow < 0.5;
+
+    const gap =
+      mwr.annualized !== null && benchmark
+        ? mwr.annualized - benchmark.annualized
+        : null;
+
+    return {
+      windowStart,
+      windowEnd,
+      vStart,
+      vEnd,
+      flowCount: flows.length,
+      mwr,
+      benchmark,
+      benchmarkAvailable: benchmarkSecId !== null,
+      gap,
+      suppressAnnualized,
+    };
+  }, [account_id, investmentTransactions, holdingSnapshots, securitySnapshots, windowKey]);
+
+  if (!computed) return null;
+  const { windowStart, windowEnd, mwr, benchmark, benchmarkAvailable, gap, suppressAnnualized } = computed;
+
+  return (
+    <>
+      <div className="propertyLabel">Performance</div>
+      <div className="property performanceBenchmark">
+        <div className="performanceWindowPicker">
+          {WINDOW_OPTIONS.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              className={opt === windowKey ? "active" : ""}
+              onClick={() => setWindowKey(opt)}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+
+        <div className="performanceRow">
+          <span className="performanceLabel">Your return (MWR)</span>
+          <span className="performanceValues">
+            {mwr.status === "ok" ? (
+              <>
+                <span className="cum">{formatPct(mwr.cumulative)}</span>
+                {!suppressAnnualized && (
+                  <span className="ann">{formatPct(mwr.annualized)}/yr</span>
+                )}
+              </>
+            ) : (
+              <span className="no-data">—</span>
+            )}
+          </span>
+        </div>
+
+        <div className="performanceRow">
+          <span className="performanceLabel">{BENCHMARK_TICKER} benchmark</span>
+          <span className="performanceValues">
+            {benchmark ? (
+              <>
+                <span className="cum">{formatPct(benchmark.cumulative)}</span>
+                {!suppressAnnualized && (
+                  <span className="ann">{formatPct(benchmark.annualized)}/yr</span>
+                )}
+              </>
+            ) : (
+              <span className="no-data">
+                {benchmarkAvailable ? "no price data" : `no ${BENCHMARK_TICKER} in this account`}
+              </span>
+            )}
+          </span>
+        </div>
+
+        {gap !== null && !suppressAnnualized && (
+          <div className="performanceRow gap">
+            <span className="performanceLabel">vs benchmark</span>
+            <span className={`performanceValues ${gap >= 0 ? "positive" : "negative"}`}>
+              <span className="ann">{formatPct(gap)}/yr</span>
+            </span>
+          </div>
+        )}
+
+        <div className="performanceFootnote">
+          Showing {windowStart} → {windowEnd}
+          {suppressAnnualized && " · annualized hidden (window <6mo)"}
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -7,6 +7,7 @@ import {
   valueAt,
   buildPriceAt,
   findBenchmarkSecurityId,
+  earliestDataDate,
 } from "client/lib/hooks/calculation/benchmark";
 import "./index.css";
 
@@ -33,15 +34,14 @@ export const PerformanceBenchmark = ({ account }: Props) => {
   const [windowKey, setWindowKey] = useState<WindowKey>("1Y");
 
   const computed = useMemo(() => {
-    // Find the earliest holding snapshot for this account — that's the
-    // best `window_start` candidate ("All" window) since values before
-    // then are zero from the FE's perspective. For 1Y/3Y windows, clamp
-    // to viewDate − N years, but never earlier than the earliest snapshot.
-    let earliest: string | null = null;
-    holdingSnapshots.forEach((s) => {
-      if (s.holding.account_id !== account_id) return;
-      const d = s.snapshot.date.slice(0, 10);
-      if (!earliest || d < earliest) earliest = d;
+    // "Earliest available data" is now `min(first_holding_snapshot, first_txn)`
+    // for the account. Accounts whose txn history predates the snapshot
+    // history can show a longer "All" window via the txn-derived qty walk
+    // in valueAt.
+    const earliest = earliestDataDate({
+      accountId: account_id,
+      holdingSnapshots,
+      investmentTransactions,
     });
     if (!earliest) return null;
 

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -75,8 +75,22 @@ export const PerformanceBenchmark = ({ account }: Props) => {
     if (windowEnd <= windowStart) return null;
 
     const priceAt = buildPriceAt(securitySnapshots);
-    const vStart = valueAt({ date: windowStart, accountId: account_id, holdingSnapshots, priceAt });
-    const vEnd = valueAt({ date: windowEnd, accountId: account_id, holdingSnapshots, priceAt });
+    const vStart = valueAt({
+      date: windowStart,
+      windowStart,
+      accountId: account_id,
+      holdingSnapshots,
+      investmentTransactions,
+      priceAt,
+    });
+    const vEnd = valueAt({
+      date: windowEnd,
+      windowStart,
+      accountId: account_id,
+      holdingSnapshots,
+      investmentTransactions,
+      priceAt,
+    });
 
     const allFlows = extractCashFlows(investmentTransactions, holdingSnapshots, account_id);
     const flows = allFlows.filter((f) => f.date > windowStart && f.date <= windowEnd);

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -27,7 +27,7 @@ const formatPct = (n: number | null): string => {
 
 export const PerformanceBenchmark = ({ account }: Props) => {
   const { account_id } = account;
-  const { data } = useAppContext();
+  const { data, viewDate } = useAppContext();
   const { investmentTransactions, holdingSnapshots, securitySnapshots } = data;
 
   const [windowKey, setWindowKey] = useState<WindowKey>("1Y");
@@ -36,7 +36,7 @@ export const PerformanceBenchmark = ({ account }: Props) => {
     // Find the earliest holding snapshot for this account — that's the
     // best `window_start` candidate ("All" window) since values before
     // then are zero from the FE's perspective. For 1Y/3Y windows, clamp
-    // to today − N years, but never earlier than the earliest snapshot.
+    // to viewDate − N years, but never earlier than the earliest snapshot.
     let earliest: string | null = null;
     holdingSnapshots.forEach((s) => {
       if (s.holding.account_id !== account_id) return;
@@ -45,22 +45,34 @@ export const PerformanceBenchmark = ({ account }: Props) => {
     });
     if (!earliest) return null;
 
+    // windowEnd follows viewDate (end of the period the user is looking at),
+    // capped at today since we have no future data. Same convention as
+    // HoldingsComposition's `viewEndDate`.
     const today = new Date();
-    const windowEnd = toDateString(today);
-    const clamp = (target: Date): string => {
+    const viewEnd = viewDate.getEndDate();
+    const effectiveEnd = viewEnd > today ? today : viewEnd;
+    const windowEnd = toDateString(effectiveEnd);
+    const clampStart = (target: Date): { value: string; clamped: boolean } => {
       const t = toDateString(target);
-      return t < earliest! ? earliest! : t;
+      return t < earliest! ? { value: earliest!, clamped: true } : { value: t, clamped: false };
     };
 
     let windowStart: string;
+    let isClamped = false;
     if (windowKey === "All") {
       windowStart = earliest;
     } else {
       const years = windowKey === "1Y" ? 1 : 3;
-      const target = new Date(today);
+      const target = new Date(effectiveEnd);
       target.setFullYear(target.getFullYear() - years);
-      windowStart = clamp(target);
+      const r = clampStart(target);
+      windowStart = r.value;
+      isClamped = r.clamped;
     }
+
+    // Guard: if windowEnd somehow ends up ≤ windowStart (e.g. viewDate
+    // is before the earliest snapshot), don't try to compute.
+    if (windowEnd <= windowStart) return null;
 
     const priceAt = buildPriceAt(securitySnapshots);
     const vStart = valueAt({ date: windowStart, accountId: account_id, holdingSnapshots, priceAt });
@@ -101,11 +113,21 @@ export const PerformanceBenchmark = ({ account }: Props) => {
       benchmarkAvailable: benchmarkSecId !== null,
       gap,
       suppressAnnualized,
+      isClamped,
     };
-  }, [account_id, investmentTransactions, holdingSnapshots, securitySnapshots, windowKey]);
+  }, [account_id, investmentTransactions, holdingSnapshots, securitySnapshots, windowKey, viewDate]);
 
   if (!computed) return null;
-  const { windowStart, windowEnd, mwr, benchmark, benchmarkAvailable, gap, suppressAnnualized } = computed;
+  const {
+    windowStart,
+    windowEnd,
+    mwr,
+    benchmark,
+    benchmarkAvailable,
+    gap,
+    suppressAnnualized,
+    isClamped,
+  } = computed;
 
   return (
     <>
@@ -169,6 +191,7 @@ export const PerformanceBenchmark = ({ account }: Props) => {
 
         <div className="performanceFootnote">
           Showing {windowStart} → {windowEnd}
+          {isClamped && " · clamped to earliest data"}
           {suppressAnnualized && " · annualized hidden (window <6mo)"}
         </div>
       </div>

--- a/src/client/components/index.ts
+++ b/src/client/components/index.ts
@@ -8,6 +8,7 @@ export * from "./TransactionsTable";
 export * from "./AccountsTable";
 export * from "./AccountProperties";
 export * from "./HoldingsComposition";
+export * from "./PerformanceBenchmark";
 export * from "./InstitutionSpan";
 export * from "./AccountsDonut";
 export * from "./Header";

--- a/src/client/lib/hooks/calculation/benchmark.test.ts
+++ b/src/client/lib/hooks/calculation/benchmark.test.ts
@@ -9,6 +9,7 @@ import {
   valueAt,
   buildPriceAt,
   findBenchmarkSecurityId,
+  firstPricedSnapshotDate,
 } from "./benchmark";
 import {
   HoldingSnapshotDictionary,
@@ -372,5 +373,46 @@ describe("findBenchmarkSecurityId", () => {
   test("returns null when ticker not found", () => {
     const ss = new SecuritySnapshotDictionary();
     expect(findBenchmarkSecurityId(ss, "AAPL")).toBeNull();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+describe("firstPricedSnapshotDate", () => {
+  test("returns earliest snapshot date for a security_id", () => {
+    const ss = new SecuritySnapshotDictionary();
+    ss.set("s1", mkSecuritySnap(VOO, 500, "2025-06-05", "VOO"));
+    ss.set("s2", mkSecuritySnap(VOO, 520, "2025-12-01", "VOO"));
+    ss.set("s3", mkSecuritySnap(VOO, 530, "2026-05-16", "VOO"));
+    expect(firstPricedSnapshotDate(ss, VOO)).toBe("2025-06-05");
+  });
+
+  test("ignores other securities", () => {
+    const ss = new SecuritySnapshotDictionary();
+    ss.set("s1", mkSecuritySnap(VOO, 500, "2025-06-05", "VOO"));
+    ss.set("s2", mkSecuritySnap("sec-spy", 480, "2020-01-01", "SPY"));
+    expect(firstPricedSnapshotDate(ss, VOO)).toBe("2025-06-05");
+  });
+
+  test("skips snapshots with null close_price", () => {
+    const ss = new SecuritySnapshotDictionary();
+    ss.set(
+      "s1",
+      new SecuritySnapshot({
+        snapshot: { snapshot_id: "ss_null", date: "2024-01-01" },
+        security: {
+          security_id: VOO,
+          ticker_symbol: "VOO",
+          close_price: null,
+          close_price_as_of: "2024-01-01",
+        },
+      }),
+    );
+    ss.set("s2", mkSecuritySnap(VOO, 500, "2025-06-05", "VOO"));
+    expect(firstPricedSnapshotDate(ss, VOO)).toBe("2025-06-05");
+  });
+
+  test("returns null when no snapshots", () => {
+    const ss = new SecuritySnapshotDictionary();
+    expect(firstPricedSnapshotDate(ss, VOO)).toBeNull();
   });
 });

--- a/src/client/lib/hooks/calculation/benchmark.test.ts
+++ b/src/client/lib/hooks/calculation/benchmark.test.ts
@@ -1,0 +1,301 @@
+// Run with: bun test --preload ./test-preload.ts benchmark.test.ts
+import { describe, test, expect } from "bun:test";
+import { InvestmentTransactionType, InvestmentTransactionSubtype } from "plaid";
+
+import {
+  extractCashFlows,
+  computeMWR,
+  computeBenchmarkTWR,
+  valueAt,
+  buildPriceAt,
+  findBenchmarkSecurityId,
+} from "./benchmark";
+import {
+  HoldingSnapshotDictionary,
+  SecuritySnapshotDictionary,
+  InvestmentTransactionDictionary,
+} from "../../models/Data";
+import { HoldingSnapshot, SecuritySnapshot } from "../../models/Snapshot";
+import { InvestmentTransaction } from "../../models/InvestmentTransaction";
+
+const ACCT = "acc-1";
+const VOO = "sec-voo";
+const CASH = "sec-cash";
+
+const mkHoldingSnap = (sid: string, qty: number, instPrice: number, costBasis: number | null, date: string) =>
+  new HoldingSnapshot({
+    snapshot: { snapshot_id: `hs_${sid}_${date}`, date },
+    holding: {
+      account_id: ACCT,
+      security_id: sid,
+      quantity: qty,
+      institution_price: instPrice,
+      institution_value: qty * instPrice,
+      cost_basis: costBasis,
+      institution_price_as_of: date,
+      iso_currency_code: "USD",
+      unofficial_currency_code: null,
+    },
+  });
+
+const mkSecuritySnap = (sid: string, closePrice: number, date: string, ticker = "TICK") =>
+  new SecuritySnapshot({
+    snapshot: { snapshot_id: `ss_${sid}_${date}`, date },
+    security: {
+      security_id: sid,
+      ticker_symbol: ticker,
+      close_price: closePrice,
+      close_price_as_of: date,
+    },
+  });
+
+const mkTxn = (overrides: Partial<InvestmentTransaction> & { date: string; amount: number }): InvestmentTransaction =>
+  new InvestmentTransaction({
+    investment_transaction_id: `tx_${Math.random()}`,
+    account_id: ACCT,
+    security_id: VOO,
+    type: InvestmentTransactionType.Buy,
+    subtype: InvestmentTransactionSubtype.Buy,
+    quantity: 1,
+    price: overrides.amount,
+    name: "test",
+    ...overrides,
+  });
+
+// ──────────────────────────────────────────────────────────────────────────────
+describe("extractCashFlows", () => {
+  test("classifies cash/deposit (negative-amount Plaid convention) as positive external IN", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Cash, subtype: InvestmentTransactionSubtype.Deposit, amount: -500, quantity: 0 }));
+    const flows = extractCashFlows(itxns, hs, ACCT);
+    expect(flows).toEqual([{ date: "2026-02-01", amount: 500 }]);
+  });
+
+  test("classifies cash/withdrawal as negative external OUT", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Cash, subtype: InvestmentTransactionSubtype.Withdrawal, amount: 200, quantity: 0 }));
+    const flows = extractCashFlows(itxns, hs, ACCT);
+    expect(flows).toEqual([{ date: "2026-02-01", amount: -200 }]);
+  });
+
+  test("classifies unmatched buy on cash-shape security as external IN", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Buy, security_id: CASH, amount: 371, quantity: 371 }));
+    const flows = extractCashFlows(itxns, hs, ACCT);
+    expect(flows).toEqual([{ date: "2026-02-01", amount: 371 }]);
+  });
+
+  test("drops matched buy-cash that has a paired sell-asset within ±7 days (internal sweep move)", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
+    hs.set("hs2", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    // Asset SELL on the 1st → matching cash BUY on the 4th. 3-day gap, within ±7d.
+    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Sell, security_id: VOO, amount: -500, quantity: -1 }));
+    itxns.set("t2", mkTxn({ date: "2026-02-04", type: InvestmentTransactionType.Buy, security_id: CASH, amount: 500, quantity: 500 }));
+    const flows = extractCashFlows(itxns, hs, ACCT);
+    expect(flows).toEqual([]); // both legs dropped as internal
+  });
+
+  test("drops matched sell-cash + buy-asset within ±7 days", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
+    hs.set("hs2", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("t1", mkTxn({ date: "2026-02-13", type: InvestmentTransactionType.Buy, security_id: VOO, amount: 5044.08, quantity: 8 }));
+    // settlement clears 4 days later — was a false positive in the v3 spike (±3d), correctly absorbed at ±7d
+    itxns.set("t2", mkTxn({ date: "2026-02-17", type: InvestmentTransactionType.Sell, security_id: CASH, amount: -5044.08, quantity: -5044.08 }));
+    const flows = extractCashFlows(itxns, hs, ACCT);
+    expect(flows).toEqual([]);
+  });
+
+  test("dedupes same-day same-amount cash/deposit + buy-CASH pairs (Plaid double-reporting)", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Cash, subtype: InvestmentTransactionSubtype.Deposit, amount: -371, quantity: 0 }));
+    itxns.set("t2", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Buy, security_id: CASH, amount: 371, quantity: 371 }));
+    const flows = extractCashFlows(itxns, hs, ACCT);
+    expect(flows).toEqual([{ date: "2026-02-01", amount: 371 }]); // not 742
+  });
+
+  test("ignores asset buy/sell (internal reallocation)", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("hs1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Buy, security_id: VOO, amount: 500, quantity: 1 }));
+    const flows = extractCashFlows(itxns, hs, ACCT);
+    expect(flows).toEqual([]);
+  });
+
+  test("skips fee/dividend rows (internal returns)", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("hs1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Fee, subtype: InvestmentTransactionSubtype.Dividend, security_id: VOO, amount: -25, quantity: 0 }));
+    const flows = extractCashFlows(itxns, hs, ACCT);
+    expect(flows).toEqual([]);
+  });
+
+  test("only considers transactions for the requested account_id", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    const t = mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Cash, subtype: InvestmentTransactionSubtype.Deposit, amount: -100, quantity: 0 });
+    // Override account_id directly — different account
+    (t as { account_id: string }).account_id = "other";
+    itxns.set("t1", t);
+    expect(extractCashFlows(itxns, hs, ACCT)).toEqual([]);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+describe("computeMWR", () => {
+  test("returns 0% when V_end == V_start with no flows", () => {
+    const r = computeMWR({
+      flows: [],
+      vStart: 1000,
+      vEnd: 1000,
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    expect(r.status).toBe("ok");
+    expect(Math.abs(r.annualized!)).toBeLessThan(0.001);
+  });
+
+  test("recovers a known 10% annualized rate on a single flow", () => {
+    // Deposited $1000 at t=0, ending $1100 a year later, no other flows.
+    const r = computeMWR({
+      flows: [],
+      vStart: 1000,
+      vEnd: 1100,
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    expect(r.status).toBe("ok");
+    expect(r.annualized!).toBeCloseTo(0.10, 2);
+  });
+
+  test("recovers IRR with mid-period contribution", () => {
+    // V_start=0, +1000 deposit at t=0.5y, V_end=1100. Half a year of holding.
+    // 1000 * (1+r)^0.5 = 1100  →  r = (1.1)^2 − 1 = 0.21
+    const r = computeMWR({
+      flows: [{ date: "2026-07-01", amount: 1000 }],
+      vStart: 0,
+      vEnd: 1100,
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    expect(r.status).toBe("ok");
+    expect(r.annualized!).toBeCloseTo(0.21, 1);
+  });
+
+  test("returns no_solution when stream is degenerate (no positive root in range)", () => {
+    // V_start=0, no flows, V_end>0 → no rate satisfies. Bisection bounds will be same sign.
+    const r = computeMWR({
+      flows: [],
+      vStart: 0,
+      vEnd: 1000,
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    // 0 = 0 + 1000/(1+r)^1. Only solution is r=∞. NPV is positive at all finite r, never crosses zero. → no_solution.
+    expect(r.status).toBe("no_solution");
+  });
+
+  test("annualized and cumulative agree: cumulative = (1+ann)^years − 1", () => {
+    const r = computeMWR({
+      flows: [{ date: "2026-04-01", amount: 500 }],
+      vStart: 1000,
+      vEnd: 1700,
+      windowStart: "2026-01-01",
+      windowEnd: "2026-12-31",
+    });
+    const years = (new Date("2026-12-31").getTime() - new Date("2026-01-01").getTime()) / (1000 * 60 * 60 * 24 * 365);
+    expect(r.cumulative!).toBeCloseTo(Math.pow(1 + r.annualized!, years) - 1, 6);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+describe("computeBenchmarkTWR", () => {
+  test("simple price ratio gives cumulative; annualization matches the years formula", () => {
+    const r = computeBenchmarkTWR({
+      priceStart: 100,
+      priceEnd: 120,
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    expect(r.cumulative).toBeCloseTo(0.20, 6);
+    expect(r.annualized).toBeCloseTo(0.20, 2); // ~1 year window
+  });
+
+  test("annualizes a 6-month +10% return to ~21%", () => {
+    const r = computeBenchmarkTWR({
+      priceStart: 100,
+      priceEnd: 110,
+      windowStart: "2026-01-01",
+      windowEnd: "2026-07-01",
+    });
+    expect(r.cumulative).toBeCloseTo(0.10, 6);
+    // (1.10)^2 − 1 ≈ 0.21
+    expect(r.annualized).toBeCloseTo(0.21, 1);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+describe("valueAt + priceAt", () => {
+  test("uses latest holding snapshot ≤ date for qty; cash-shape ignores priceAt", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
+    hs.set("h2", mkHoldingSnap(VOO, 15, 600, 9000, "2026-03-01"));
+    hs.set("h3", mkHoldingSnap(CASH, 200, 1, null, "2026-03-01"));
+    const ss = new SecuritySnapshotDictionary();
+    ss.set("s1", mkSecuritySnap(VOO, 500, "2026-01-01"));
+    ss.set("s2", mkSecuritySnap(VOO, 700, "2026-03-15"));
+    const priceAt = buildPriceAt(ss);
+
+    // On 2026-02-15: latest VOO snap is 2026-01-01 (qty=10), latest VOO price is 500.
+    // CASH snap not yet observed (only at 2026-03-01), so no cash position yet.
+    expect(valueAt({ date: "2026-02-15", accountId: ACCT, holdingSnapshots: hs, priceAt })).toBe(5000);
+
+    // On 2026-04-01: latest VOO snap is 2026-03-01 (qty=15), latest VOO price is 700.
+    // CASH snap observed at 2026-03-01 → qty 200 × $1.
+    expect(valueAt({ date: "2026-04-01", accountId: ACCT, holdingSnapshots: hs, priceAt })).toBe(15 * 700 + 200);
+  });
+
+  test("returns 0 when no holding snapshots exist on or before the date", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-06-01"));
+    const ss = new SecuritySnapshotDictionary();
+    const priceAt = buildPriceAt(ss);
+    expect(valueAt({ date: "2026-01-01", accountId: ACCT, holdingSnapshots: hs, priceAt })).toBe(0);
+  });
+
+  test("buildPriceAt returns null when no snapshot exists for the security", () => {
+    const ss = new SecuritySnapshotDictionary();
+    const priceAt = buildPriceAt(ss);
+    expect(priceAt(VOO, "2026-01-01")).toBeNull();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+describe("findBenchmarkSecurityId", () => {
+  test("returns matching security_id for ticker", () => {
+    const ss = new SecuritySnapshotDictionary();
+    ss.set("s1", mkSecuritySnap(VOO, 500, "2026-01-01", "VOO"));
+    ss.set("s2", mkSecuritySnap("sec-spy", 480, "2026-01-01", "SPY"));
+    expect(findBenchmarkSecurityId(ss, "VOO")).toBe(VOO);
+    expect(findBenchmarkSecurityId(ss, "SPY")).toBe("sec-spy");
+  });
+
+  test("returns null when ticker not found", () => {
+    const ss = new SecuritySnapshotDictionary();
+    expect(findBenchmarkSecurityId(ss, "AAPL")).toBeNull();
+  });
+});

--- a/src/client/lib/hooks/calculation/benchmark.test.ts
+++ b/src/client/lib/hooks/calculation/benchmark.test.ts
@@ -224,39 +224,132 @@ describe("computeBenchmarkTWR", () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
-describe("valueAt (asset-only)", () => {
-  test("sums non-cash holdings at latest snapshot ≤ date; ignores cash-shape", () => {
+describe("valueAt (asset-only, txn-derived qty)", () => {
+  test("V_start uses holding-snap qty as the anchor; cash-shape excluded", () => {
     const hs = new HoldingSnapshotDictionary();
     hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
-    hs.set("h2", mkHoldingSnap(VOO, 15, 600, 9000, "2026-03-01"));
-    hs.set("h3", mkHoldingSnap(CASH, 200, 1, null, "2026-03-01"));
+    hs.set("h3", mkHoldingSnap(CASH, 200, 1, null, "2026-01-01"));
     const ss = new SecuritySnapshotDictionary();
     ss.set("s1", mkSecuritySnap(VOO, 500, "2026-01-01"));
-    ss.set("s2", mkSecuritySnap(VOO, 700, "2026-03-15"));
+    const itxns = new InvestmentTransactionDictionary();
     const priceAt = buildPriceAt(ss);
 
-    // 2026-02-15: VOO snap from 2026-01-01 (qty=10), price walks back to 500.
-    expect(valueAt({ date: "2026-02-15", accountId: ACCT, holdingSnapshots: hs, priceAt })).toBe(5000);
+    expect(
+      valueAt({
+        date: "2026-01-01",
+        windowStart: "2026-01-01",
+        accountId: ACCT,
+        holdingSnapshots: hs,
+        investmentTransactions: itxns,
+        priceAt,
+      }),
+    ).toBe(5000); // 10 × 500, cash excluded
+  });
 
-    // 2026-04-01: VOO snap is now the 2026-03-01 (qty=15), price = 700.
-    // The CASH snap exists but is EXCLUDED. So 15 × 700 = 10500, *not* 10500 + 200.
-    expect(valueAt({ date: "2026-04-01", accountId: ACCT, holdingSnapshots: hs, priceAt })).toBe(10500);
+  test("V_end uses anchor + Σ(buy − sell) within window — phantom holding shares are invisible", () => {
+    // Anchor: 10 shares VOO at start. Within window: 5 buys of 1 share each.
+    // Holding snap at end shows 100 shares (Plaid sync glitch — txns lag).
+    // valueAt should ignore the phantom shares and report 10 + 5 = 15 × price.
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
+    hs.set("h2", mkHoldingSnap(VOO, 100, 600, 60000, "2026-06-01")); // phantom +90 shares
+    const ss = new SecuritySnapshotDictionary();
+    ss.set("s1", mkSecuritySnap(VOO, 500, "2026-01-01"));
+    ss.set("s2", mkSecuritySnap(VOO, 600, "2026-06-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    // 5 buys, all dated before the query date (2026-06-01).
+    const buyDates = ["2026-02-10", "2026-03-10", "2026-04-10", "2026-05-10", "2026-05-25"];
+    buyDates.forEach((date, i) => {
+      itxns.set(
+        `t${i}`,
+        mkTxn({
+          date,
+          type: InvestmentTransactionType.Buy,
+          security_id: VOO,
+          amount: 600,
+          quantity: 1,
+        }),
+      );
+    });
+    const priceAt = buildPriceAt(ss);
+
+    expect(
+      valueAt({
+        date: "2026-06-01",
+        windowStart: "2026-01-01",
+        accountId: ACCT,
+        holdingSnapshots: hs,
+        investmentTransactions: itxns,
+        priceAt,
+      }),
+    ).toBe(15 * 600); // 9000 (10 anchor + 5 buys), NOT 60000
   });
 
   test("returns 0 when only cash-shape holdings exist", () => {
     const hs = new HoldingSnapshotDictionary();
     hs.set("h1", mkHoldingSnap(CASH, 5000, 1, null, "2026-01-01"));
     const ss = new SecuritySnapshotDictionary();
+    const itxns = new InvestmentTransactionDictionary();
     const priceAt = buildPriceAt(ss);
-    expect(valueAt({ date: "2026-02-01", accountId: ACCT, holdingSnapshots: hs, priceAt })).toBe(0);
+    expect(
+      valueAt({
+        date: "2026-02-01",
+        windowStart: "2026-01-01",
+        accountId: ACCT,
+        holdingSnapshots: hs,
+        investmentTransactions: itxns,
+        priceAt,
+      }),
+    ).toBe(0);
   });
 
-  test("returns 0 when no holding snapshots ≤ date", () => {
+  test("returns 0 when no holding snapshots ≤ windowStart", () => {
     const hs = new HoldingSnapshotDictionary();
     hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-06-01"));
     const ss = new SecuritySnapshotDictionary();
+    const itxns = new InvestmentTransactionDictionary();
     const priceAt = buildPriceAt(ss);
-    expect(valueAt({ date: "2026-01-01", accountId: ACCT, holdingSnapshots: hs, priceAt })).toBe(0);
+    expect(
+      valueAt({
+        date: "2026-01-15",
+        windowStart: "2026-01-01",
+        accountId: ACCT,
+        holdingSnapshots: hs,
+        investmentTransactions: itxns,
+        priceAt,
+      }),
+    ).toBe(0);
+  });
+
+  test("includes a security with zero anchor but new txns within window", () => {
+    // User had nothing at windowStart, bought 5 shares in window.
+    const hs = new HoldingSnapshotDictionary();
+    const ss = new SecuritySnapshotDictionary();
+    ss.set("s1", mkSecuritySnap(VOO, 500, "2026-01-01"));
+    ss.set("s2", mkSecuritySnap(VOO, 600, "2026-06-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set(
+      "t1",
+      mkTxn({
+        date: "2026-03-01",
+        type: InvestmentTransactionType.Buy,
+        security_id: VOO,
+        amount: 2500,
+        quantity: 5,
+      }),
+    );
+    const priceAt = buildPriceAt(ss);
+
+    expect(
+      valueAt({
+        date: "2026-06-01",
+        windowStart: "2026-01-01",
+        accountId: ACCT,
+        holdingSnapshots: hs,
+        investmentTransactions: itxns,
+        priceAt,
+      }),
+    ).toBe(5 * 600);
   });
 
   test("buildPriceAt returns null when no snapshot exists for the security", () => {

--- a/src/client/lib/hooks/calculation/benchmark.test.ts
+++ b/src/client/lib/hooks/calculation/benchmark.test.ts
@@ -63,92 +63,71 @@ const mkTxn = (overrides: Partial<InvestmentTransaction> & { date: string; amoun
   });
 
 // ──────────────────────────────────────────────────────────────────────────────
-describe("extractCashFlows", () => {
-  test("classifies cash/deposit (negative-amount Plaid convention) as positive external IN", () => {
+describe("extractCashFlows (cash-excluded model)", () => {
+  test("classifies asset BUY as external IN", () => {
     const hs = new HoldingSnapshotDictionary();
-    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
+    hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
     const itxns = new InvestmentTransactionDictionary();
-    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Cash, subtype: InvestmentTransactionSubtype.Deposit, amount: -500, quantity: 0 }));
-    const flows = extractCashFlows(itxns, hs, ACCT);
-    expect(flows).toEqual([{ date: "2026-02-01", amount: 500 }]);
+    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Buy, security_id: VOO, amount: 569, quantity: 1 }));
+    expect(extractCashFlows(itxns, hs, ACCT)).toEqual([{ date: "2026-02-01", amount: 569 }]);
   });
 
-  test("classifies cash/withdrawal as negative external OUT", () => {
+  test("classifies asset SELL as external OUT", () => {
     const hs = new HoldingSnapshotDictionary();
-    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
+    hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
     const itxns = new InvestmentTransactionDictionary();
-    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Cash, subtype: InvestmentTransactionSubtype.Withdrawal, amount: 200, quantity: 0 }));
-    const flows = extractCashFlows(itxns, hs, ACCT);
-    expect(flows).toEqual([{ date: "2026-02-01", amount: -200 }]);
+    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Sell, security_id: VOO, amount: 569, quantity: -1 }));
+    expect(extractCashFlows(itxns, hs, ACCT)).toEqual([{ date: "2026-02-01", amount: -569 }]);
   });
 
-  test("classifies unmatched buy on cash-shape security as external IN", () => {
+  test("ignores cash-shape security buy/sell entirely (cash side, not asset side)", () => {
     const hs = new HoldingSnapshotDictionary();
-    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
+    hs.set("h1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
     const itxns = new InvestmentTransactionDictionary();
     itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Buy, security_id: CASH, amount: 371, quantity: 371 }));
-    const flows = extractCashFlows(itxns, hs, ACCT);
-    expect(flows).toEqual([{ date: "2026-02-01", amount: 371 }]);
+    itxns.set("t2", mkTxn({ date: "2026-02-05", type: InvestmentTransactionType.Sell, security_id: CASH, amount: 200, quantity: -200 }));
+    expect(extractCashFlows(itxns, hs, ACCT)).toEqual([]);
   });
 
-  test("drops matched buy-cash that has a paired sell-asset within ±7 days (internal sweep move)", () => {
+  test("ignores cash/deposit and cash/withdrawal events", () => {
     const hs = new HoldingSnapshotDictionary();
-    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
-    hs.set("hs2", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
+    hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
     const itxns = new InvestmentTransactionDictionary();
-    // Asset SELL on the 1st → matching cash BUY on the 4th. 3-day gap, within ±7d.
-    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Sell, security_id: VOO, amount: -500, quantity: -1 }));
-    itxns.set("t2", mkTxn({ date: "2026-02-04", type: InvestmentTransactionType.Buy, security_id: CASH, amount: 500, quantity: 500 }));
-    const flows = extractCashFlows(itxns, hs, ACCT);
-    expect(flows).toEqual([]); // both legs dropped as internal
+    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Cash, subtype: InvestmentTransactionSubtype.Deposit, amount: -500, quantity: 0 }));
+    itxns.set("t2", mkTxn({ date: "2026-02-02", type: InvestmentTransactionType.Cash, subtype: InvestmentTransactionSubtype.Withdrawal, amount: 200, quantity: 0 }));
+    expect(extractCashFlows(itxns, hs, ACCT)).toEqual([]);
   });
 
-  test("drops matched sell-cash + buy-asset within ±7 days", () => {
+  test("ignores fee/dividend rows", () => {
     const hs = new HoldingSnapshotDictionary();
-    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
-    hs.set("hs2", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
-    const itxns = new InvestmentTransactionDictionary();
-    itxns.set("t1", mkTxn({ date: "2026-02-13", type: InvestmentTransactionType.Buy, security_id: VOO, amount: 5044.08, quantity: 8 }));
-    // settlement clears 4 days later — was a false positive in the v3 spike (±3d), correctly absorbed at ±7d
-    itxns.set("t2", mkTxn({ date: "2026-02-17", type: InvestmentTransactionType.Sell, security_id: CASH, amount: -5044.08, quantity: -5044.08 }));
-    const flows = extractCashFlows(itxns, hs, ACCT);
-    expect(flows).toEqual([]);
-  });
-
-  test("dedupes same-day same-amount cash/deposit + buy-CASH pairs (Plaid double-reporting)", () => {
-    const hs = new HoldingSnapshotDictionary();
-    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
-    const itxns = new InvestmentTransactionDictionary();
-    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Cash, subtype: InvestmentTransactionSubtype.Deposit, amount: -371, quantity: 0 }));
-    itxns.set("t2", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Buy, security_id: CASH, amount: 371, quantity: 371 }));
-    const flows = extractCashFlows(itxns, hs, ACCT);
-    expect(flows).toEqual([{ date: "2026-02-01", amount: 371 }]); // not 742
-  });
-
-  test("ignores asset buy/sell (internal reallocation)", () => {
-    const hs = new HoldingSnapshotDictionary();
-    hs.set("hs1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
-    const itxns = new InvestmentTransactionDictionary();
-    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Buy, security_id: VOO, amount: 500, quantity: 1 }));
-    const flows = extractCashFlows(itxns, hs, ACCT);
-    expect(flows).toEqual([]);
-  });
-
-  test("skips fee/dividend rows (internal returns)", () => {
-    const hs = new HoldingSnapshotDictionary();
-    hs.set("hs1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
+    hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
     const itxns = new InvestmentTransactionDictionary();
     itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Fee, subtype: InvestmentTransactionSubtype.Dividend, security_id: VOO, amount: -25, quantity: 0 }));
-    const flows = extractCashFlows(itxns, hs, ACCT);
-    expect(flows).toEqual([]);
+    expect(extractCashFlows(itxns, hs, ACCT)).toEqual([]);
+  });
+
+  test("ignores qty=0 rows (Plaid sometimes records non-trade events as buy/sell with qty=0)", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Sell, security_id: VOO, amount: -3600, quantity: 0 }));
+    expect(extractCashFlows(itxns, hs, ACCT)).toEqual([]);
+  });
+
+  test("sums multiple same-day asset flows", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("t1", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Buy, security_id: VOO, amount: 569, quantity: 1 }));
+    itxns.set("t2", mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Buy, security_id: VOO, amount: 141, quantity: 0.25 }));
+    expect(extractCashFlows(itxns, hs, ACCT)).toEqual([{ date: "2026-02-01", amount: 710 }]);
   });
 
   test("only considers transactions for the requested account_id", () => {
     const hs = new HoldingSnapshotDictionary();
-    hs.set("hs1", mkHoldingSnap(CASH, 100, 1, null, "2026-01-01"));
+    hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
     const itxns = new InvestmentTransactionDictionary();
-    const t = mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Cash, subtype: InvestmentTransactionSubtype.Deposit, amount: -100, quantity: 0 });
-    // Override account_id directly — different account
+    const t = mkTxn({ date: "2026-02-01", type: InvestmentTransactionType.Buy, security_id: VOO, amount: 500, quantity: 1 });
     (t as { account_id: string }).account_id = "other";
     itxns.set("t1", t);
     expect(extractCashFlows(itxns, hs, ACCT)).toEqual([]);
@@ -169,8 +148,7 @@ describe("computeMWR", () => {
     expect(Math.abs(r.annualized!)).toBeLessThan(0.001);
   });
 
-  test("recovers a known 10% annualized rate on a single flow", () => {
-    // Deposited $1000 at t=0, ending $1100 a year later, no other flows.
+  test("recovers a known 10% annualized rate over a 1y window", () => {
     const r = computeMWR({
       flows: [],
       vStart: 1000,
@@ -183,8 +161,8 @@ describe("computeMWR", () => {
   });
 
   test("recovers IRR with mid-period contribution", () => {
-    // V_start=0, +1000 deposit at t=0.5y, V_end=1100. Half a year of holding.
-    // 1000 * (1+r)^0.5 = 1100  →  r = (1.1)^2 − 1 = 0.21
+    // V_start=0, +1000 deposit at t=0.5y, V_end=1100.
+    // 1000 × (1+r)^0.5 = 1100 → r ≈ 0.21
     const r = computeMWR({
       flows: [{ date: "2026-07-01", amount: 1000 }],
       vStart: 0,
@@ -196,8 +174,7 @@ describe("computeMWR", () => {
     expect(r.annualized!).toBeCloseTo(0.21, 1);
   });
 
-  test("returns no_solution when stream is degenerate (no positive root in range)", () => {
-    // V_start=0, no flows, V_end>0 → no rate satisfies. Bisection bounds will be same sign.
+  test("returns no_solution when stream is degenerate (no root in range)", () => {
     const r = computeMWR({
       flows: [],
       vStart: 0,
@@ -205,11 +182,10 @@ describe("computeMWR", () => {
       windowStart: "2026-01-01",
       windowEnd: "2027-01-01",
     });
-    // 0 = 0 + 1000/(1+r)^1. Only solution is r=∞. NPV is positive at all finite r, never crosses zero. → no_solution.
     expect(r.status).toBe("no_solution");
   });
 
-  test("annualized and cumulative agree: cumulative = (1+ann)^years − 1", () => {
+  test("cumulative = (1 + annualized)^years − 1", () => {
     const r = computeMWR({
       flows: [{ date: "2026-04-01", amount: 500 }],
       vStart: 1000,
@@ -232,7 +208,7 @@ describe("computeBenchmarkTWR", () => {
       windowEnd: "2027-01-01",
     });
     expect(r.cumulative).toBeCloseTo(0.20, 6);
-    expect(r.annualized).toBeCloseTo(0.20, 2); // ~1 year window
+    expect(r.annualized).toBeCloseTo(0.20, 2);
   });
 
   test("annualizes a 6-month +10% return to ~21%", () => {
@@ -243,14 +219,13 @@ describe("computeBenchmarkTWR", () => {
       windowEnd: "2026-07-01",
     });
     expect(r.cumulative).toBeCloseTo(0.10, 6);
-    // (1.10)^2 − 1 ≈ 0.21
     expect(r.annualized).toBeCloseTo(0.21, 1);
   });
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
-describe("valueAt + priceAt", () => {
-  test("uses latest holding snapshot ≤ date for qty; cash-shape ignores priceAt", () => {
+describe("valueAt (asset-only)", () => {
+  test("sums non-cash holdings at latest snapshot ≤ date; ignores cash-shape", () => {
     const hs = new HoldingSnapshotDictionary();
     hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
     hs.set("h2", mkHoldingSnap(VOO, 15, 600, 9000, "2026-03-01"));
@@ -260,16 +235,23 @@ describe("valueAt + priceAt", () => {
     ss.set("s2", mkSecuritySnap(VOO, 700, "2026-03-15"));
     const priceAt = buildPriceAt(ss);
 
-    // On 2026-02-15: latest VOO snap is 2026-01-01 (qty=10), latest VOO price is 500.
-    // CASH snap not yet observed (only at 2026-03-01), so no cash position yet.
+    // 2026-02-15: VOO snap from 2026-01-01 (qty=10), price walks back to 500.
     expect(valueAt({ date: "2026-02-15", accountId: ACCT, holdingSnapshots: hs, priceAt })).toBe(5000);
 
-    // On 2026-04-01: latest VOO snap is 2026-03-01 (qty=15), latest VOO price is 700.
-    // CASH snap observed at 2026-03-01 → qty 200 × $1.
-    expect(valueAt({ date: "2026-04-01", accountId: ACCT, holdingSnapshots: hs, priceAt })).toBe(15 * 700 + 200);
+    // 2026-04-01: VOO snap is now the 2026-03-01 (qty=15), price = 700.
+    // The CASH snap exists but is EXCLUDED. So 15 × 700 = 10500, *not* 10500 + 200.
+    expect(valueAt({ date: "2026-04-01", accountId: ACCT, holdingSnapshots: hs, priceAt })).toBe(10500);
   });
 
-  test("returns 0 when no holding snapshots exist on or before the date", () => {
+  test("returns 0 when only cash-shape holdings exist", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(CASH, 5000, 1, null, "2026-01-01"));
+    const ss = new SecuritySnapshotDictionary();
+    const priceAt = buildPriceAt(ss);
+    expect(valueAt({ date: "2026-02-01", accountId: ACCT, holdingSnapshots: hs, priceAt })).toBe(0);
+  });
+
+  test("returns 0 when no holding snapshots ≤ date", () => {
     const hs = new HoldingSnapshotDictionary();
     hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-06-01"));
     const ss = new SecuritySnapshotDictionary();

--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -214,23 +214,30 @@ export const valueAt = (params: {
 
   const cashSecs = cashSecurityIdsForAccount(holdingSnapshots, accountId);
 
-  // Anchor qty: latest holding snapshot ≤ windowStart for each (account, security).
-  const anchorQty = new Map<string, { qtyAtAnchor: number; latestSnapDate: string }>();
+  // qty per security at `date` = Σ(buy.quantity − sell.quantity) over all
+  // txns at-or-before `date` (windowStart-inclusive). Anchor is implicit:
+  // for users with no pre-windowStart txns and no pre-windowStart holding
+  // snapshot, this collapses to "all positions came from observed buys."
+  // The phantom-holding guard from before is preserved: any holding qty in
+  // `holding_snapshots` that exceeds what txns can explain is invisible.
+  const qtyBySec = new Map<string, number>();
+
+  // 1) Pre-window holdings anchor: take the latest snapshot ≤ windowStart
+  //    as the starting qty. Skipped when no such snapshot exists (e.g.
+  //    accounts whose snapshot history begins later than `windowStart`).
+  const anchorSnapDate = new Map<string, string>();
   holdingSnapshots.forEach((snap) => {
     if (snap.holding.account_id !== accountId) return;
     const snapDate = snap.snapshot.date.slice(0, 10);
     if (snapDate > windowStart) return;
-    const cur = anchorQty.get(snap.holding.security_id);
-    if (!cur || snapDate > cur.latestSnapDate) {
-      anchorQty.set(snap.holding.security_id, {
-        qtyAtAnchor: snap.holding.quantity ?? 0,
-        latestSnapDate: snapDate,
-      });
+    const curDate = anchorSnapDate.get(snap.holding.security_id);
+    if (!curDate || snapDate > curDate) {
+      anchorSnapDate.set(snap.holding.security_id, snapDate);
+      qtyBySec.set(snap.holding.security_id, snap.holding.quantity ?? 0);
     }
   });
 
-  // Walk txns in (windowStart, date] to derive qty delta per security.
-  const qtyDelta = new Map<string, number>();
+  // 2) Walk txns in (windowStart, date] and adjust qty per security.
   investmentTransactions.forEach((t) => {
     if (t.account_id !== accountId) return;
     if (t.security_id == null) return;
@@ -241,24 +248,64 @@ export const valueAt = (params: {
     if (txnDate <= windowStart) return;
     if (txnDate > date) return;
     const signed = t.type === "buy" ? Math.abs(t.quantity) : -Math.abs(t.quantity);
-    qtyDelta.set(t.security_id, (qtyDelta.get(t.security_id) ?? 0) + signed);
+    qtyBySec.set(t.security_id, (qtyBySec.get(t.security_id) ?? 0) + signed);
   });
 
-  // Union of security_ids seen in either anchor or txns
-  const allSecIds = new Set<string>([...anchorQty.keys(), ...qtyDelta.keys()]);
+  // 3) For securities with no pre-window snapshot anchor but with
+  //    investment_transactions BEFORE windowStart (e.g. the user's first
+  //    txn was in 2022 but our holding-snapshot history only starts in
+  //    2025 — anchored-at-first-txn use case), build the anchor from
+  //    txn history at-or-before windowStart.
+  investmentTransactions.forEach((t) => {
+    if (t.account_id !== accountId) return;
+    if (t.security_id == null) return;
+    if (cashSecs.has(t.security_id)) return;
+    if (t.quantity == null || t.quantity === 0) return;
+    if (t.type !== "buy" && t.type !== "sell") return;
+    if (anchorSnapDate.has(t.security_id)) return; // anchor came from holding snap
+    const txnDate = t.date.slice(0, 10);
+    if (txnDate > windowStart) return; // already counted in step 2
+    const signed = t.type === "buy" ? Math.abs(t.quantity) : -Math.abs(t.quantity);
+    qtyBySec.set(t.security_id, (qtyBySec.get(t.security_id) ?? 0) + signed);
+  });
 
   let total = 0;
-  allSecIds.forEach((sid) => {
-    if (cashSecs.has(sid)) return; // cash-excluded
-    const anchor = anchorQty.get(sid)?.qtyAtAnchor ?? 0;
-    const delta = qtyDelta.get(sid) ?? 0;
-    const qty = anchor + delta;
+  qtyBySec.forEach((qty, sid) => {
+    if (cashSecs.has(sid)) return;
     if (qty <= 0) return;
     const price = priceAt(sid, date);
     if (price === null) return;
     total += qty * price;
   });
   return total;
+};
+
+/**
+ * The earliest date for which we have *any* data for the account —
+ * either a holding snapshot or an investment transaction. Used as the
+ * "All" window start, and as the clamp floor for shorter windows.
+ *
+ * If the account has txn history that predates the holding snapshot
+ * history (common — txns go back further), the earliest txn wins.
+ */
+export const earliestDataDate = (params: {
+  accountId: string;
+  holdingSnapshots: HoldingSnapshotDictionary;
+  investmentTransactions: InvestmentTransactionDictionary;
+}): string | null => {
+  const { accountId, holdingSnapshots, investmentTransactions } = params;
+  let earliest: string | null = null;
+  holdingSnapshots.forEach((snap) => {
+    if (snap.holding.account_id !== accountId) return;
+    const d = snap.snapshot.date.slice(0, 10);
+    if (!earliest || d < earliest) earliest = d;
+  });
+  investmentTransactions.forEach((t) => {
+    if (t.account_id !== accountId) return;
+    const d = t.date.slice(0, 10);
+    if (!earliest || d < earliest) earliest = d;
+  });
+  return earliest;
 };
 
 /**

--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -325,6 +325,18 @@ export const buildPriceAt = (securitySnapshots: SecuritySnapshotDictionary) => {
   });
   bySec.forEach((arr) => arr.sort((a, b) => (a.date < b.date ? -1 : 1)));
 
+  // Walks the price index for a security: prefer latest snapshot ≤ date,
+  // fall back to earliest snapshot when the query date predates all our
+  // price history. The fall-back lets valueAt produce a *non-zero* V_start
+  // for windows that extend back to a user's first transaction date, even
+  // when the security-snapshot history begins later — same trade-off Hoie
+  // accepted on the "exclude phantom holdings" change: an approximation
+  // that's strictly more useful than reporting `null` and zeroing V_start.
+  // The benchmark TWR is more sensitive to this (since it's literally
+  // priceEnd/priceStart); callers that want strict prices can check
+  // `priceAt(sid, date) === null` before the fall-back. We don't expose
+  // that here because both call sites (`valueAt`, the benchmark resolver)
+  // are fine with the fallback semantics.
   return (securityId: string, date: string): number | null => {
     const arr = bySec.get(securityId);
     if (!arr || arr.length === 0) return null;
@@ -333,6 +345,8 @@ export const buildPriceAt = (securitySnapshots: SecuritySnapshotDictionary) => {
       if (entry.date <= date) best = entry.price;
       else break;
     }
+    // Pre-history fallback: earliest known price.
+    if (best === null) best = arr[0].price;
     return best;
   };
 };

--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -1,0 +1,346 @@
+import { InvestmentTransactionType } from "plaid";
+import { InvestmentTransactionDictionary, HoldingSnapshotDictionary, SecuritySnapshotDictionary } from "../../models/Data";
+
+/**
+ * Performance benchmarking math — money-weighted return (IRR) + index benchmark.
+ *
+ * Pure functions only — no React, no appContext. Components pass in the
+ * relevant dictionaries from `appContext.data` and the per-account scope.
+ * Methodology reference (Hoie 2026-05-16): MWR for "what did my money do",
+ * benchmark TWR for "what would lump-sum buy-and-hold have returned over the
+ * same window". MWR < benchmark for steady-DCA accounts is expected because
+ * dollars contributed mid-window have spent less time earning — that's the
+ * dollar-weighting effect, not strategy underperformance.
+ *
+ * See `~/budget/issues/377` for the widget scope.
+ */
+
+export interface CashFlow {
+  /** Date the flow hit the account, as YYYY-MM-DD. */
+  date: string;
+  /** Signed amount. Positive = external deposit IN, negative = withdrawal OUT. */
+  amount: number;
+}
+
+export interface MwrResult {
+  status: "ok" | "no_solution";
+  /** Annualized rate (e.g. 0.1781 = 17.81%). Null when status != "ok". */
+  annualized: number | null;
+  /** Cumulative-over-window equivalent: (1 + annualized)^years - 1. */
+  cumulative: number | null;
+}
+
+export interface BenchmarkResult {
+  /** (priceEnd / priceStart) - 1 */
+  cumulative: number;
+  /** (1 + cumulative)^(1/years) - 1 */
+  annualized: number;
+}
+
+/**
+ * Detect cash-shape holdings from a snapshot record. Mirrors the FE
+ * `isCash` heuristic used in `HoldingsComposition` — Plaid surfaces cash
+ * positions with `institution_price === 1` and no real cost basis, and
+ * the wire serializer collapses null cost_basis to 0, so we accept both.
+ */
+const isCashShapeHolding = (h: { institution_price?: number | null; cost_basis?: number | null }) =>
+  h.institution_price === 1 && (h.cost_basis === null || h.cost_basis === undefined || h.cost_basis === 0);
+
+/**
+ * Build the set of cash-shape security_ids for an account from the
+ * latest holding snapshot of each (account, security). A security is
+ * considered cash-shape if any of its snapshots looked cash-shape — we
+ * conservatively classify the security itself, not per-snapshot.
+ */
+const cashSecurityIdsForAccount = (
+  holdingSnapshots: HoldingSnapshotDictionary,
+  accountId: string,
+): Set<string> => {
+  const out = new Set<string>();
+  holdingSnapshots.forEach((snap) => {
+    if (snap.holding.account_id !== accountId) return;
+    if (isCashShapeHolding(snap.holding)) out.add(snap.holding.security_id);
+  });
+  return out;
+};
+
+const DEFAULT_MATCH_WINDOW_DAYS = 7;
+
+interface AssetLeg {
+  date: string;
+  amount: number;
+  type: "buy" | "sell";
+}
+
+const daysBetween = (a: string, b: string): number => {
+  const aT = new Date(a).getTime();
+  const bT = new Date(b).getTime();
+  return Math.abs(aT - bT) / (1000 * 60 * 60 * 24);
+};
+
+/**
+ * Classify investment transactions for an account into the external
+ * cash-flow stream needed for MWR computation. Internal reallocations
+ * (buy-cash paired with a sell-asset, etc.) are dropped.
+ *
+ * Rules:
+ *   - type='cash' subtype='deposit' → +abs(amount), external IN. Plaid
+ *     reports these with negative amounts ("money coming in") so we flip.
+ *   - type='cash' subtype='withdrawal' → -abs(amount), external OUT.
+ *   - type='buy' on a cash-shape security with amount > $1 → external IN
+ *     **unless** matched by an opposite-sign asset leg within ±7 days
+ *     (then it's an internal sale-proceeds-returning-to-cash event).
+ *   - type='sell' on a cash-shape security → external OUT unless matched.
+ *   - Asset buy/sell and fee/dividend → internal, skipped.
+ *
+ * Dedupe: when both a `cash/deposit` and a `buy CASH` of the same
+ * magnitude land on the same day (Plaid double-reports some deposits),
+ * count only the explicit `cash/deposit` row.
+ */
+export const extractCashFlows = (
+  investmentTransactions: InvestmentTransactionDictionary,
+  holdingSnapshots: HoldingSnapshotDictionary,
+  accountId: string,
+  options: { matchWindowDays?: number } = {},
+): CashFlow[] => {
+  const matchWindow = options.matchWindowDays ?? DEFAULT_MATCH_WINDOW_DAYS;
+  const cashSecs = cashSecurityIdsForAccount(holdingSnapshots, accountId);
+
+  const allTxns: { date: string; type: string; subtype: string; security_id: string | null; amount: number; quantity: number }[] = [];
+  investmentTransactions.forEach((t) => {
+    if (t.account_id !== accountId) return;
+    allTxns.push({
+      date: t.date.slice(0, 10),
+      type: t.type,
+      subtype: t.subtype,
+      security_id: t.security_id,
+      amount: t.amount ?? 0,
+      quantity: t.quantity ?? 0,
+    });
+  });
+
+  // Asset legs = non-cash-shape buy/sell with non-zero quantity. The
+  // matching heuristic looks for these to identify internal sweep moves.
+  const assetLegs: AssetLeg[] = allTxns
+    .filter((t) => {
+      if (t.security_id == null) return false;
+      if (cashSecs.has(t.security_id)) return false;
+      if (t.type !== InvestmentTransactionType.Buy && t.type !== InvestmentTransactionType.Sell) return false;
+      return t.quantity !== 0;
+    })
+    .map((t) => ({ date: t.date, amount: t.amount, type: t.type as "buy" | "sell" }));
+
+  const isMatchedByAsset = (cashLeg: { date: string; type: string; amount: number }): boolean => {
+    const target = Math.abs(cashLeg.amount);
+    for (const a of assetLegs) {
+      if (daysBetween(a.date, cashLeg.date) > matchWindow) continue;
+      // Cash SELL (money out of sweep) matches an asset BUY funded from cash.
+      if (cashLeg.type === "sell" && a.type !== "buy") continue;
+      // Cash BUY (money into sweep) matches an asset SELL whose proceeds return.
+      if (cashLeg.type === "buy" && a.type !== "sell") continue;
+      if (Math.abs(Math.abs(a.amount) - target) < Math.max(0.5, target * 0.01)) return true;
+    }
+    return false;
+  };
+
+  // Dedupe set: (date, abs_amount) of explicit cash/deposit and cash/withdrawal rows.
+  const explicitCashEvents = new Set<string>();
+  for (const t of allTxns) {
+    if (t.type === InvestmentTransactionType.Cash && (t.subtype === "deposit" || t.subtype === "withdrawal")) {
+      explicitCashEvents.add(`${t.date}|${Math.abs(t.amount).toFixed(2)}`);
+    }
+  }
+
+  const flowsByDate = new Map<string, number>();
+  for (const t of allTxns) {
+    if (t.type === InvestmentTransactionType.Cash && t.subtype === "deposit") {
+      flowsByDate.set(t.date, (flowsByDate.get(t.date) ?? 0) + -t.amount);
+      continue;
+    }
+    if (t.type === InvestmentTransactionType.Cash && t.subtype === "withdrawal") {
+      flowsByDate.set(t.date, (flowsByDate.get(t.date) ?? 0) + -Math.abs(t.amount));
+      continue;
+    }
+    if (t.security_id == null || !cashSecs.has(t.security_id)) continue;
+    if (t.type === InvestmentTransactionType.Buy && t.amount > 1) {
+      const key = `${t.date}|${t.amount.toFixed(2)}`;
+      if (explicitCashEvents.has(key)) continue;
+      if (isMatchedByAsset(t)) continue;
+      flowsByDate.set(t.date, (flowsByDate.get(t.date) ?? 0) + t.amount);
+    } else if (t.type === InvestmentTransactionType.Sell && Math.abs(t.amount) > 1) {
+      const key = `${t.date}|${Math.abs(t.amount).toFixed(2)}`;
+      if (explicitCashEvents.has(key)) continue;
+      if (isMatchedByAsset(t)) continue;
+      flowsByDate.set(t.date, (flowsByDate.get(t.date) ?? 0) + t.amount);
+    }
+  }
+
+  return Array.from(flowsByDate.entries())
+    .map(([date, amount]) => ({ date, amount }))
+    .sort((a, b) => (a.date < b.date ? -1 : 1));
+};
+
+const yearsBetween = (start: string, end: string): number => {
+  const startT = new Date(start).getTime();
+  const endT = new Date(end).getTime();
+  return Math.max((endT - startT) / (1000 * 60 * 60 * 24 * 365), 0.001);
+};
+
+/**
+ * Solve the IRR equation:
+ *   −V_start + Σᵢ (−Cᵢ / (1+r)^tᵢ) + V_end / (1+r)^T = 0
+ *
+ * Bisection over `[-0.99, 10]`. Returns `no_solution` when the sign
+ * of NPV doesn't change between the bounds (rare; typically only
+ * happens when V_start = 0 and flows + V_end yield a degenerate stream).
+ */
+export const computeMWR = (params: {
+  flows: CashFlow[];
+  vStart: number;
+  vEnd: number;
+  windowStart: string;
+  windowEnd: string;
+}): MwrResult => {
+  const { flows, vStart, vEnd, windowStart, windowEnd } = params;
+  const years = yearsBetween(windowStart, windowEnd);
+  const tEnd = years;
+
+  const npv = (rate: number): number => {
+    let total = -vStart;
+    for (const f of flows) {
+      const t = yearsBetween(windowStart, f.date);
+      total += -f.amount / Math.pow(1 + rate, t);
+    }
+    total += vEnd / Math.pow(1 + rate, tEnd);
+    return total;
+  };
+
+  const lo0 = -0.99;
+  const hi0 = 10.0;
+  if (npv(lo0) * npv(hi0) > 0) {
+    return { status: "no_solution", annualized: null, cumulative: null };
+  }
+  let lo = lo0;
+  let hi = hi0;
+  for (let i = 0; i < 200; i++) {
+    const mid = (lo + hi) / 2;
+    if (npv(mid) * npv(lo) <= 0) hi = mid;
+    else lo = mid;
+  }
+  const annualized = (lo + hi) / 2;
+  const cumulative = Math.pow(1 + annualized, years) - 1;
+  return { status: "ok", annualized, cumulative };
+};
+
+/**
+ * Benchmark return for a passive security held over the same window.
+ * For an ETF like VOO with no contributions, TWR = simple price ratio.
+ *
+ * `priceAt` is the price lookup function — typically a closure over
+ * `data.securitySnapshots` that returns the close_price for a security
+ * on a given date, with optional walk-back to the latest available
+ * date ≤ requested.
+ */
+export const computeBenchmarkTWR = (params: {
+  priceStart: number;
+  priceEnd: number;
+  windowStart: string;
+  windowEnd: string;
+}): BenchmarkResult => {
+  const { priceStart, priceEnd, windowStart, windowEnd } = params;
+  const years = yearsBetween(windowStart, windowEnd);
+  const cumulative = priceEnd / priceStart - 1;
+  const annualized = Math.pow(1 + cumulative, 1 / years) - 1;
+  return { cumulative, annualized };
+};
+
+/**
+ * Portfolio value at a given date: Σ(security_id) qty_at(t) × price_at(t).
+ *   - qty_at(t) = latest holding_snapshot for (account, security) with date ≤ t.
+ *   - price_at(t) for cash-shape = 1.
+ *   - price_at(t) for non-cash = priceAt(security_id, t) from securitySnapshots.
+ *
+ * Returns 0 when no holding snapshots have been recorded yet.
+ */
+export const valueAt = (params: {
+  date: string;
+  accountId: string;
+  holdingSnapshots: HoldingSnapshotDictionary;
+  priceAt: (securityId: string, date: string) => number | null;
+}): number => {
+  const { date, accountId, holdingSnapshots, priceAt } = params;
+  // Per-security latest snapshot ≤ date
+  const latestBySec = new Map<string, { date: string; qty: number; isCash: boolean }>();
+  holdingSnapshots.forEach((snap) => {
+    if (snap.holding.account_id !== accountId) return;
+    const snapDate = snap.snapshot.date.slice(0, 10);
+    if (snapDate > date) return;
+    const cur = latestBySec.get(snap.holding.security_id);
+    if (!cur || snapDate > cur.date) {
+      latestBySec.set(snap.holding.security_id, {
+        date: snapDate,
+        qty: snap.holding.quantity ?? 0,
+        isCash: isCashShapeHolding(snap.holding),
+      });
+    }
+  });
+
+  let total = 0;
+  latestBySec.forEach((entry, secId) => {
+    if (entry.qty === 0) return;
+    if (entry.isCash) {
+      total += entry.qty * 1;
+    } else {
+      const price = priceAt(secId, date);
+      if (price === null) return;
+      total += entry.qty * price;
+    }
+  });
+  return total;
+};
+
+/**
+ * Build a price lookup function over `securitySnapshots`. For a given
+ * (security_id, date) the function returns the close_price of the latest
+ * snapshot whose date is ≤ the requested date. Returns null when no such
+ * snapshot exists. Typical caller: VOO price lookup for the benchmark.
+ */
+export const buildPriceAt = (securitySnapshots: SecuritySnapshotDictionary) => {
+  // Build a per-security sorted (date, price) array once for fast lookup.
+  const bySec = new Map<string, Array<{ date: string; price: number }>>();
+  securitySnapshots.forEach((snap) => {
+    const close = snap.security.close_price;
+    if (close == null) return;
+    const arr = bySec.get(snap.security.security_id) ?? [];
+    arr.push({ date: snap.snapshot.date.slice(0, 10), price: close });
+    bySec.set(snap.security.security_id, arr);
+  });
+  bySec.forEach((arr) => arr.sort((a, b) => (a.date < b.date ? -1 : 1)));
+
+  return (securityId: string, date: string): number | null => {
+    const arr = bySec.get(securityId);
+    if (!arr || arr.length === 0) return null;
+    let best: number | null = null;
+    for (const entry of arr) {
+      if (entry.date <= date) best = entry.price;
+      else break;
+    }
+    return best;
+  };
+};
+
+/**
+ * Resolve the security_id for a benchmark ticker (default VOO) from
+ * `securitySnapshots`. Returns null if the ticker has no security row.
+ */
+export const findBenchmarkSecurityId = (
+  securitySnapshots: SecuritySnapshotDictionary,
+  ticker: string,
+): string | null => {
+  let found: string | null = null;
+  securitySnapshots.forEach((snap) => {
+    if (found) return;
+    if (snap.security.ticker_symbol === ticker) found = snap.security.security_id;
+  });
+  return found;
+};

--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -366,3 +366,25 @@ export const findBenchmarkSecurityId = (
   });
   return found;
 };
+
+/**
+ * Earliest snapshot date we have for a given security_id, formatted as
+ * YYYY-MM-DD. Returns null when the security has no priced snapshots.
+ *
+ * Used by the benchmark resolver so it can narrow the comparison window
+ * to the overlap of [user-chosen window] and [available benchmark data]
+ * when the user-chosen window extends before our snapshot history.
+ */
+export const firstPricedSnapshotDate = (
+  securitySnapshots: SecuritySnapshotDictionary,
+  securityId: string,
+): string | null => {
+  let earliest: string | null = null;
+  securitySnapshots.forEach((snap) => {
+    if (snap.security.security_id !== securityId) return;
+    if (snap.security.close_price == null) return;
+    const d = snap.snapshot.date.slice(0, 10);
+    if (earliest === null || d < earliest) earliest = d;
+  });
+  return earliest;
+};

--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -184,38 +184,79 @@ export const computeBenchmarkTWR = (params: {
  * Cash-shape holdings (per `isCashShapeHolding`) are excluded — the
  * widget's scope is the asset portfolio, not the total account.
  *
+ * **`qty(t)` is txn-derived** (Hoie 2026-05-16). For each non-cash security:
+ *   qty(t) = qty_from_holding_snapshot_at_windowStart
+ *          + Σ(buy.quantity − sell.quantity from txns in (windowStart, t])
+ *
+ * This guards against holdings that update faster than the txn stream — a
+ * Plaid sync gap where the FE sees +N shares in `holding_snapshots` but the
+ * corresponding `buy` txn hasn't landed yet would otherwise have IRR
+ * "explain" the unaccounted value as growth and inflate the MWR. With this
+ * txn-walk, the unaccounted shares are invisible to the widget until their
+ * matching txn arrives.
+ *
+ * `windowStart` anchors pre-window history we can't reconstruct from txns
+ * (the user may have years of holdings predating the snapshot history we
+ * have). For `t = windowStart`, this collapses to "holding snapshot qty"
+ * which is what we want for V_start.
+ *
  * Returns 0 when no non-cash holding snapshots have been recorded yet.
  */
 export const valueAt = (params: {
   date: string;
+  windowStart: string;
   accountId: string;
   holdingSnapshots: HoldingSnapshotDictionary;
+  investmentTransactions: InvestmentTransactionDictionary;
   priceAt: (securityId: string, date: string) => number | null;
 }): number => {
-  const { date, accountId, holdingSnapshots, priceAt } = params;
-  // Per-security latest snapshot ≤ date
-  const latestBySec = new Map<string, { date: string; qty: number; isCash: boolean }>();
+  const { date, windowStart, accountId, holdingSnapshots, investmentTransactions, priceAt } = params;
+
+  const cashSecs = cashSecurityIdsForAccount(holdingSnapshots, accountId);
+
+  // Anchor qty: latest holding snapshot ≤ windowStart for each (account, security).
+  const anchorQty = new Map<string, { qtyAtAnchor: number; latestSnapDate: string }>();
   holdingSnapshots.forEach((snap) => {
     if (snap.holding.account_id !== accountId) return;
     const snapDate = snap.snapshot.date.slice(0, 10);
-    if (snapDate > date) return;
-    const cur = latestBySec.get(snap.holding.security_id);
-    if (!cur || snapDate > cur.date) {
-      latestBySec.set(snap.holding.security_id, {
-        date: snapDate,
-        qty: snap.holding.quantity ?? 0,
-        isCash: isCashShapeHolding(snap.holding),
+    if (snapDate > windowStart) return;
+    const cur = anchorQty.get(snap.holding.security_id);
+    if (!cur || snapDate > cur.latestSnapDate) {
+      anchorQty.set(snap.holding.security_id, {
+        qtyAtAnchor: snap.holding.quantity ?? 0,
+        latestSnapDate: snapDate,
       });
     }
   });
 
+  // Walk txns in (windowStart, date] to derive qty delta per security.
+  const qtyDelta = new Map<string, number>();
+  investmentTransactions.forEach((t) => {
+    if (t.account_id !== accountId) return;
+    if (t.security_id == null) return;
+    if (cashSecs.has(t.security_id)) return;
+    if (t.quantity == null || t.quantity === 0) return;
+    if (t.type !== "buy" && t.type !== "sell") return;
+    const txnDate = t.date.slice(0, 10);
+    if (txnDate <= windowStart) return;
+    if (txnDate > date) return;
+    const signed = t.type === "buy" ? Math.abs(t.quantity) : -Math.abs(t.quantity);
+    qtyDelta.set(t.security_id, (qtyDelta.get(t.security_id) ?? 0) + signed);
+  });
+
+  // Union of security_ids seen in either anchor or txns
+  const allSecIds = new Set<string>([...anchorQty.keys(), ...qtyDelta.keys()]);
+
   let total = 0;
-  latestBySec.forEach((entry, secId) => {
-    if (entry.qty === 0) return;
-    if (entry.isCash) return; // cash-excluded
-    const price = priceAt(secId, date);
+  allSecIds.forEach((sid) => {
+    if (cashSecs.has(sid)) return; // cash-excluded
+    const anchor = anchorQty.get(sid)?.qtyAtAnchor ?? 0;
+    const delta = qtyDelta.get(sid) ?? 0;
+    const qty = anchor + delta;
+    if (qty <= 0) return;
+    const price = priceAt(sid, date);
     if (price === null) return;
-    total += entry.qty * price;
+    total += qty * price;
   });
   return total;
 };

--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -2,23 +2,31 @@ import { InvestmentTransactionType } from "plaid";
 import { InvestmentTransactionDictionary, HoldingSnapshotDictionary, SecuritySnapshotDictionary } from "../../models/Data";
 
 /**
- * Performance benchmarking math — money-weighted return (IRR) + index benchmark.
+ * Investment-performance benchmarking math — money-weighted return (IRR) of
+ * the user's non-cash positions plus an index TWR for the same window.
+ *
+ * **Scope (Hoie 2026-05-16): cash is excluded.** The "portfolio" tracked here
+ * is the user's non-cash holdings only (VOO etc.); cash positions (QACDS,
+ * pending-settlement orphans, USD sweep balances) are deliberately ignored.
+ * Every asset BUY counts as an external deposit into the asset portfolio and
+ * every asset SELL counts as a withdrawal. Cash/deposit/withdrawal rows and
+ * `fee/dividend` rows are skipped. This sidesteps the settlement-pending
+ * complexity that surfaced in the v1 spike against real prod data — at the
+ * cost of underreporting dividends/interest credited to cash. The
+ * cash-inclusive version is tracked separately (see follow-up issue).
  *
  * Pure functions only — no React, no appContext. Components pass in the
  * relevant dictionaries from `appContext.data` and the per-account scope.
- * Methodology reference (Hoie 2026-05-16): MWR for "what did my money do",
- * benchmark TWR for "what would lump-sum buy-and-hold have returned over the
- * same window". MWR < benchmark for steady-DCA accounts is expected because
- * dollars contributed mid-window have spent less time earning — that's the
- * dollar-weighting effect, not strategy underperformance.
- *
- * See `~/budget/issues/377` for the widget scope.
  */
 
 export interface CashFlow {
-  /** Date the flow hit the account, as YYYY-MM-DD. */
+  /** Date the flow hit the asset portfolio, as YYYY-MM-DD. */
   date: string;
-  /** Signed amount. Positive = external deposit IN, negative = withdrawal OUT. */
+  /**
+   * Signed amount in account currency. Positive = asset purchased
+   * (external IN, money entering the asset side from elsewhere).
+   * Negative = asset sold (external OUT, money leaving the asset side).
+   */
   amount: number;
 }
 
@@ -38,20 +46,15 @@ export interface BenchmarkResult {
 }
 
 /**
- * Detect cash-shape holdings from a snapshot record. Mirrors the FE
- * `isCash` heuristic used in `HoldingsComposition` — Plaid surfaces cash
- * positions with `institution_price === 1` and no real cost basis, and
- * the wire serializer collapses null cost_basis to 0, so we accept both.
+ * Cash-shape detector — mirrors the `isCash` heuristic in
+ * `HoldingsComposition`. Same security may be cash-shape across all its
+ * snapshots; we conservatively classify the *security_id* itself, so a
+ * holding that ever appeared as cash-shape stays excluded from the
+ * asset-portfolio view.
  */
 const isCashShapeHolding = (h: { institution_price?: number | null; cost_basis?: number | null }) =>
   h.institution_price === 1 && (h.cost_basis === null || h.cost_basis === undefined || h.cost_basis === 0);
 
-/**
- * Build the set of cash-shape security_ids for an account from the
- * latest holding snapshot of each (account, security). A security is
- * considered cash-shape if any of its snapshots looked cash-shape — we
- * conservatively classify the security itself, not per-snapshot.
- */
 const cashSecurityIdsForAccount = (
   holdingSnapshots: HoldingSnapshotDictionary,
   accountId: string,
@@ -64,116 +67,40 @@ const cashSecurityIdsForAccount = (
   return out;
 };
 
-const DEFAULT_MATCH_WINDOW_DAYS = 7;
-
-interface AssetLeg {
-  date: string;
-  amount: number;
-  type: "buy" | "sell";
-}
-
-const daysBetween = (a: string, b: string): number => {
-  const aT = new Date(a).getTime();
-  const bT = new Date(b).getTime();
-  return Math.abs(aT - bT) / (1000 * 60 * 60 * 24);
-};
-
 /**
- * Classify investment transactions for an account into the external
- * cash-flow stream needed for MWR computation. Internal reallocations
- * (buy-cash paired with a sell-asset, etc.) are dropped.
+ * Build the external-flow stream from a user's investment transactions.
  *
- * Rules:
- *   - type='cash' subtype='deposit' → +abs(amount), external IN. Plaid
- *     reports these with negative amounts ("money coming in") so we flip.
- *   - type='cash' subtype='withdrawal' → -abs(amount), external OUT.
- *   - type='buy' on a cash-shape security with amount > $1 → external IN
- *     **unless** matched by an opposite-sign asset leg within ±7 days
- *     (then it's an internal sale-proceeds-returning-to-cash event).
- *   - type='sell' on a cash-shape security → external OUT unless matched.
- *   - Asset buy/sell and fee/dividend → internal, skipped.
+ * **Cash-excluded model:** an "external flow" is any movement of money
+ * into or out of the *asset side* of the portfolio. That maps onto Plaid's
+ * `type` field cleanly:
  *
- * Dedupe: when both a `cash/deposit` and a `buy CASH` of the same
- * magnitude land on the same day (Plaid double-reports some deposits),
- * count only the explicit `cash/deposit` row.
+ *   - `type='buy'` on a non-cash security → external IN (+amount).
+ *   - `type='sell'` on a non-cash security → external OUT (−|amount|).
+ *   - Everything else (`cash/deposit`, `cash/withdrawal`, `fee/dividend`,
+ *     `buy`/`sell` on cash-shape securities) → skipped. Those are cash-side
+ *     events and we're not tracking cash.
+ *
+ * Same-day flows for the same account are summed.
  */
 export const extractCashFlows = (
   investmentTransactions: InvestmentTransactionDictionary,
   holdingSnapshots: HoldingSnapshotDictionary,
   accountId: string,
-  options: { matchWindowDays?: number } = {},
 ): CashFlow[] => {
-  const matchWindow = options.matchWindowDays ?? DEFAULT_MATCH_WINDOW_DAYS;
   const cashSecs = cashSecurityIdsForAccount(holdingSnapshots, accountId);
+  const flowsByDate = new Map<string, number>();
 
-  const allTxns: { date: string; type: string; subtype: string; security_id: string | null; amount: number; quantity: number }[] = [];
   investmentTransactions.forEach((t) => {
     if (t.account_id !== accountId) return;
-    allTxns.push({
-      date: t.date.slice(0, 10),
-      type: t.type,
-      subtype: t.subtype,
-      security_id: t.security_id,
-      amount: t.amount ?? 0,
-      quantity: t.quantity ?? 0,
-    });
+    if (t.security_id == null) return;
+    if (cashSecs.has(t.security_id)) return; // cash-side event, skip
+    if (t.quantity == null || t.quantity === 0) return; // qty=0 rows aren't real asset moves
+    if (t.type !== InvestmentTransactionType.Buy && t.type !== InvestmentTransactionType.Sell) return;
+
+    const date = t.date.slice(0, 10);
+    const signed = t.type === InvestmentTransactionType.Buy ? t.amount : -Math.abs(t.amount);
+    flowsByDate.set(date, (flowsByDate.get(date) ?? 0) + signed);
   });
-
-  // Asset legs = non-cash-shape buy/sell with non-zero quantity. The
-  // matching heuristic looks for these to identify internal sweep moves.
-  const assetLegs: AssetLeg[] = allTxns
-    .filter((t) => {
-      if (t.security_id == null) return false;
-      if (cashSecs.has(t.security_id)) return false;
-      if (t.type !== InvestmentTransactionType.Buy && t.type !== InvestmentTransactionType.Sell) return false;
-      return t.quantity !== 0;
-    })
-    .map((t) => ({ date: t.date, amount: t.amount, type: t.type as "buy" | "sell" }));
-
-  const isMatchedByAsset = (cashLeg: { date: string; type: string; amount: number }): boolean => {
-    const target = Math.abs(cashLeg.amount);
-    for (const a of assetLegs) {
-      if (daysBetween(a.date, cashLeg.date) > matchWindow) continue;
-      // Cash SELL (money out of sweep) matches an asset BUY funded from cash.
-      if (cashLeg.type === "sell" && a.type !== "buy") continue;
-      // Cash BUY (money into sweep) matches an asset SELL whose proceeds return.
-      if (cashLeg.type === "buy" && a.type !== "sell") continue;
-      if (Math.abs(Math.abs(a.amount) - target) < Math.max(0.5, target * 0.01)) return true;
-    }
-    return false;
-  };
-
-  // Dedupe set: (date, abs_amount) of explicit cash/deposit and cash/withdrawal rows.
-  const explicitCashEvents = new Set<string>();
-  for (const t of allTxns) {
-    if (t.type === InvestmentTransactionType.Cash && (t.subtype === "deposit" || t.subtype === "withdrawal")) {
-      explicitCashEvents.add(`${t.date}|${Math.abs(t.amount).toFixed(2)}`);
-    }
-  }
-
-  const flowsByDate = new Map<string, number>();
-  for (const t of allTxns) {
-    if (t.type === InvestmentTransactionType.Cash && t.subtype === "deposit") {
-      flowsByDate.set(t.date, (flowsByDate.get(t.date) ?? 0) + -t.amount);
-      continue;
-    }
-    if (t.type === InvestmentTransactionType.Cash && t.subtype === "withdrawal") {
-      flowsByDate.set(t.date, (flowsByDate.get(t.date) ?? 0) + -Math.abs(t.amount));
-      continue;
-    }
-    if (t.security_id == null || !cashSecs.has(t.security_id)) continue;
-    if (t.type === InvestmentTransactionType.Buy && t.amount > 1) {
-      const key = `${t.date}|${t.amount.toFixed(2)}`;
-      if (explicitCashEvents.has(key)) continue;
-      if (isMatchedByAsset(t)) continue;
-      flowsByDate.set(t.date, (flowsByDate.get(t.date) ?? 0) + t.amount);
-    } else if (t.type === InvestmentTransactionType.Sell && Math.abs(t.amount) > 1) {
-      const key = `${t.date}|${Math.abs(t.amount).toFixed(2)}`;
-      if (explicitCashEvents.has(key)) continue;
-      if (isMatchedByAsset(t)) continue;
-      flowsByDate.set(t.date, (flowsByDate.get(t.date) ?? 0) + t.amount);
-    }
-  }
 
   return Array.from(flowsByDate.entries())
     .map(([date, amount]) => ({ date, amount }))
@@ -187,12 +114,14 @@ const yearsBetween = (start: string, end: string): number => {
 };
 
 /**
- * Solve the IRR equation:
+ * Solve the IRR equation for the asset-side cash flows:
  *   −V_start + Σᵢ (−Cᵢ / (1+r)^tᵢ) + V_end / (1+r)^T = 0
  *
- * Bisection over `[-0.99, 10]`. Returns `no_solution` when the sign
- * of NPV doesn't change between the bounds (rare; typically only
- * happens when V_start = 0 and flows + V_end yield a degenerate stream).
+ * `V_start` and `V_end` are the non-cash asset values at the window
+ * boundaries (cash positions excluded — see `valueAt`).
+ *
+ * Bisection over `[-0.99, 10]`. Returns `no_solution` when the sign of NPV
+ * doesn't change between the bounds.
  */
 export const computeMWR = (params: {
   flows: CashFlow[];
@@ -235,11 +164,6 @@ export const computeMWR = (params: {
 /**
  * Benchmark return for a passive security held over the same window.
  * For an ETF like VOO with no contributions, TWR = simple price ratio.
- *
- * `priceAt` is the price lookup function — typically a closure over
- * `data.securitySnapshots` that returns the close_price for a security
- * on a given date, with optional walk-back to the latest available
- * date ≤ requested.
  */
 export const computeBenchmarkTWR = (params: {
   priceStart: number;
@@ -255,12 +179,12 @@ export const computeBenchmarkTWR = (params: {
 };
 
 /**
- * Portfolio value at a given date: Σ(security_id) qty_at(t) × price_at(t).
- *   - qty_at(t) = latest holding_snapshot for (account, security) with date ≤ t.
- *   - price_at(t) for cash-shape = 1.
- *   - price_at(t) for non-cash = priceAt(security_id, t) from securitySnapshots.
+ * Non-cash asset value at a given date: Σ(non_cash_security_id) qty(t) × price(t).
  *
- * Returns 0 when no holding snapshots have been recorded yet.
+ * Cash-shape holdings (per `isCashShapeHolding`) are excluded — the
+ * widget's scope is the asset portfolio, not the total account.
+ *
+ * Returns 0 when no non-cash holding snapshots have been recorded yet.
  */
 export const valueAt = (params: {
   date: string;
@@ -288,13 +212,10 @@ export const valueAt = (params: {
   let total = 0;
   latestBySec.forEach((entry, secId) => {
     if (entry.qty === 0) return;
-    if (entry.isCash) {
-      total += entry.qty * 1;
-    } else {
-      const price = priceAt(secId, date);
-      if (price === null) return;
-      total += entry.qty * price;
-    }
+    if (entry.isCash) return; // cash-excluded
+    const price = priceAt(secId, date);
+    if (price === null) return;
+    total += entry.qty * price;
   });
   return total;
 };
@@ -303,10 +224,9 @@ export const valueAt = (params: {
  * Build a price lookup function over `securitySnapshots`. For a given
  * (security_id, date) the function returns the close_price of the latest
  * snapshot whose date is ≤ the requested date. Returns null when no such
- * snapshot exists. Typical caller: VOO price lookup for the benchmark.
+ * snapshot exists.
  */
 export const buildPriceAt = (securitySnapshots: SecuritySnapshotDictionary) => {
-  // Build a per-security sorted (date, price) array once for fast lookup.
   const bySec = new Map<string, Array<{ date: string; price: number }>>();
   securitySnapshots.forEach((snap) => {
     const close = snap.security.close_price;

--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -332,12 +332,13 @@ export const buildPriceAt = (securitySnapshots: SecuritySnapshotDictionary) => {
   // when the security-snapshot history begins later — same trade-off Hoie
   // accepted on the "exclude phantom holdings" change: an approximation
   // that's strictly more useful than reporting `null` and zeroing V_start.
-  // The benchmark TWR is more sensitive to this (since it's literally
-  // priceEnd/priceStart); callers that want strict prices can check
-  // `priceAt(sid, date) === null` before the fall-back. We don't expose
-  // that here because both call sites (`valueAt`, the benchmark resolver)
-  // are fine with the fallback semantics.
-  return (securityId: string, date: string): number | null => {
+  //
+  // The benchmark TWR is more sensitive to this (it's literally
+  // priceEnd/priceStart, and silently snapping windowStart to the earliest
+  // known price collapses the gauge to a constant). Pass `{ strict: true }`
+  // to disable the fallback — the benchmark resolver uses it so the
+  // benchmark row hides when the window predates VOO snapshot history.
+  return (securityId: string, date: string, opts?: { strict?: boolean }): number | null => {
     const arr = bySec.get(securityId);
     if (!arr || arr.length === 0) return null;
     let best: number | null = null;
@@ -345,8 +346,7 @@ export const buildPriceAt = (securitySnapshots: SecuritySnapshotDictionary) => {
       if (entry.date <= date) best = entry.price;
       else break;
     }
-    // Pre-history fallback: earliest known price.
-    if (best === null) best = arr[0].price;
+    if (best === null && !opts?.strict) best = arr[0].price; // pre-history fallback
     return best;
   };
 };

--- a/src/client/lib/hooks/calculation/index.ts
+++ b/src/client/lib/hooks/calculation/index.ts
@@ -1,3 +1,4 @@
 export * from "./accounts";
+export * from "./benchmark";
 export * from "./budgets";
 export * from "./holdings";


### PR DESCRIPTION
Closes #377. Follow-ups tracked in #381.

## What (v1, per Hoie 2026-05-16)
Per-investment-account widget showing the user's *asset-side* return:
- **Your asset return (MWR)** — money-weighted IRR of the non-cash positions in this account.
- **VOO benchmark** — passive lump-sum TWR over the same window.
- **vs benchmark** — annualized gap.

Window picker: **1Y / 3Y / All**, with the window automatically clamped to the earliest available data and `windowEnd` following the user's `viewDate` (capped at today). Caption shows the actual window + a "clamped to earliest data" flag when 1Y/3Y collapse to the same start as All.

**Cash is excluded.** Settlement-pending events (`buy QACDS`, the negative-cash orphan rows, etc.) sidestepped entirely. The metric scopes to "did the asset side perform well", not "did the whole brokerage account do well". The trade-off (loses dividend/interest income captured to cash) and the cash-inclusive v2 are documented in #381.

## How
FE-only. Math is in `src/client/lib/hooks/calculation/benchmark.ts` as 5 pure functions exercised by 21 unit tests:
- `extractCashFlows()` — non-cash asset buys/sells only. Skips `cash/deposit`, `cash/withdrawal`, fee/dividend, qty=0 rows, and any buy/sell on cash-shape securities.
- `valueAt()` — sums non-cash holdings only (price from `securitySnapshots`).
- `computeMWR()` — IRR bisection over `[-0.99, 10]`. Returns `no_solution` on degenerate streams.
- `computeBenchmarkTWR()` — simple price ratio over the window.
- `buildPriceAt()` / `findBenchmarkSecurityId()` — helpers.

Component is `src/client/components/PerformanceBenchmark/` (`index.tsx` + `index.css`), wired into `AccountProperties` to render below `HoldingsComposition` for investment accounts only. Reads `appContext.data` only; no new API calls, no IndexedDB writes.

## What's deferred
See **#381** for the full list — cash-inclusive MWR, data-anomaly guards, benchmark picker, multi-account aggregation, dividend reattribution, "DCA timing vs underperformance" caption.

## Verification
- `bun run test:client` — 196/196 pass (21 in `benchmark.test.ts` — covers the cash-excluded classifier rules, IRR math, benchmark TWR, valueAt scope, edge cases).
- `bun run typecheck`, `bun run lint` — clean.
- Sandbox `:20380` (unscrambled prod clone) E2E verified: widget renders, viewDate moves recalc, window picker recalcs, "clamped to earliest data" flag shows when relevant.

## Known data sensitivity in current prod
The widget reads `investmentTransactions` and `holdingSnapshots`. If those two streams are out of sync at the boundary (e.g. holdings reflect a buy that the txn-stream hasn't recorded yet, or a txn is `is_deleted=t` while its qty bump remains in holdings), the IRR is forced to "explain" the gap as growth and the number inflates. Two such anomalies exist in current Chase prod data — see #381 for details and v2 guards.

## Test plan
- [ ] Sandbox spin, navigate to Chase investment account on Account Detail.
- [ ] Verify the widget renders MWR / VOO / gap rows + caption.
- [ ] Toggle 1Y/3Y/All — values recompute (or hold the same with "clamped" flag).
- [ ] Move viewDate back and forward — values recompute.
- [ ] Visit a non-investment account — widget should NOT render.