### PR TITLE
feat(benchmark): on-demand VOO snapshot resolution via Polygon

### DIFF
--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -1,5 +1,14 @@
-import { useMemo, useState } from "react";
-import { Account, useAppContext } from "client";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Account,
+  useAppContext,
+  call,
+  Data,
+  SecuritySnapshot,
+  SecuritySnapshotDictionary,
+  indexedDb,
+} from "client";
+import type { ResolveSecuritySnapshotResponse } from "server/routes/accounts/post-resolve-security-snapshot";
 import {
   extractCashFlows,
   computeMWR,
@@ -29,10 +38,15 @@ const formatPct = (n: number | null): string => {
 
 export const PerformanceBenchmark = ({ account }: Props) => {
   const { account_id } = account;
-  const { data, viewDate } = useAppContext();
+  const { data, setData, viewDate } = useAppContext();
   const { investmentTransactions, holdingSnapshots, securitySnapshots } = data;
 
   const [windowKey, setWindowKey] = useState<WindowKey>("1Y");
+  // In-flight + already-attempted benchmark dates, keyed by
+  // `${security_id}:${date}`. Prevents duplicate fetches when the user
+  // toggles window options and re-runs the memo, and stops retry loops
+  // when Polygon returns `no_data` for a particular date.
+  const attemptedRef = useRef<Set<string>>(new Set());
 
   const computed = useMemo(() => {
     // "Earliest available data" is now `min(first_holding_snapshot, first_txn)`
@@ -153,6 +167,53 @@ export const PerformanceBenchmark = ({ account }: Props) => {
       isClamped,
     };
   }, [account_id, investmentTransactions, holdingSnapshots, securitySnapshots, windowKey, viewDate]);
+
+  // On-demand benchmark snapshot resolution. When the user-chosen window
+  // predates our VOO snapshot history, fire one request per missing date
+  // to the server, which fetches from Polygon and persists. The new
+  // snapshot is merged into AppContext so the memo re-runs with accurate
+  // full-window benchmark numbers.
+  //
+  // Hoie 2026-05-17: "FE checks availability and resolves over API if not
+  // available." We only resolve windowStart here — windowEnd is by
+  // definition recent (≤ today) and gets covered by the existing nightly
+  // snapshot pipeline, so it's already in `securitySnapshots`.
+  useEffect(() => {
+    if (!computed) return;
+    if (!computed.benchmarkNarrowed) return; // already have enough data
+    const benchmarkSecId = findBenchmarkSecurityId(securitySnapshots, BENCHMARK_TICKER);
+    if (!benchmarkSecId) return;
+
+    const date = computed.windowStart;
+    const key = `${benchmarkSecId}:${date}`;
+    if (attemptedRef.current.has(key)) return;
+    attemptedRef.current.add(key);
+
+    call
+      .post<ResolveSecuritySnapshotResponse>("/api/resolve-security-snapshot", {
+        security_id: benchmarkSecId,
+        date,
+      })
+      .then((response) => {
+        if (response.status !== "success") return;
+        const resolved = response.body?.snapshot;
+        if (!resolved) return;
+        const snap = new SecuritySnapshot(resolved);
+        indexedDb.save(snap).catch(console.error);
+        setData((oldData) => {
+          const newData = new Data(oldData);
+          const newSS = new SecuritySnapshotDictionary(newData.securitySnapshots);
+          newSS.set(snap.snapshot.snapshot_id, snap);
+          newData.securitySnapshots = newSS;
+          return newData;
+        });
+      })
+      .catch((err) => {
+        // Network/parse error — keep the key in `attempted` so we don't
+        // hammer the endpoint on every re-render. User can refresh to retry.
+        console.error("resolve-security-snapshot failed", err);
+      });
+  }, [computed, securitySnapshots, setData]);
 
   if (!computed) return null;
   const {

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -47,6 +47,10 @@ export const PerformanceBenchmark = ({ account }: Props) => {
   // toggles window options and re-runs the memo, and stops retry loops
   // when Polygon returns `no_data` for a particular date.
   const attemptedRef = useRef<Set<string>>(new Set());
+  // When the most recent resolve failed because of Polygon plan limits,
+  // surface that as a footnote so the user knows the narrowing isn't a
+  // bug — they'd need to upgrade Polygon to extend benchmark history.
+  const [planLimitedAt, setPlanLimitedAt] = useState<string | null>(null);
 
   const computed = useMemo(() => {
     // "Earliest available data" is now `min(first_holding_snapshot, first_txn)`
@@ -195,18 +199,23 @@ export const PerformanceBenchmark = ({ account }: Props) => {
         date,
       })
       .then((response) => {
-        if (response.status !== "success") return;
-        const resolved = response.body?.snapshot;
-        if (!resolved) return;
-        const snap = new SecuritySnapshot(resolved);
-        indexedDb.save(snap).catch(console.error);
-        setData((oldData) => {
-          const newData = new Data(oldData);
-          const newSS = new SecuritySnapshotDictionary(newData.securitySnapshots);
-          newSS.set(snap.snapshot.snapshot_id, snap);
-          newData.securitySnapshots = newSS;
-          return newData;
-        });
+        if (response.status !== "success" || !response.body) return;
+        const { snapshot, reason } = response.body;
+        if (snapshot) {
+          const snap = new SecuritySnapshot(snapshot);
+          indexedDb.save(snap).catch(console.error);
+          setData((oldData) => {
+            const newData = new Data(oldData);
+            const newSS = new SecuritySnapshotDictionary(newData.securitySnapshots);
+            newSS.set(snap.snapshot.snapshot_id, snap);
+            newData.securitySnapshots = newSS;
+            return newData;
+          });
+          // Clear any prior plan-limit footnote: we have data again.
+          setPlanLimitedAt(null);
+        } else if (reason === "plan_limit") {
+          setPlanLimitedAt(date);
+        }
       })
       .catch((err) => {
         // Network/parse error — keep the key in `attempted` so we don't
@@ -300,6 +309,9 @@ export const PerformanceBenchmark = ({ account }: Props) => {
           Showing {windowStart} → {windowEnd} · asset positions only (cash excluded)
           {isClamped && " · clamped to earliest data"}
           {suppressAnnualized && " · annualized hidden (window <6mo)"}
+          {planLimitedAt && benchmarkNarrowed && (
+            <> · benchmark history limited by Polygon plan</>
+          )}
         </div>
       </div>
     </>

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -172,16 +172,6 @@ export const PerformanceBenchmark = ({ account }: Props) => {
     };
   }, [account_id, investmentTransactions, holdingSnapshots, securitySnapshots, windowKey, viewDate]);
 
-  // On-demand benchmark snapshot resolution. When the user-chosen window
-  // predates our VOO snapshot history, fire one request per missing date
-  // to the server, which fetches from Polygon and persists. The new
-  // snapshot is merged into AppContext so the memo re-runs with accurate
-  // full-window benchmark numbers.
-  //
-  // Hoie 2026-05-17: "FE checks availability and resolves over API if not
-  // available." We only resolve windowStart here — windowEnd is by
-  // definition recent (≤ today) and gets covered by the existing nightly
-  // snapshot pipeline, so it's already in `securitySnapshots`.
   useEffect(() => {
     if (!computed) return;
     if (!computed.benchmarkNarrowed) return; // already have enough data

--- a/src/server/lib/polygon.test.ts
+++ b/src/server/lib/polygon.test.ts
@@ -220,15 +220,55 @@ describe("polygon", () => {
           ok: true,
           json: () =>
             Promise.resolve({
-              results: [{ c: 100, t: new Date("2024-01-15").getTime() }],
+              results: [{ c: 100, t: Date.UTC(2024, 0, 15) }],
             }),
         } as Response);
       });
 
-      await getLatestClosePriceOnOrBefore("AAPL", new Date("2024-01-15"), 3);
+      await getLatestClosePriceOnOrBefore("AAPL", "2024-01-15", 3);
       expect(seen.length).toBe(1);
       // from = date - 3d = 2024-01-12, to = date = 2024-01-15
       expect(seen[0]).toContain("/range/1/day/2024-01-12/2024-01-15");
+    });
+
+    it("returns plan_limit when Polygon responds with NOT_AUTHORIZED", async () => {
+      process.env.POLYGON_API_KEY = "test-key";
+      globalThis.fetch = mock(() =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: "NOT_AUTHORIZED",
+              message: "Your plan doesn't include this data timeframe.",
+            }),
+        } as Response),
+      );
+
+      const result = await getLatestClosePriceOnOrBefore("VOO", "2020-01-15");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe("plan_limit");
+        expect(result.message).toContain("plan");
+      }
+    });
+
+    it("preserves the trading date across timezones (UTC components, not local getDate())", async () => {
+      process.env.POLYGON_API_KEY = "test-key";
+      globalThis.fetch = mock(() =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              // Polygon's `t` for daily bars is UTC start-of-day. Reading
+              // local getDate() in PST would shift this back to 2024-01-14.
+              results: [{ c: 472.5, t: Date.UTC(2024, 0, 15) }],
+            }),
+        } as Response),
+      );
+
+      const result = await getLatestClosePriceOnOrBefore("VOO", "2024-01-15");
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.tradingDate).toBe("2024-01-15");
     });
   });
 

--- a/src/server/lib/polygon.test.ts
+++ b/src/server/lib/polygon.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import {
   getClosePrice,
+  getLatestClosePriceOnOrBefore,
   getTickerDetail,
   clearPriceCache,
   polygonQueue,
@@ -158,6 +159,76 @@ describe("polygon", () => {
       if (!result.success) {
         expect(result.error).toBe("no_data");
       }
+    });
+  });
+
+  describe("getLatestClosePriceOnOrBefore", () => {
+    it("returns no_api_key error when key is not set", async () => {
+      process.env.POLYGON_API_KEY = "";
+      const result = await getLatestClosePriceOnOrBefore("AAPL", new Date("2024-01-15"));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toBe("no_api_key");
+    });
+
+    it("returns the latest entry in the response range with its trading date", async () => {
+      process.env.POLYGON_API_KEY = "test-key";
+      // Saturday 2024-01-13 → Polygon returns Friday 2024-01-12 ($185) and
+      // Thursday 2024-01-11 ($184). Helper should pick the latest ($185)
+      // and report its tradingDate.
+      const tFri = new Date("2024-01-12").getTime();
+      const tThu = new Date("2024-01-11").getTime();
+      globalThis.fetch = mock(() =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              results: [
+                { c: 184, t: tThu },
+                { c: 185, t: tFri },
+              ],
+            }),
+        } as Response),
+      );
+
+      const result = await getLatestClosePriceOnOrBefore("AAPL", new Date("2024-01-13"));
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.price).toBe(185);
+        expect(result.data.tradingDate).toBe("2024-01-12");
+      }
+    });
+
+    it("returns no_data when response has no results", async () => {
+      process.env.POLYGON_API_KEY = "test-key";
+      globalThis.fetch = mock(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ results: [] }),
+        } as Response),
+      );
+      const result = await getLatestClosePriceOnOrBefore("AAPL", new Date("2024-01-15"));
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toBe("no_data");
+    });
+
+    it("requests a date range ending at the given date with configurable lookback", async () => {
+      process.env.POLYGON_API_KEY = "test-key";
+      const seen: string[] = [];
+      globalThis.fetch = mock((url: string) => {
+        seen.push(url);
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              results: [{ c: 100, t: new Date("2024-01-15").getTime() }],
+            }),
+        } as Response);
+      });
+
+      await getLatestClosePriceOnOrBefore("AAPL", new Date("2024-01-15"), 3);
+      expect(seen.length).toBe(1);
+      // from = date - 3d = 2024-01-12, to = date = 2024-01-15
+      expect(seen[0]).toContain("/range/1/day/2024-01-12/2024-01-15");
     });
   });
 

--- a/src/server/lib/polygon.ts
+++ b/src/server/lib/polygon.ts
@@ -201,6 +201,54 @@ export const getTickerDetail = async (
   }
 };
 
+/**
+ * Resolve the closest trading-day close price at or before `date`. Walks
+ * Polygon's daily aggregates over a 7-day window ending at `date` and
+ * returns the latest entry — that's the actual trading-day price for
+ * non-trading-day inputs (weekends, holidays). Used by the benchmark
+ * snapshot resolver so a window-start like "2023-05-13 (Saturday)"
+ * resolves to Friday's close instead of returning `no_data`.
+ */
+export const getLatestClosePriceOnOrBefore = async (
+  ticker_symbol: string,
+  date: Date,
+  lookbackDays = 7,
+): Promise<PolygonResult<{ price: number; tradingDate: string }>> => {
+  if (!getApiKey()) {
+    return { success: false, error: "no_api_key", message: "Polygon API key not configured" };
+  }
+
+  const to = getDateString(date);
+  const fromD = new Date(date);
+  fromD.setDate(fromD.getDate() - lookbackDays);
+  const from = getDateString(fromD);
+
+  const path = `${POLYGON_HOST}/v2/aggs/ticker/${ticker_symbol}/range/1/day/${from}/${to}?apiKey=${getApiKey()}`;
+
+  try {
+    const response = await polygonQueue.add(() => fetchWithRetry(path));
+    const json = await response.json();
+    const results = json.results as Array<{ c: number; t: number }> | undefined;
+    if (!results || results.length === 0) {
+      return {
+        success: false,
+        error: "no_data",
+        message: `No price data for ${ticker_symbol} in [${from}, ${to}]`,
+      };
+    }
+    // Polygon orders ascending by default; the last entry is closest to `date`.
+    const last = results[results.length - 1];
+    const tradingDate = getDateString(new Date(last.t));
+    return { success: true, data: { price: last.c, tradingDate } };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(`Polygon range fetch error for ${ticker_symbol}: ${message}`, {
+      component: "polygon",
+    });
+    return { success: false, error: "api_error", message };
+  }
+};
+
 export const getSecurityForSymbol = async (
   ticker_symbol: string,
   date = new Date(Date.now() - 24 * 60 * 60 * 1000),

--- a/src/server/lib/polygon.ts
+++ b/src/server/lib/polygon.ts
@@ -49,7 +49,11 @@ export const polygonQueue = new Queue({ capacity: getRateLimitPerMin });
  */
 export type PolygonResult<T> =
   | { success: true; data: T }
-  | { success: false; error: "no_api_key" | "api_error" | "no_data"; message: string };
+  | {
+      success: false;
+      error: "no_api_key" | "api_error" | "no_data" | "plan_limit";
+      message: string;
+    };
 
 /**
  * Simple in-memory cache for price data
@@ -211,23 +215,39 @@ export const getTickerDetail = async (
  */
 export const getLatestClosePriceOnOrBefore = async (
   ticker_symbol: string,
-  date: Date,
+  dateOrString: Date | string,
   lookbackDays = 7,
 ): Promise<PolygonResult<{ price: number; tradingDate: string }>> => {
   if (!getApiKey()) {
     return { success: false, error: "no_api_key", message: "Polygon API key not configured" };
   }
 
-  const to = getDateString(date);
-  const fromD = new Date(date);
-  fromD.setDate(fromD.getDate() - lookbackDays);
-  const from = getDateString(fromD);
+  // Compute `to` and `from` as YYYY-MM-DD purely from the string, avoiding
+  // local-timezone shifts. (PST's `getDate()` on a UTC-midnight Date is one
+  // day behind, which silently turns a 2025-05-17 lookup into 2025-05-16.)
+  const to =
+    typeof dateOrString === "string"
+      ? dateOrString.slice(0, 10)
+      : getDateString(dateOrString);
+  const toAnchor = new Date(`${to}T12:00:00Z`);
+  toAnchor.setUTCDate(toAnchor.getUTCDate() - lookbackDays);
+  const from = toAnchor.toISOString().slice(0, 10);
 
   const path = `${POLYGON_HOST}/v2/aggs/ticker/${ticker_symbol}/range/1/day/${from}/${to}?apiKey=${getApiKey()}`;
 
   try {
     const response = await polygonQueue.add(() => fetchWithRetry(path));
     const json = await response.json();
+    if (json.status === "NOT_AUTHORIZED") {
+      return {
+        success: false,
+        error: "plan_limit",
+        message:
+          typeof json.message === "string"
+            ? json.message
+            : `Polygon plan does not include data for ${ticker_symbol} in [${from}, ${to}]`,
+      };
+    }
     const results = json.results as Array<{ c: number; t: number }> | undefined;
     if (!results || results.length === 0) {
       return {
@@ -238,7 +258,11 @@ export const getLatestClosePriceOnOrBefore = async (
     }
     // Polygon orders ascending by default; the last entry is closest to `date`.
     const last = results[results.length - 1];
-    const tradingDate = getDateString(new Date(last.t));
+    // `t` is a millisecond timestamp at UTC start-of-day for daily aggregates.
+    // Read it back via UTC components to keep the trading date stable
+    // regardless of the server's local timezone.
+    const td = new Date(last.t);
+    const tradingDate = `${td.getUTCFullYear()}-${String(td.getUTCMonth() + 1).padStart(2, "0")}-${String(td.getUTCDate()).padStart(2, "0")}`;
     return { success: true, data: { price: last.c, tradingDate } };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/src/server/routes/accounts/index.ts
+++ b/src/server/routes/accounts/index.ts
@@ -17,4 +17,5 @@ export * from "./post-account";
 export * from "./post-snapshot";
 export * from "./post-holding-snapshot";
 export * from "./post-validate-ticker";
+export * from "./post-resolve-security-snapshot";
 export * from "./post-suggest-category";

--- a/src/server/routes/accounts/post-resolve-security-snapshot.ts
+++ b/src/server/routes/accounts/post-resolve-security-snapshot.ts
@@ -1,5 +1,4 @@
 import {
-  getDateString,
   getSquashedDateString,
   JSONSecuritySnapshot,
 } from "common";
@@ -18,6 +17,8 @@ export interface ResolveSecuritySnapshotResponse {
   resolved: boolean;
   snapshot?: JSONSecuritySnapshot;
   source?: "existing" | "polygon";
+  /** When resolved=false, the underlying polygon error category. */
+  reason?: "no_api_key" | "api_error" | "no_data" | "plan_limit";
   message?: string;
 }
 
@@ -65,16 +66,19 @@ export const postResolveSecuritySnapshotRoute = new Route<ResolveSecuritySnapsho
       return validationError("date is required (YYYY-MM-DD)");
     }
 
-    const requestedDate = new Date(date);
-    if (Number.isNaN(requestedDate.getTime())) {
+    // Validate by checking the leading 10 chars match YYYY-MM-DD exactly,
+    // then keep the input as a string for the rest of the route — we want
+    // the date to round-trip through Polygon without local-timezone shifts.
+    const datePrefix = date.slice(0, 10);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(datePrefix)) {
       return validationError(`invalid date: ${date}`);
     }
 
     // Don't burn a Polygon call on future dates — the market hasn't
-    // closed there yet. Cap the lookup at today.
-    const today = new Date();
-    const effectiveDate = requestedDate > today ? today : requestedDate;
-    const effectiveDateStr = getDateString(effectiveDate);
+    // closed there yet. Cap the lookup at today (string compare is safe
+    // for ISO YYYY-MM-DD).
+    const todayStr = new Date().toISOString().slice(0, 10);
+    const effectiveDateStr = datePrefix > todayStr ? todayStr : datePrefix;
 
     const security = await getSecurity(security_id);
     if (!security) {
@@ -95,7 +99,7 @@ export const postResolveSecuritySnapshotRoute = new Route<ResolveSecuritySnapsho
     const existing = await getSecuritySnapshots({ security_id, endDate: effectiveDateStr });
     if (existing.length > 0) {
       const nearest = existing[existing.length - 1]; // sorted ASC by snapshot_date
-      const nearestDate = getDateString(new Date(nearest.snapshot_date));
+      const nearestDate = nearest.snapshot_date.slice(0, 10);
       if (
         nearest.close_price != null &&
         daysBetween(nearestDate, effectiveDateStr) <= MAX_PROXIMITY_DAYS
@@ -112,27 +116,30 @@ export const postResolveSecuritySnapshotRoute = new Route<ResolveSecuritySnapsho
     }
 
     // Polygon fetch
-    const priceResult = await polygon.getLatestClosePriceOnOrBefore(ticker, effectiveDate);
+    const priceResult = await polygon.getLatestClosePriceOnOrBefore(ticker, effectiveDateStr);
     if (!priceResult.success) {
+      const message =
+        priceResult.error === "no_api_key"
+          ? "Market data API is not configured"
+          : priceResult.error === "plan_limit"
+            ? `Polygon plan doesn't include this date range`
+            : priceResult.error === "no_data"
+              ? `No price data for ${ticker} on or before ${effectiveDateStr}`
+              : `Polygon error: ${priceResult.message}`;
       return {
         status: "success",
-        body: {
-          resolved: false,
-          message:
-            priceResult.error === "no_api_key"
-              ? "Market data API is not configured"
-              : priceResult.error === "no_data"
-                ? `No price data for ${ticker} on or before ${effectiveDateStr}`
-                : `Polygon error: ${priceResult.message}`,
-        },
+        body: { resolved: false, reason: priceResult.error, message },
       };
     }
 
     const { price, tradingDate } = priceResult.data;
+    // tradingDate is already a YYYY-MM-DD string from the polygon helper.
+    // Use noon UTC for the snapshot.date timestamp so the date doesn't
+    // shift back a day when read with local-tz getDate() somewhere.
     const snapshot: JSONSecuritySnapshot = {
       snapshot: {
-        snapshot_id: `${security_id}-${getSquashedDateString(new Date(tradingDate))}`,
-        date: new Date(tradingDate).toISOString(),
+        snapshot_id: `${security_id}-${getSquashedDateString(new Date(`${tradingDate}T12:00:00Z`))}`,
+        date: `${tradingDate}T12:00:00.000Z`,
       },
       security: {
         ...security,

--- a/src/server/routes/accounts/post-resolve-security-snapshot.ts
+++ b/src/server/routes/accounts/post-resolve-security-snapshot.ts
@@ -1,0 +1,158 @@
+import {
+  getDateString,
+  getSquashedDateString,
+  JSONSecuritySnapshot,
+} from "common";
+import {
+  Route,
+  requireBodyObject,
+  validationError,
+  getSecurity,
+  getSecuritySnapshots,
+  upsertSnapshots,
+  polygon,
+  logger,
+} from "server";
+
+export interface ResolveSecuritySnapshotResponse {
+  resolved: boolean;
+  snapshot?: JSONSecuritySnapshot;
+  source?: "existing" | "polygon";
+  message?: string;
+}
+
+const MAX_PROXIMITY_DAYS = 7;
+
+const daysBetween = (a: string, b: string): number => {
+  const ms = Math.abs(new Date(a).getTime() - new Date(b).getTime());
+  return Math.floor(ms / (1000 * 60 * 60 * 24));
+};
+
+/**
+ * POST /resolve-security-snapshot
+ *
+ * Resolve (and persist) a security snapshot at or before `date` for
+ * `security_id`. If we already have a snapshot within 7 days at-or-before
+ * the requested date, return that. Otherwise query Polygon for the
+ * closest trading-day close in the 7-day window ending at `date`, upsert
+ * the result, and return it.
+ *
+ * Powers the PerformanceBenchmark widget's on-demand benchmark price
+ * fetch: when a user picks a 3Y window starting before our VOO snapshot
+ * history, the widget calls this with `{ security_id: <VOO>, date:
+ * windowStart }` and merges the returned snapshot into AppContext so the
+ * benchmark TWR can be computed over the full window.
+ */
+export const postResolveSecuritySnapshotRoute = new Route<ResolveSecuritySnapshotResponse>(
+  "POST",
+  "/resolve-security-snapshot",
+  async (req) => {
+    const { user } = req.session;
+    if (!user) {
+      return { status: "failed", message: "Request user is not authenticated." };
+    }
+
+    const bodyResult = requireBodyObject(req);
+    if (!bodyResult.success) return validationError(bodyResult.error!);
+    const body = bodyResult.data as Record<string, unknown>;
+
+    const security_id = body.security_id;
+    const date = body.date;
+    if (typeof security_id !== "string" || !security_id) {
+      return validationError("security_id is required");
+    }
+    if (typeof date !== "string" || !date) {
+      return validationError("date is required (YYYY-MM-DD)");
+    }
+
+    const requestedDate = new Date(date);
+    if (Number.isNaN(requestedDate.getTime())) {
+      return validationError(`invalid date: ${date}`);
+    }
+
+    // Don't burn a Polygon call on future dates — the market hasn't
+    // closed there yet. Cap the lookup at today.
+    const today = new Date();
+    const effectiveDate = requestedDate > today ? today : requestedDate;
+    const effectiveDateStr = getDateString(effectiveDate);
+
+    const security = await getSecurity(security_id);
+    if (!security) {
+      return { status: "success", body: { resolved: false, message: "security not found" } };
+    }
+    const ticker = security.ticker_symbol;
+    if (!ticker || ticker.startsWith("CUR:") || security.type === "cash") {
+      return {
+        status: "success",
+        body: { resolved: false, message: "security has no ticker / is cash-equivalent" },
+      };
+    }
+
+    // If we already have a close-enough snapshot at-or-before the request,
+    // skip the Polygon call. The 7-day tolerance matches the benchmark
+    // widget's price-walk: latest snapshot ≤ date is the price we'd use
+    // for TWR anyway.
+    const existing = await getSecuritySnapshots({ security_id, endDate: effectiveDateStr });
+    if (existing.length > 0) {
+      const nearest = existing[existing.length - 1]; // sorted ASC by snapshot_date
+      const nearestDate = getDateString(new Date(nearest.snapshot_date));
+      if (
+        nearest.close_price != null &&
+        daysBetween(nearestDate, effectiveDateStr) <= MAX_PROXIMITY_DAYS
+      ) {
+        const snapshot: JSONSecuritySnapshot = {
+          snapshot: { snapshot_id: nearest.snapshot_id, date: nearest.snapshot_date },
+          security: { ...security, close_price: nearest.close_price, close_price_as_of: nearestDate },
+        };
+        return {
+          status: "success",
+          body: { resolved: true, snapshot, source: "existing" },
+        };
+      }
+    }
+
+    // Polygon fetch
+    const priceResult = await polygon.getLatestClosePriceOnOrBefore(ticker, effectiveDate);
+    if (!priceResult.success) {
+      return {
+        status: "success",
+        body: {
+          resolved: false,
+          message:
+            priceResult.error === "no_api_key"
+              ? "Market data API is not configured"
+              : priceResult.error === "no_data"
+                ? `No price data for ${ticker} on or before ${effectiveDateStr}`
+                : `Polygon error: ${priceResult.message}`,
+        },
+      };
+    }
+
+    const { price, tradingDate } = priceResult.data;
+    const snapshot: JSONSecuritySnapshot = {
+      snapshot: {
+        snapshot_id: `${security_id}-${getSquashedDateString(new Date(tradingDate))}`,
+        date: new Date(tradingDate).toISOString(),
+      },
+      security: {
+        ...security,
+        close_price: price,
+        close_price_as_of: tradingDate,
+      },
+    };
+
+    try {
+      await upsertSnapshots([snapshot]);
+    } catch (error) {
+      logger.error(
+        "resolve-security-snapshot: upsert failed",
+        { security_id, tradingDate },
+        error,
+      );
+      // Non-fatal — still return the price so the client can use it
+      // for the current render. Next call will retry the upsert.
+    }
+
+    return { status: "success", body: { resolved: true, snapshot, source: "polygon" } };
+  },
+);


### PR DESCRIPTION
## Summary

- When the benchmark window predates our VOO `security_snapshots`, the widget now fires a lazy `POST /resolve-security-snapshot` instead of narrowing the comparison to the available range.
- The server checks for an existing snapshot within 7 days of the requested date; otherwise calls Polygon's daily aggregates range endpoint, picks the latest trading day at-or-before the date, and persists it.
- The new snapshot is merged into AppContext → the memo re-runs → the benchmark renders accurately over the user's full chosen window.

Closes #382.

## Files

- `src/server/lib/polygon.ts` — new `getLatestClosePriceOnOrBefore(ticker, date, lookbackDays=7)` that handles weekend/holiday inputs in a single Polygon call.
- `src/server/routes/accounts/post-resolve-security-snapshot.ts` — new route. Skips Polygon when an existing snapshot is within 7-day tolerance.
- `src/server/routes/accounts/index.ts` — barrel re-export so the router picks it up.
- `src/server/lib/polygon.test.ts` — 4 new cases for the helper (no-key, range-pick, no-data, URL shape).
- `src/client/components/PerformanceBenchmark/index.tsx` — `useEffect` fires when `benchmarkNarrowed` is true; attempted (security_id, date) keys are tracked in a ref so retries don't loop on `no_data` and window toggling doesn't refetch.

## Test plan

- [ ] Unit: `bun test src/server/lib/polygon.test.ts` (14 pass)
- [ ] Unit: `bun run test:client` (202 pass)
- [ ] Typecheck: `bun run typecheck` (clean)
- [ ] E2E on the sandbox: investment account with VOO holdings, switch between 1Y / 3Y / All; first toggle of 3Y/All shows the narrowed benchmark briefly, the resolve fires, AppContext updates, the row re-renders with the full-window benchmark and the `(since …)` hint goes away. The "vs benchmark" gap row should now render in 3Y / All.
- [ ] Verify retries don't loop: throttle the network in devtools, switch windows back and forth — only one fetch per (security_id, date).