### PR TITLE
test(transfers): route-level coverage for /transfers, /transfers/pair, DELETE /transfers

### DIFF
--- a/src/server/routes/transfers/delete-transfer.test.ts
+++ b/src/server/routes/transfers/delete-transfer.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for DELETE /transfers (Closes #378 — DELETE coverage).
+ *
+ * `removeTransferPair` calls `transactionPairsTable.softDelete`, which
+ * underneath issues a single `pool.query`. Mock at the pool layer to
+ * pin the route contract: the session user_id is forwarded into the
+ * WHERE clause as `user_id` — never a client-supplied value.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+
+import { pool } from "server/lib/postgres/client";
+import { deleteTransferRoute } from "./delete-transfer";
+
+const originalQuery = pool.query.bind(pool);
+
+const mockQuery = mock(
+  (_sql: string, _values?: unknown[]): Promise<{ rows: unknown[]; rowCount: number | null }> =>
+    Promise.resolve({ rows: [], rowCount: 0 }),
+);
+
+(pool as unknown as { query: typeof mockQuery }).query = mockQuery;
+
+afterAll(() => {
+  (pool as unknown as { query: typeof originalQuery }).query = originalQuery;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+function makeReq(
+  query: Record<string, unknown>,
+  opts: { user?: { user_id: string; username: string } | null } = {},
+) {
+  const user =
+    opts.user === undefined ? { user_id: "u-1", username: "test" } : opts.user;
+  return {
+    method: "DELETE",
+    path: "/transfers",
+    url: "http://x/api/transfers",
+    headers: {},
+    query,
+    body: undefined,
+    session: {
+      id: "s-1",
+      user: user ?? undefined,
+      regenerate() {},
+      destroy() {},
+    },
+    ip: "127.0.0.1",
+  } as unknown as Parameters<typeof deleteTransferRoute.execute>[0];
+}
+
+const fakeRes = () =>
+  ({
+    statusCode: 200,
+    headersSent: false,
+    status() {
+      return this;
+    },
+    write() {
+      return true;
+    },
+    end() {},
+  }) as unknown as Parameters<typeof deleteTransferRoute.execute>[1];
+
+describe("delete-transfer", () => {
+  test("rejects unauthenticated requests", async () => {
+    const result = await deleteTransferRoute.execute(
+      makeReq({ id: "p-1" }, { user: null }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/not authenticated/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("rejects missing id query param", async () => {
+    const result = await deleteTransferRoute.execute(makeReq({}), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("rejects empty id query param", async () => {
+    const result = await deleteTransferRoute.execute(makeReq({ id: "   " }), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("rejects array id query param (?id=a&id=b)", async () => {
+    const result = await deleteTransferRoute.execute(
+      makeReq({ id: ["a", "b"] }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("happy path returns success and pins user_id into the WHERE clause", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    const result = await deleteTransferRoute.execute(makeReq({ id: "p-1" }), fakeRes());
+    expect(result?.status).toBe("success");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, values] = mockQuery.mock.calls[0];
+    // softDelete issues an UPDATE with both the primary key and user_id in the WHERE.
+    expect(sql).toMatch(/UPDATE transaction_pairs/i);
+    expect(sql).toMatch(/user_id/);
+    expect(values).toContain("p-1");
+    expect(values).toContain("u-1");
+  });
+
+  test("cross-user delete: the route forwards the session user_id, never a client value", async () => {
+    // User A is logged in and asks to delete a pair_id that belongs to user B.
+    // The WHERE clause includes user_id = session.user.user_id, so the
+    // soft-delete won't affect user B's row. We pin that the value supplied
+    // to the query is the *session* user_id (u-A), not anything from the request.
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const result = await deleteTransferRoute.execute(
+      makeReq({ id: "p-belongs-to-B" }, { user: { user_id: "u-A", username: "a" } }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("success");
+    const [, values] = mockQuery.mock.calls[0];
+    expect(values).toContain("p-belongs-to-B");
+    expect(values).toContain("u-A");
+    expect(values).not.toContain("u-B");
+  });
+});

--- a/src/server/routes/transfers/get-transfers.test.ts
+++ b/src/server/routes/transfers/get-transfers.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for GET /transfers (Closes #378 — GET coverage).
+ *
+ * Mocks `pool.query` because `getTransferPairs` calls that directly.
+ * Pattern follows api-keys/get-api-keys.test.ts — monkey-patch + restore,
+ * avoiding `mock.module("server", ...)` since Bun's module mock is
+ * process-wide and leaks into sibling test files.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+
+import { pool } from "server/lib/postgres/client";
+import { getTransfersRoute } from "./get-transfers";
+
+const originalQuery = pool.query.bind(pool);
+
+const mockQuery = mock(
+  (_sql: string, _values?: unknown[]): Promise<{ rows: unknown[]; rowCount: number | null }> =>
+    Promise.resolve({ rows: [], rowCount: 0 }),
+);
+
+(pool as unknown as { query: typeof mockQuery }).query = mockQuery;
+
+afterAll(() => {
+  (pool as unknown as { query: typeof originalQuery }).query = originalQuery;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+function makeReq(opts: { user?: { user_id: string; username: string } | null } = {}) {
+  const user =
+    opts.user === undefined ? { user_id: "u-1", username: "test" } : opts.user;
+  return {
+    method: "GET",
+    path: "/transfers",
+    url: "http://x/api/transfers",
+    headers: {},
+    query: {},
+    body: undefined,
+    session: {
+      id: "s-1",
+      user: user ?? undefined,
+      regenerate() {},
+      destroy() {},
+    },
+    ip: "127.0.0.1",
+  } as unknown as Parameters<typeof getTransfersRoute.execute>[0];
+}
+
+const fakeRes = () =>
+  ({
+    statusCode: 200,
+    headersSent: false,
+    status() {
+      return this;
+    },
+    write() {
+      return true;
+    },
+    end() {},
+  }) as unknown as Parameters<typeof getTransfersRoute.execute>[1];
+
+describe("get-transfers", () => {
+  test("rejects unauthenticated requests", async () => {
+    const result = await getTransfersRoute.execute(makeReq({ user: null }), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/not authenticated/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("empty pairs list returns success with empty array — no second query issued", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const result = await getTransfersRoute.execute(makeReq(), fakeRes());
+    expect(result?.status).toBe("success");
+    expect(result?.body).toEqual([]);
+    // Second query (transactions fetch) is skipped when there are no pairs.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  test("happy path scopes the pairs SELECT to the caller's user_id", async () => {
+    const pairRow = {
+      pair_id: "p-1",
+      user_id: "u-1",
+      transaction_id_a: "t-a",
+      transaction_id_b: "t-b",
+      status: "confirmed",
+      created_at: "2026-05-01T00:00:00Z",
+      updated: "2026-05-01T00:00:00Z",
+      is_deleted: false,
+    };
+    const txnRow = (id: string, amount: number) => ({
+      transaction_id: id,
+      user_id: "u-1",
+      account_id: "acc-1",
+      name: "Transfer",
+      merchant_name: null,
+      amount,
+      iso_currency_code: "USD",
+      date: "2026-05-01",
+      pending: false,
+      pending_transaction_id: null,
+      payment_channel: "other",
+      location_country: null,
+      location_region: null,
+      location_city: null,
+      label_budget_id: null,
+      label_category_id: null,
+      label_memo: null,
+      label_category_confidence: null,
+      raw: null,
+      updated: "2026-05-01T00:00:00Z",
+      is_deleted: false,
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [pairRow], rowCount: 1 });
+    mockQuery.mockResolvedValueOnce({
+      rows: [txnRow("t-a", 100), txnRow("t-b", -100)],
+      rowCount: 2,
+    });
+
+    const result = await getTransfersRoute.execute(makeReq(), fakeRes());
+    expect(result?.status).toBe("success");
+    expect(result?.body).toHaveLength(1);
+    expect(result?.body?.[0].pair_id).toBe("p-1");
+    expect(result?.body?.[0].status).toBe("confirmed");
+    expect(result?.body?.[0].transactions).toHaveLength(2);
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    const [pairsSql, pairsValues] = mockQuery.mock.calls[0];
+    expect(pairsSql).toMatch(/FROM transaction_pairs/);
+    expect(pairsSql).toMatch(/WHERE user_id = \$1/);
+    expect(pairsValues).toEqual(["u-1"]);
+
+    // Second query: transactions fetched ALSO scoped by user_id.
+    const [txnsSql, txnsValues] = mockQuery.mock.calls[1];
+    expect(txnsSql).toMatch(/WHERE user_id = \$1/);
+    expect(txnsValues?.[0]).toBe("u-1");
+  });
+
+  test("cross-user isolation: another user's pairs are never returned", async () => {
+    // User B is logged in but the underlying pairs table has only user A's rows.
+    // The WHERE user_id = $1 clause must filter them out at the SQL layer.
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const result = await getTransfersRoute.execute(
+      makeReq({ user: { user_id: "u-B", username: "b" } }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("success");
+    expect(result?.body).toEqual([]);
+    const [, values] = mockQuery.mock.calls[0];
+    expect(values).toEqual(["u-B"]);
+  });
+});

--- a/src/server/routes/transfers/post-transfer-pair.test.ts
+++ b/src/server/routes/transfers/post-transfer-pair.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for POST /transfers/pair (Closes #378 — POST coverage).
+ *
+ * Two distinct request modes plus validation/auth paths are covered:
+ *   • pair_id branch     → confirmTransferPair (UPDATE one row)
+ *   • new-pair branch    → pairTransactions (INSERT ON CONFLICT)
+ *
+ * Both helpers issue a single pool.query, so mocking at the pool layer
+ * is sufficient and follows the same pattern as the api-keys tests.
+ * The cross-user ownership guarantees are enforced at the SQL layer by
+ * the `WHERE user_id = $N` clauses; these tests pin that the route always
+ * forwards the *session* user_id into the parameter list.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+
+import { pool } from "server/lib/postgres/client";
+import { postTransferPairRoute } from "./post-transfer-pair";
+
+const originalQuery = pool.query.bind(pool);
+
+const mockQuery = mock(
+  (_sql: string, _values?: unknown[]): Promise<{ rows: unknown[]; rowCount: number | null }> =>
+    Promise.resolve({ rows: [], rowCount: 0 }),
+);
+
+(pool as unknown as { query: typeof mockQuery }).query = mockQuery;
+
+afterAll(() => {
+  (pool as unknown as { query: typeof originalQuery }).query = originalQuery;
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+function makeReq(
+  body: unknown,
+  opts: { user?: { user_id: string; username: string } | null } = {},
+) {
+  const user =
+    opts.user === undefined ? { user_id: "u-1", username: "test" } : opts.user;
+  return {
+    method: "POST",
+    path: "/transfers/pair",
+    url: "http://x/api/transfers/pair",
+    headers: {},
+    query: {},
+    body,
+    session: {
+      id: "s-1",
+      user: user ?? undefined,
+      regenerate() {},
+      destroy() {},
+    },
+    ip: "127.0.0.1",
+  } as unknown as Parameters<typeof postTransferPairRoute.execute>[0];
+}
+
+const fakeRes = () =>
+  ({
+    statusCode: 200,
+    headersSent: false,
+    status() {
+      return this;
+    },
+    write() {
+      return true;
+    },
+    end() {},
+  }) as unknown as Parameters<typeof postTransferPairRoute.execute>[1];
+
+describe("post-transfer-pair", () => {
+  test("rejects unauthenticated requests", async () => {
+    const result = await postTransferPairRoute.execute(
+      makeReq({ pair_id: "p-1" }, { user: null }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/not authenticated/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("rejects missing body", async () => {
+    const result = await postTransferPairRoute.execute(makeReq(null), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("rejects array body (not an object)", async () => {
+    const result = await postTransferPairRoute.execute(makeReq(["x"]), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  describe("confirm-existing-pair branch (pair_id is a string)", () => {
+    test("happy path: UPDATE scoped to session user_id, returns the pair_id", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+      const result = await postTransferPairRoute.execute(
+        makeReq({ pair_id: "p-confirm" }),
+        fakeRes(),
+      );
+
+      expect(result?.status).toBe("success");
+      expect(result?.body).toEqual({ pair_id: "p-confirm" });
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const [sql, values] = mockQuery.mock.calls[0];
+      expect(sql).toMatch(/UPDATE transaction_pairs/i);
+      expect(sql).toMatch(/SET status = 'confirmed'/);
+      expect(sql).toMatch(/WHERE pair_id = \$1\s+AND user_id = \$2/);
+      expect(values).toEqual(["p-confirm", "u-1"]);
+    });
+
+    test("cross-user confirm: the route uses the session user_id, never a client value", async () => {
+      // User A tries to confirm a pair_id that belongs to user B. The UPDATE
+      // is no-op at the SQL layer (rowCount = 0). Surface contract: the
+      // route still resolves "success" and echoes the pair_id, but the
+      // user_id parameter pinned into the query is the *session* one.
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      const result = await postTransferPairRoute.execute(
+        makeReq({ pair_id: "p-belongs-to-B" }, { user: { user_id: "u-A", username: "a" } }),
+        fakeRes(),
+      );
+      expect(result?.status).toBe("success");
+      const [, values] = mockQuery.mock.calls[0];
+      expect(values).toEqual(["p-belongs-to-B", "u-A"]);
+      expect(values).not.toContain("u-B");
+    });
+  });
+
+  describe("new-pair branch (no pair_id)", () => {
+    test("rejects missing transaction_id_a", async () => {
+      const result = await postTransferPairRoute.execute(
+        makeReq({ transaction_id_b: "t-b" }),
+        fakeRes(),
+      );
+      expect(result?.status).toBe("failed");
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    test("rejects missing transaction_id_b", async () => {
+      const result = await postTransferPairRoute.execute(
+        makeReq({ transaction_id_a: "t-a" }),
+        fakeRes(),
+      );
+      expect(result?.status).toBe("failed");
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    test("rejects non-string transaction_id_a", async () => {
+      const result = await postTransferPairRoute.execute(
+        makeReq({ transaction_id_a: 42, transaction_id_b: "t-b" }),
+        fakeRes(),
+      );
+      expect(result?.status).toBe("failed");
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    test("happy path with status=confirmed: INSERT scoped to session user_id", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ pair_id: "p-new" }], rowCount: 1 });
+
+      const result = await postTransferPairRoute.execute(
+        makeReq({
+          transaction_id_a: "t-a",
+          transaction_id_b: "t-b",
+          status: "confirmed",
+        }),
+        fakeRes(),
+      );
+
+      expect(result?.status).toBe("success");
+      expect(result?.body).toEqual({ pair_id: "p-new" });
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const [sql, values] = mockQuery.mock.calls[0];
+      expect(sql).toMatch(/INSERT INTO transaction_pairs/i);
+      // (pair_id, user_id, transaction_id_a, transaction_id_b, status)
+      expect(values?.[1]).toBe("u-1");
+      expect(values?.[4]).toBe("confirmed");
+      // Both transaction IDs are forwarded (canonicalized order may differ).
+      const txnIds = [values?.[2], values?.[3]].sort();
+      expect(txnIds).toEqual(["t-a", "t-b"]);
+    });
+
+    test("status defaults to 'suggested' when absent", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ pair_id: "p-new" }], rowCount: 1 });
+
+      await postTransferPairRoute.execute(
+        makeReq({ transaction_id_a: "t-a", transaction_id_b: "t-b" }),
+        fakeRes(),
+      );
+      const [, values] = mockQuery.mock.calls[0];
+      expect(values?.[4]).toBe("suggested");
+    });
+
+    test("status defaults to 'suggested' when given any non-'confirmed' value", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ pair_id: "p-new" }], rowCount: 1 });
+
+      await postTransferPairRoute.execute(
+        makeReq({
+          transaction_id_a: "t-a",
+          transaction_id_b: "t-b",
+          status: "totally-bogus",
+        }),
+        fakeRes(),
+      );
+      const [, values] = mockQuery.mock.calls[0];
+      expect(values?.[4]).toBe("suggested");
+    });
+
+    test("cross-user new pair: route forwards the session user_id, never a client value", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ pair_id: "p-new" }], rowCount: 1 });
+
+      await postTransferPairRoute.execute(
+        makeReq(
+          { transaction_id_a: "t-a", transaction_id_b: "t-b" },
+          { user: { user_id: "u-A", username: "a" } },
+        ),
+        fakeRes(),
+      );
+      const [, values] = mockQuery.mock.calls[0];
+      // The pair row's user_id (param $2) must be the session user, full stop.
+      expect(values?.[1]).toBe("u-A");
+    });
+  });
+});


### PR DESCRIPTION
Closes #378.

## Summary
- Adds 22 route-level tests across three new test files mirroring the api-keys/*.test.ts pattern (monkey-patch `pool.query`, no `mock.module`).
- Covers all 12 branches called out in the issue: auth gating, body/query validation, the pair_id confirm branch, the new-pair INSERT branch, and cross-user ownership pinning on each route.

## Files
- `src/server/routes/transfers/get-transfers.test.ts` (4 tests)
- `src/server/routes/transfers/delete-transfer.test.ts` (6 tests)
- `src/server/routes/transfers/post-transfer-pair.test.ts` (12 tests)

## Security focus
Cross-user pair confirmation and pair deletion are the exact surfaces a Bearer-auth misroute would expose. Every test in the cross-user group asserts that the **session** `user_id` is the value forwarded into the SQL parameter list — never a value derived from the request body or query.

## E2E / verification
- `bun test src/server/routes/transfers/` → **22 pass, 0 fail**
- `bun test src/server/routes/` (wider regression) → **61 pass, 0 fail**
- `bun run typecheck` → clean

Non-functional change (tests only — every changed file matches `*.test.ts`). No sandbox spin needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)