### PR TITLE
fix(holdings): relabel Cost/sh → Cost basis to match stored semantic

### DIFF
--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -371,10 +371,10 @@ export const HoldingProperties = () => {
             />
           </div>
           <div className="row keyValue">
-            <span className="propertyName">Cost/sh&nbsp;(opt)</span>
+            <span className="propertyName">Cost&nbsp;basis&nbsp;(opt)</span>
             <input
               type="number"
-              placeholder="0.00"
+              placeholder="Total $ paid (all shares)"
               min="0"
               step="any"
               value={form.costBasis}
@@ -464,7 +464,7 @@ export const HoldingProperties = () => {
           )}
         </div>
         <div className="row keyValue">
-          <span className="propertyName">Cost/sh</span>
+          <span className="propertyName">Cost&nbsp;basis</span>
           {isReadOnly ? (
             <span>{editCostBasis || "—"}</span>
           ) : (


### PR DESCRIPTION
Closes #375.

## Summary

`HoldingProperties` labeled both its new-form and edit-form cost-basis inputs as **`Cost/sh`** (per-share), but the underlying `cost_basis` field is the **total** cost basis everywhere else in the codebase. A user reading the label literally would enter per-share dollars, causing the stored value to be off by a factor of `quantity`.

## Root cause

Three pieces of upstream code treat `cost_basis` as a total:

- `src/server/lib/postgres/models/snapshot.ts:153` — server collapses NULL to `0` for the *total* cost basis.
- `src/client/lib/hooks/calculation/holdings.ts:215-218` — `inferCostBasis` accumulates `totalCost += price * quantity + fees`.
- `src/client/lib/models/Calculations.ts:364-367` — `unrealizedGain = value − costBasis` where `value = price × quantity`; dimensionally `costBasis` must be total.

Production data confirms: e.g. IBM-RBA has `price=95.46`, `quantity=157.861`, `value=15069.41`, `cost_basis=14754.8` — only makes sense as total.

So `cost_basis` is consistently total throughout; only the UI label was wrong (and that label mismatch then poisoned manual entries).

## Fix (Approach 1 from issue body — recommended)

Relabel both fields:

| | Before | After |
|---|---|---|
| L374 (new-holding) | `Cost/sh (opt)` | `Cost basis (opt)` |
| L377 (placeholder) | `0.00` | `Total $ paid (all shares)` |
| L467 (edit) | `Cost/sh` | `Cost basis` |

No data migration needed — existing manual holdings entered against the old label are now correctly described by the new label (since the stored value was always treated as total downstream).

## Why not Approach 2 (UI ↔ data conversion)

Multiplying/dividing by `quantity` on every UI read/write would:
1. Break consistency with the codebase's \"treat `cost_basis` as total\" idiom.
2. Introduce a divide-by-zero hazard when `quantity = 0`.
3. Retroactively re-interpret every manual holding ever entered (silently change displayed G/L for current users).

Relabel-only fixes the bug and respects existing data.

## Test plan

- [x] `bun run tsc --noEmit` clean
- [x] `bun run test:client` — 202 pass / 0 fail
- [ ] Sandbox E2E: open a manual investment account → \"+ Add Holding\" → confirm field reads \"Cost basis (opt)\" with the new placeholder; open an existing holding → confirm edit field reads \"Cost basis\".

## Out of scope

- One-off audit of existing manual holdings whose entered `cost_basis` may have been per-share-intent (flagged in issue body; no clean way to know intent retroactively).