### PR TITLE
chore(env): remove dead APP_TIMEZONE entry from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,6 @@ HOST_NAME=example.com
 
 ADMIN_PASSWORD=qwert12345
 
-# Optional: set server timezone (defaults to America/Los_Angeles)
-# APP_TIMEZONE=UTC
-
 # Optional: log verbosity. One of debug | info | warn | error.
 # Default: info (or error when NODE_ENV=test). See src/server/lib/logger.ts.
 # LOG_LEVEL=info


### PR DESCRIPTION
## Summary
- `.env.example` still advertises \`# APP_TIMEZONE=UTC\` even though the override no longer exists. APP_TIMEZONE was implemented in PR #194 by reading \`process.env.APP_TIMEZONE\` inside \`src/server/config.ts\`, but commit 200eeb0 (\"fixed redundant timestamp in logging & fixed security fetching default date\", 2026-04-05) removed the entire \`config.ts\` file and stopped setting \`process.env.TZ\` altogether.
- Verified no source code under \`src/\` references \`APP_TIMEZONE\` or sets \`process.env.TZ\`:
  \`\`\`
  rg 'APP_TIMEZONE|process\.env\.TZ' src/   # 0 matches
  \`\`\`
- Removes the entry so \`.env.example\` stops promising a knob that does nothing.

## Test plan
- [x] \`rg 'APP_TIMEZONE' src/\` returns no matches (confirmed dead).
- [x] No app behavior change — \`.env.example\` is documentation only.
- [x] Visual diff: 3-line removal (the comment header + the variable + the blank line), no other entries touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)