### PR TITLE
chore: rephrase Hoie-attributed comments as design choices

### DIFF
--- a/src/client/components/HoldingsComposition/index.tsx
+++ b/src/client/components/HoldingsComposition/index.tsx
@@ -40,8 +40,8 @@ export const HoldingsComposition = ({ account }: Props) => {
 
   // Every row is clickable and drills into HOLDING_DETAIL. Edit gating
   // lives on the detail page — synced + current viewDate renders read-only
-  // there (Hoie 2026-05-15). "+ Add Holding" stays manual-only because
-  // synced brokers re-derive their own holding set on every sync.
+  // there. "+ Add Holding" stays manual-only because synced brokers
+  // re-derive their own holding set on every sync.
   const isManualAccount = items.get(item_id)?.provider === ItemProvider.MANUAL;
 
   const viewEndDate = viewDate.getEndDate();
@@ -134,7 +134,7 @@ export const HoldingsComposition = ({ account }: Props) => {
     viewDayString,
   ]);
 
-  // Collapse all cash-shape rows into a single "Cash" row (Hoie 2026-05-15).
+  // Collapse all cash-shape rows into a single "Cash" row at the UI layer.
   // Plaid sometimes reports the same logical cash position under multiple
   // `security_id`s over time — each becomes a distinct `holding_id` in the
   // snapshot store and would otherwise render as a separate "Cash" line.
@@ -179,11 +179,10 @@ export const HoldingsComposition = ({ account }: Props) => {
     router.go(PATH.HOLDING_DETAIL, { params });
   };
 
-  // Account snapshot wins for the total (Hoie 2026-05-14: "for account
-  // histogram and account total amount, priority is account snapshot if
-  // exists. Secondary is holdings total from holdings snapshot. If account
-  // snapshot exists and doesn't match with holdings snapshot, display the
-  // diff as 'Unknown' in holdings summary table.").
+  // Priority for the account-level total: account snapshot when it exists,
+  // otherwise the holdings total derived from holding snapshots. When both
+  // exist and disagree, the diff renders as an "Unknown" row in the
+  // holdings summary table.
   //
   // The Unknown row is the UI safeguard for reconciliation gaps; the data
   // fix is PR #353's auto-inferred USD cash holding on the server side. On
@@ -248,8 +247,8 @@ export const HoldingsComposition = ({ account }: Props) => {
             row.unrealizedGain === null ? "" : row.unrealizedGain >= 0 ? "positive" : "negative";
           // Cash holdings get a uniform "Cash" label regardless of how the
           // broker named the underlying sweep ("QACDS", "Chase Deposit
-          // Sweep", a truncated security_id, etc.). Hoie 2026-05-14: "When
-          // the holding is cash, display 'Cash' instead of the security id."
+          // Sweep", a truncated security_id, etc.) — `securityId` is never
+          // exposed for cash rows.
           const primaryLabel = row.isCash
             ? "Cash"
             : (row.ticker ?? row.name ?? truncateSecurityId(row.securityId));

--- a/src/server/lib/compute-tools/backfill-snapshots.ts
+++ b/src/server/lib/compute-tools/backfill-snapshots.ts
@@ -23,7 +23,7 @@ export interface BackfillSecurityRef {
 // DI seams — production callers pass nothing and get the real DB/polygon
 // implementations. Tests pass mocks via positional args instead of
 // `mock.module`, which is process-wide in Bun and leaks across sibling
-// test files. Same factoring as `cash-holding.ts` (Hoie 2026-05-14).
+// test files. Same factoring as `cash-holding.ts`.
 type GetSecuritySnapshotsFn = typeof realGetSecuritySnapshots;
 type SearchSecuritiesByIdFn = typeof realSearchSecuritiesById;
 type UpsertSnapshotsFn = typeof realUpsertSnapshots;
@@ -48,7 +48,7 @@ const MAX_MONTHS_PER_INVOCATION = 60;
  * the 15th of that month (or nearest prior trading day — polygon returns
  * the bar for the closest trading day in the range).
  *
- * Forward-only by design (Hoie 2026-05-13): we never reach into months
+ * Forward-only by design: we never reach into months
  * before the caller's `fromDate`, even if the security has been around
  * longer in the user's portfolio. The 60-month per-invocation cap is a
  * sanity ceiling for accidental "5-year-old manual holding" inputs.
@@ -148,10 +148,10 @@ export const backfillMonthlySecuritySnapshotsForward = async (
       }
 
       // Snapshot date = 15th for past months; previous day for the current
-      // month. Today's market hasn't closed yet (Hoie 2026-05-15), so polygon
-      // either returns no_data or the previous trading day's bar — either way
-      // we should anchor the snapshot to "yesterday's close" rather than
-      // labelling a future/in-progress price with today's date.
+      // month. Today's market hasn't closed yet, so polygon either returns
+      // no_data or the previous trading day's bar — either way we anchor
+      // the snapshot to "yesterday's close" rather than labelling a
+      // future/in-progress price with today's date.
       const dayInMonth =
         cursor === nowYearMonth ? getDateString(getYesterday()) : `${cursor}-15`;
       const fetchResult = await getClosePrice(ticker_symbol, new Date(dayInMonth));

--- a/src/server/lib/compute-tools/cash-holding.ts
+++ b/src/server/lib/compute-tools/cash-holding.ts
@@ -16,8 +16,8 @@ import {
  * itself uses tickers like `CUR:USD` for cash-equivalent securities; we
  * deliberately pick a different label so the inferred-cash row is
  * distinguishable from a broker-reported one at the data layer, but the
- * UI treats them identically (Hoie 2026-05-14: "Plaid-provided and
- * inferred cash account displays identically").
+ * UI treats them identically: Plaid-provided and inferred cash render
+ * the same in every holdings view.
  */
 const USD_CASH_TICKER = "USD";
 
@@ -112,7 +112,7 @@ const CASH_INFERENCE_MIN = 0.01;
  * Returns the array of new holdings to merge into the sync's
  * `incomingHoldings` list. The downstream `upsertAndDeleteHoldingsWithSnapshots`
  * then writes each as a normal holding snapshot — the UI sees no difference
- * between Plaid-reported and inferred cash (per Hoie 2026-05-14).
+ * between Plaid-reported and inferred cash.
  *
  * Forward-only: we don't try to infer historical cash positions. The
  * inferred row gets a fresh snapshot dated now, and future syncs either

--- a/src/server/lib/compute-tools/sync-plaid.ts
+++ b/src/server/lib/compute-tools/sync-plaid.ts
@@ -262,7 +262,7 @@ export const syncPlaidAccounts = async (item_id: string) => {
       // Auto-infer a USD cash holding for any investment account where
       // Plaid didn't surface cash as a holding. The inferred row is a
       // real holding snapshot — same data path as Plaid-provided cash —
-      // so the UI is identical regardless of source (Hoie 2026-05-14).
+      // so the UI is identical regardless of source.
       const inferredCash = await inferCashHoldings(accounts, holdings, securities);
       const allHoldings = inferredCash.length ? [...holdings, ...inferredCash] : holdings;
 


### PR DESCRIPTION
## Summary
Reviewer directive: *\"Don't document with my name in the code. Don't document quoting canonical instructions. Phrase them as design choices.\"* (PR #383 / PR #352)

Sweeps existing source comments that still cite \`(Hoie 2026-XX-XX)\` or quote canonical instructions, rephrasing each as a direct design statement.

| File | Hits |
|------|-----:|
| \`src/server/lib/compute-tools/backfill-snapshots.ts\` | 3 |
| \`src/server/lib/compute-tools/sync-plaid.ts\` | 1 |
| \`src/server/lib/compute-tools/cash-holding.ts\` | 2 |
| \`src/client/components/HoldingsComposition/index.tsx\` | 4 |

**Scope note.** \`src/client/lib/hooks/calculation/benchmark.ts\` and \`src/client/components/PerformanceBenchmark/index.tsx\` also carry Hoie-attributed comments, but both are inside the active diff of PR #386. Left to that branch's owner to avoid merge churn — this PR steers clear of files PR #386 touches.

No behaviour change — comment-only diff.

## Test plan
- [x] \`rg 'Hoie 2026|Per Hoie' src/server/lib/compute-tools/ src/client/components/HoldingsComposition/\` returns 0 hits after this PR.
- [x] \`bun run typecheck\` clean.
- [x] \`bun run lint\` clean.
- [x] Pure comment edits — no exported symbols changed, no logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)