### PR TITLE
docs: correct Scheduled Background Work order and DI claim

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -98,13 +98,13 @@ Common mappings (light → dark):
 
 ## Scheduled Background Work
 
-The server's hourly background job lives in `src/server/lib/compute-tools/schedule.ts` (`scheduledSync`). It runs:
+The server's hourly background job lives in `src/server/lib/compute-tools/schedule.ts` (`scheduledSync`). It runs, in order:
 
 1. Plaid / SimpleFin sync for every connected item
-2. `runTransferDetection` — pairs cross-account transfers
-3. `runAutoSuggestions` — applies per-merchant category suggestions (see [ARCHITECTURE.md — Transaction Categorization](ARCHITECTURE.md#transaction-categorization-auto-suggest))
+2. `runAutoSuggestions` — applies per-merchant category suggestions (see [ARCHITECTURE.md — Transaction Categorization](ARCHITECTURE.md#transaction-categorization-auto-suggest))
+3. `runTransferDetection` — pairs cross-account transfers
 
-All three accept dependency-injection parameters with sensible defaults, so you can invoke them manually from a REPL or a one-off script when debugging:
+`runAutoSuggestions` and `runTransferDetection` both accept dependency-injection parameters with sensible defaults, so you can invoke them manually from a REPL or a one-off script when debugging:
 
 ```typescript
 import { runAutoSuggestions } from "server/lib/compute-tools/auto-suggest";


### PR DESCRIPTION
## Summary

Two small inaccuracies in \`docs/DEVELOPMENT.md\` § \"Scheduled Background Work\" (originally added in #345 on 2026-05-13) versus the current \`src/server/lib/compute-tools/schedule.ts\`:

1. **Order is wrong.** Docs list \`runTransferDetection\` before \`runAutoSuggestions\`, but \`schedule.ts:90-95\` actually awaits \`runAutoSuggestions()\` first and then \`runTransferDetection()\`. Reordered the bullets to match.

2. **\"All three\" overstates DI surface.** Only \`runAutoSuggestions\` and \`runTransferDetection\` accept DI parameters. The Plaid/SimpleFin sync functions (\`syncPlaidAccounts\`, \`syncPlaidTransactions\`, \`syncSimpleFinData\`) take only \`item_id\`. Reworded to name the two jobs that actually accept DI so developers don't go looking for DI hooks on the sync functions.

No code change — pure markdown edit.

## Test plan
- [x] Compared docs against \`schedule.ts:90-95\` for the order claim.
- [x] Verified DI surface against the signatures of \`runAutoSuggestions\` (auto-suggest.ts:160), \`runTransferDetection\` (detect-transfers.ts:155), \`syncPlaidAccounts\` (sync-plaid.ts:215), \`syncPlaidTransactions\` (sync-plaid.ts:87), \`syncSimpleFinData\` (sync-simple-fin.ts:40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)