### PR TITLE
fix(security): login rate-limit counts only failures (#389)

### DIFF
--- a/src/server/lib/rate-limit.test.ts
+++ b/src/server/lib/rate-limit.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect } from "bun:test";
+import {
+  isLoginRateLimited,
+  recordLoginFailure,
+  resetLoginAttempts,
+} from "./rate-limit";
+
+// Each test uses a unique IP so the module-level Map state can't bleed
+// between tests. No mocking needed — the pure failure-only API is testable
+// directly.
+let ipCounter = 0;
+const nextIp = () => `198.51.100.${++ipCounter}`;
+
+describe("isLoginRateLimited", () => {
+  test("returns false for a never-seen IP", () => {
+    expect(isLoginRateLimited(nextIp())).toBe(false);
+  });
+
+  test("is pure — calling it does not consume a slot", () => {
+    const ip = nextIp();
+    for (let i = 0; i < 100; i++) isLoginRateLimited(ip);
+    // A subsequent 5 failures should still be allowed (i.e. the 100 checks
+    // didn't push us over the limit). The 6th failure exceeds the cap.
+    for (let i = 0; i < 5; i++) recordLoginFailure(ip);
+    expect(isLoginRateLimited(ip)).toBe(true);
+  });
+});
+
+describe("recordLoginFailure / lockout threshold", () => {
+  test("5 failures put the IP at the cap, 6th attempt is blocked", () => {
+    const ip = nextIp();
+    for (let i = 0; i < 5; i++) {
+      recordLoginFailure(ip);
+    }
+    expect(isLoginRateLimited(ip)).toBe(true);
+  });
+
+  test("4 failures are still under the cap", () => {
+    const ip = nextIp();
+    for (let i = 0; i < 4; i++) recordLoginFailure(ip);
+    expect(isLoginRateLimited(ip)).toBe(false);
+  });
+});
+
+describe("successful-login behavior (the #389 regression)", () => {
+  test("a successful login resets the counter so subsequent logins are not blocked", () => {
+    const ip = nextIp();
+    // 4 failed attempts under the cap, then a success clears the bucket.
+    for (let i = 0; i < 4; i++) recordLoginFailure(ip);
+    resetLoginAttempts(ip);
+    // Should now tolerate another 5 failures before locking out.
+    for (let i = 0; i < 5; i++) recordLoginFailure(ip);
+    expect(isLoginRateLimited(ip)).toBe(true);
+  });
+
+  test("simulating 6 successful logins in a row — the bug repro — never blocks", () => {
+    // In the buggy code each "success" was implicitly a check-and-bump:
+    // 5 bumps → the 6th request was 429'd. With failure-only counting,
+    // successes simply don't touch the counter, so this loop never blocks.
+    const ip = nextIp();
+    for (let i = 0; i < 6; i++) {
+      expect(isLoginRateLimited(ip)).toBe(false);
+      // Success path: resetLoginAttempts is the only state change.
+      resetLoginAttempts(ip);
+    }
+  });
+});
+
+describe("resetLoginAttempts", () => {
+  test("clears a locked-out IP", () => {
+    const ip = nextIp();
+    for (let i = 0; i < 5; i++) recordLoginFailure(ip);
+    expect(isLoginRateLimited(ip)).toBe(true);
+    resetLoginAttempts(ip);
+    expect(isLoginRateLimited(ip)).toBe(false);
+  });
+
+  test("is safe to call on an unknown IP", () => {
+    expect(() => resetLoginAttempts(nextIp())).not.toThrow();
+  });
+});

--- a/src/server/lib/rate-limit.ts
+++ b/src/server/lib/rate-limit.ts
@@ -64,22 +64,38 @@ export const stopRateLimitCleanup = () => {
 };
 
 /**
- * Check rate limit for the given IP address.
- * Returns true if the request should be blocked (too many attempts).
- * Increments the attempt counter when not blocked.
+ * Read-only check: returns true if the IP has hit the failure cap within
+ * the active window. Does NOT mutate state.
+ *
+ * Successful logins must not consume a slot — that's what failure-only
+ * counting prevents. See #389: counting successes locked out anyone who
+ * legitimately signed in from 5+ devices within 15 minutes.
  */
-export const checkLoginRateLimit = (ip: string): boolean => {
+export const isLoginRateLimited = (ip: string): boolean => {
+  const now = Date.now();
+  const record = attempts.get(ip);
+  return !!record && now < record.resetAt && record.count >= MAX_ATTEMPTS;
+};
+
+/**
+ * Record a failed login attempt for the given IP. Call only after auth
+ * has actually failed.
+ */
+export const recordLoginFailure = (ip: string): void => {
   const now = Date.now();
   const record = attempts.get(ip);
 
   if (record && now < record.resetAt) {
-    if (record.count >= MAX_ATTEMPTS) {
-      return true; // rate limited
-    }
     record.count++;
   } else {
     attempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
   }
+};
 
-  return false;
+/**
+ * Clear the bucket for an IP on a successful login so a user's prior
+ * failures don't accumulate against them indefinitely within the window.
+ */
+export const resetLoginAttempts = (ip: string): void => {
+  attempts.delete(ip);
 };

--- a/src/server/routes/users/post-login.ts
+++ b/src/server/routes/users/post-login.ts
@@ -1,5 +1,15 @@
 import bcrypt from "bcrypt";
-import { Route, searchUser, MaskedUser, maskUser, requireBodyObject, requireStringField, validationError } from "server";
+import {
+  Route,
+  searchUser,
+  MaskedUser,
+  maskUser,
+  requireBodyObject,
+  requireStringField,
+  validationError,
+  recordLoginFailure,
+  resetLoginAttempts,
+} from "server";
 
 export type LoginPostResponse = MaskedUser;
 
@@ -25,6 +35,9 @@ export const postLoginRoute = new Route<LoginPostResponse>("POST", "/login", asy
     : await bcrypt.compare(passwordResult.data!, DUMMY_HASH).then(() => false);
 
   if (pwMatches && user) {
+    // Successful auth: clear any prior failures so they don't accumulate
+    // against the user within the window.
+    resetLoginAttempts(req.ip);
     const maskedUser = maskUser(user);
     await new Promise<void>((resolve, reject) => {
       req.session.regenerate((err) => {
@@ -35,6 +48,9 @@ export const postLoginRoute = new Route<LoginPostResponse>("POST", "/login", asy
     req.session.user = maskedUser;
     return { status: "success", body: maskedUser };
   }
+
+  // Only auth failures count toward the rate limit (#389).
+  recordLoginFailure(req.ip);
 
   // Return the same generic message regardless of whether the username exists
   // to prevent username enumeration attacks.

--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -8,7 +8,7 @@ import {
   stopScheduledSync,
   logger,
   sendAlarm,
-  checkLoginRateLimit,
+  isLoginRateLimited,
   startRateLimitCleanup,
   stopRateLimitCleanup,
   pool,
@@ -284,9 +284,11 @@ const server = Bun.serve({
       }
     });
 
-    // Rate-limit POST /login before session loading to fail fast
+    // Rate-limit POST /login before session loading to fail fast.
+    // Read-only check — the counter is bumped only on auth failure inside
+    // post-login.ts (#389).
     if (request.method === "POST" && apiPath === "/login") {
-      if (checkLoginRateLimit(ip)) {
+      if (isLoginRateLimited(ip)) {
         return jsonResponse(
           { status: "failed", message: "Too many login attempts, try again later" },
           429,


### PR DESCRIPTION
## Summary
- Splits `checkLoginRateLimit` into a read-only `isLoginRateLimited` gate plus explicit `recordLoginFailure` / `resetLoginAttempts` recorders.
- `start.ts` only does the read-only check before routing; `post-login.ts` records a failure on the failure path and clears the bucket on the success path.
- 5 legit logins from one IP no longer 429 the 6th attempt — brute-force defense (5 failures → lock) is unchanged.

Closes #389

## What changed
| File | Change |
|------|--------|
| `src/server/lib/rate-limit.ts` | Replace single-function `checkLoginRateLimit` with `isLoginRateLimited` (pure) + `recordLoginFailure` (mutator) + `resetLoginAttempts` (clear). |
| `src/server/start.ts` | Use `isLoginRateLimited` for the early 429 gate. |
| `src/server/routes/users/post-login.ts` | Call `resetLoginAttempts(req.ip)` on success; `recordLoginFailure(req.ip)` on failure. |
| `src/server/lib/rate-limit.test.ts` | New: 8 tests covering purity, the 5/6-failure threshold, success-resets-counter (the bug repro), and the locked-IP recovery path. |

## Test plan
- [x] `bun test src/server/lib/rate-limit.test.ts` → 8 pass / 0 fail.
- [x] `bun --bun tsc --noEmit` clean.
- [x] E2E against fresh dev server (port 3005):
  - 10 successful `POST /api/login` with `admin/budget` — all 200 (was: 5 × 200 then 5 × 429).
  - 5 wrong-password attempts → 200 `{status:"failed"}`; 6th and 7th → 429 (brute-force defense intact).
  - 4 fails + 1 success + 5 more fails — none blocked (success cleared the bucket).

## Notes
- `req.ip` is already populated by `start.ts:309` (`getClientIp` fallback chain).
- `resetLoginAttempts` is also safe to call when no record exists (`Map.delete` is a no-op).
- The adjacent bugs flagged in the issue body (inbox HTTP `createLimiter` has the same shape; `getClientIp` "unknown" fallback shares one bucket across callers) are out of scope here and worth separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)