### PR TITLE
test(users): coverage for post-login, get-login, delete-login (#393 partial)

### DIFF
--- a/src/server/routes/users/delete-login.test.ts
+++ b/src/server/routes/users/delete-login.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for DELETE /api/login (#393 — partial: delete-login.ts coverage).
+ *
+ * The route calls `req.session.destroy(cb)` and returns success.
+ * If the callback receives an error, the route throws — the Route base
+ * class catches it and returns a 500 error envelope.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import { deleteLoginRoute } from "./delete-login";
+
+function makeReq(
+  opts: { destroyErr?: Error } = {},
+): { req: Parameters<typeof deleteLoginRoute.execute>[0]; destroyCalled: () => boolean } {
+  let destroyCalled = false;
+  const req = {
+    method: "DELETE",
+    path: "/login",
+    url: "http://x/api/login",
+    headers: {},
+    query: {},
+    body: undefined,
+    session: {
+      id: "s-1",
+      user: undefined,
+      regenerate() {},
+      destroy(cb?: (err?: Error) => void) {
+        destroyCalled = true;
+        cb?.(opts.destroyErr);
+      },
+    },
+    ip: "127.0.0.1",
+  } as unknown as Parameters<typeof deleteLoginRoute.execute>[0];
+  return { req, destroyCalled: () => destroyCalled };
+}
+
+const fakeRes = () => {
+  const res = {
+    statusCode: 200,
+    headersSent: false,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    write() {
+      return true;
+    },
+    end() {},
+  };
+  return res as unknown as Parameters<typeof deleteLoginRoute.execute>[1];
+};
+
+describe("delete-login", () => {
+  test("happy path → session.destroy called, success returned", async () => {
+    const { req, destroyCalled } = makeReq();
+    const result = await deleteLoginRoute.execute(req, fakeRes());
+    expect(destroyCalled()).toBe(true);
+    expect(result?.status).toBe("success");
+  });
+
+  test("destroy callback error → Route layer surfaces 500 error envelope", async () => {
+    const { req } = makeReq({ destroyErr: new Error("session store down") });
+    const res = fakeRes();
+    const result = await deleteLoginRoute.execute(req, res);
+    expect(result?.status).toBe("error");
+    expect((res as { statusCode: number }).statusCode).toBe(500);
+  });
+});

--- a/src/server/routes/users/get-login.test.ts
+++ b/src/server/routes/users/get-login.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for GET /api/login (#393 — partial: get-login.ts coverage).
+ *
+ * No external mocks needed — get-login reads `req.session.user` and the
+ * exported `version` constant, no DB or downstream calls.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import { version } from "server/lib/postgres/initialize";
+import { getLoginRoute } from "./get-login";
+
+function makeReq(
+  user?: { user_id: string; username: string },
+): Parameters<typeof getLoginRoute.execute>[0] {
+  return {
+    method: "GET",
+    path: "/login",
+    url: "http://x/api/login",
+    headers: {},
+    query: {},
+    body: undefined,
+    session: {
+      id: "s-1",
+      user,
+      regenerate() {},
+      destroy() {},
+    },
+    ip: "127.0.0.1",
+  } as unknown as Parameters<typeof getLoginRoute.execute>[0];
+}
+
+const fakeRes = () => {
+  const res = {
+    statusCode: 200,
+    headersSent: false,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    write() {
+      return true;
+    },
+    end() {},
+  };
+  return res as unknown as Parameters<typeof getLoginRoute.execute>[1];
+};
+
+describe("get-login", () => {
+  test("no session.user → success with undefined user + 'Not logged in.' message", async () => {
+    const result = await getLoginRoute.execute(makeReq(undefined), fakeRes());
+    expect(result?.status).toBe("success");
+    expect(result?.body?.user).toBeUndefined();
+    expect(result?.body?.app?.version).toBe(version);
+    expect(result?.message).toBe("Not logged in.");
+  });
+
+  test("authed session → success with the user echoed and no message", async () => {
+    const user = { user_id: "u-1", username: "alice" };
+    const result = await getLoginRoute.execute(makeReq(user), fakeRes());
+    expect(result?.status).toBe("success");
+    expect(result?.body?.user).toEqual(user);
+    expect(result?.body?.app?.version).toBe(version);
+    expect(result?.message).toBeUndefined();
+  });
+
+  test("version field is a non-empty string", async () => {
+    const result = await getLoginRoute.execute(makeReq(undefined), fakeRes());
+    expect(typeof result?.body?.app?.version).toBe("string");
+    expect(result?.body?.app?.version.length).toBeGreaterThan(0);
+  });
+});

--- a/src/server/routes/users/post-login.test.ts
+++ b/src/server/routes/users/post-login.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for POST /api/login (#393 — partial: post-login.ts coverage).
+ *
+ * Mocking pattern: monkey-patch `usersTable.queryOne` (the lowest-level
+ * read that `searchUser` performs), mirroring `api-keys/post-api-keys.test.ts`.
+ * Avoids `mock.module("server", ...)` because Bun's module mock is
+ * process-wide and leaks across sibling test files.
+ *
+ * bcrypt.compare runs unmocked — fixture user passwords are real hashes
+ * generated at test-module load.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+import bcrypt from "bcrypt";
+
+import { usersTable } from "server/lib/postgres/models";
+import { postLoginRoute } from "./post-login";
+
+const REAL_PASSWORD = "correct-horse-battery-staple";
+const REAL_HASH = await bcrypt.hash(REAL_PASSWORD, 10);
+
+const realUserRow = {
+  user_id: "u-1",
+  username: "alice",
+  password: REAL_HASH,
+  email: null,
+  expiry: null,
+  token: null,
+  updated: "2026-05-19T00:00:00.000Z",
+  is_deleted: false,
+};
+
+// Fake model object: queryOne callers invoke `.toUser()` (per searchUser) so
+// we just need that one method to return the User record.
+const makeFakeModel = (row: typeof realUserRow) => ({
+  ...row,
+  toUser() {
+    return { user_id: row.user_id, username: row.username, password: row.password };
+  },
+  toMaskedUser() {
+    return { user_id: row.user_id, username: row.username };
+  },
+  toJSON() {
+    return { user_id: row.user_id, username: row.username };
+  },
+});
+
+const originalQueryOne = usersTable.queryOne.bind(usersTable);
+
+const mockQueryOne = mock(async (_filters: Record<string, unknown>): Promise<unknown> => null);
+
+(usersTable as unknown as { queryOne: typeof mockQueryOne }).queryOne = mockQueryOne;
+
+afterAll(() => {
+  (usersTable as unknown as { queryOne: typeof originalQueryOne }).queryOne = originalQueryOne;
+});
+
+beforeEach(() => {
+  mockQueryOne.mockReset();
+  mockQueryOne.mockResolvedValue(null);
+});
+
+interface SessionStub {
+  id: string;
+  user?: { user_id: string; username: string };
+  regenerate: (cb: (err?: Error) => void) => void;
+  destroy: (cb?: (err?: Error) => void) => void;
+}
+
+function makeReq(
+  body: unknown,
+  opts: { regenerateErr?: Error } = {},
+): Parameters<typeof postLoginRoute.execute>[0] {
+  const session: SessionStub = {
+    id: "s-1",
+    user: undefined,
+    regenerate(cb) {
+      cb(opts.regenerateErr);
+    },
+    destroy() {},
+  };
+  return {
+    method: "POST",
+    path: "/login",
+    url: "http://x/api/login",
+    headers: {},
+    query: {},
+    body,
+    session,
+    ip: "127.0.0.1",
+  } as unknown as Parameters<typeof postLoginRoute.execute>[0];
+}
+
+const fakeRes = () => {
+  const res = {
+    statusCode: 200,
+    headersSent: false,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    write() {
+      return true;
+    },
+    end() {},
+  };
+  return res as unknown as Parameters<typeof postLoginRoute.execute>[1];
+};
+
+describe("post-login validation", () => {
+  test("missing body → validationError", async () => {
+    const result = await postLoginRoute.execute(makeReq(null), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/body/i);
+    expect(mockQueryOne).not.toHaveBeenCalled();
+  });
+
+  test("missing username → validationError", async () => {
+    const result = await postLoginRoute.execute(
+      makeReq({ password: "x" }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/username/);
+    expect(mockQueryOne).not.toHaveBeenCalled();
+  });
+
+  test("missing password → validationError", async () => {
+    const result = await postLoginRoute.execute(
+      makeReq({ username: "alice" }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/password/);
+    expect(mockQueryOne).not.toHaveBeenCalled();
+  });
+
+  test("empty-string username → validationError", async () => {
+    const result = await postLoginRoute.execute(
+      makeReq({ username: "", password: "x" }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/username/);
+  });
+});
+
+describe("post-login auth outcomes", () => {
+  test("unknown user → generic failure (no enumeration leak)", async () => {
+    mockQueryOne.mockResolvedValueOnce(null);
+    const result = await postLoginRoute.execute(
+      makeReq({ username: "ghost", password: REAL_PASSWORD }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toBe("Invalid username or password.");
+    // Verify the search was actually attempted (DUMMY_HASH timing path runs
+    // for unknown users — assertion: queryOne was called once).
+    expect(mockQueryOne).toHaveBeenCalledTimes(1);
+  });
+
+  test("known user + wrong password → same generic failure (no enumeration leak)", async () => {
+    mockQueryOne.mockResolvedValueOnce(makeFakeModel(realUserRow));
+    const result = await postLoginRoute.execute(
+      makeReq({ username: "alice", password: "WRONG" }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toBe("Invalid username or password.");
+  });
+
+  test("known user + correct password → success, session.regenerate called, user set", async () => {
+    mockQueryOne.mockResolvedValueOnce(makeFakeModel(realUserRow));
+
+    let regenerateCalled = false;
+    const session: SessionStub = {
+      id: "s-old",
+      user: undefined,
+      regenerate(cb) {
+        regenerateCalled = true;
+        cb();
+      },
+      destroy() {},
+    };
+    const req = {
+      method: "POST",
+      path: "/login",
+      url: "http://x/api/login",
+      headers: {},
+      query: {},
+      body: { username: "alice", password: REAL_PASSWORD },
+      session,
+      ip: "127.0.0.1",
+    } as unknown as Parameters<typeof postLoginRoute.execute>[0];
+
+    const result = await postLoginRoute.execute(req, fakeRes());
+    expect(result?.status).toBe("success");
+    expect(result?.body?.user_id).toBe("u-1");
+    expect(result?.body?.username).toBe("alice");
+    // Hashed password must never leak in the response.
+    expect((result?.body as Record<string, unknown> | undefined)?.password).toBeUndefined();
+    expect(regenerateCalled).toBe(true);
+    expect(session.user?.user_id).toBe("u-1");
+  });
+
+  test("session.regenerate callback error → Route layer surfaces error envelope", async () => {
+    // The Route base class catches throws and returns
+    // { status: "error", message: "Internal server error" } with HTTP 500.
+    // Pin: a regenerate failure must NOT be silently turned into success.
+    mockQueryOne.mockResolvedValueOnce(makeFakeModel(realUserRow));
+    const req = makeReq(
+      { username: "alice", password: REAL_PASSWORD },
+      { regenerateErr: new Error("boom") },
+    );
+    const res = fakeRes();
+    const result = await postLoginRoute.execute(req, res);
+    expect(result?.status).toBe("error");
+    expect((res as { statusCode: number }).statusCode).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds route-level tests for the 3 auth-entry-point files in \`src/server/routes/users/\` (post-login, get-login, delete-login) — the security-critical subset of #393.
- 13 tests, 0 failures, full suite stays green (\`bun test src/server\` → 384 / 384).
- \`bun --bun tsc --noEmit\` clean.

Refs #393 (does not close — post-public-token, get-link-token, delete-item still need coverage and will land in follow-up PRs).

## What's covered
| Route | Tests |
|-------|------:|
| \`POST /login\` | 8 (missing body / missing username / missing password / empty username; unknown user → generic failure + queryOne still hit for timing defense; known user + wrong password → same generic failure; correct password → success + regenerate + user set + password not leaked in response; regenerate callback error → Route-layer 500 error envelope) |
| \`GET /login\` | 3 (unauth → \`Not logged in.\` + undefined user; authed → user echoed + no message; version is non-empty string) |
| \`DELETE /login\` | 2 (destroy callback fired → success; destroy callback error → 500 error envelope) |

## Mocking pattern
Monkey-patch \`usersTable.queryOne\` (the lowest-level read under \`searchUser\`) per the \`api-keys/post-api-keys.test.ts\` approach. No \`mock.module(\"server\", ...)\` — Bun's module mock is process-wide and leaks across sibling test files. \`bcrypt.compare\` runs unmocked against real fixture hashes generated at module load.

## Test plan
- [x] \`bun test src/server/routes/users/\` → 13 pass / 0 fail.
- [x] \`bun test src/server\` → 384 pass / 0 fail (no regressions).
- [x] \`bun --bun tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)