### PR TITLE
fix(accounts-table): render Changes for new + closed accounts

### DIFF
--- a/src/client/components/AccountsTable/Balance.tsx
+++ b/src/client/components/AccountsTable/Balance.tsx
@@ -46,43 +46,43 @@ export const Balance = ({ account }: BalanceProps) => {
         </div>
       </div>
     );
-  } else if (subtype === AccountSubtype.CryptoExchange) {
+  }
+
+  // Show the per-row Changes widget whenever either side of the
+  // comparison has value — covers regular accounts (prev>0 AND
+  // current>0), new accounts (prev=0, current>0 → "+$current"), and
+  // closed accounts (prev>0, current=0 → "-$prev"). Closes #357: the
+  // donut's `BalanceInfo` headline change already counts new-account
+  // currents on the current side; gating the row widget on
+  // `!!previousAmount` was hiding the matching per-row entry, which is
+  // what made the donut headline appear to disagree with the table.
+  // Now the table sums to the same number the donut shows.
+  const shouldShowChanges = !!previousAmount || !!dynamicAmount;
+  const changesProps = {
+    currentAmount: dynamicAmount || current!,
+    previousAmount,
+  };
+
+  if (subtype === AccountSubtype.CryptoExchange || type === AccountType.Investment) {
     return (
       <div className="Balance">
         <div>
           {symbol}
           {numberToCommaString(dynamicAmount)}
         </div>
-        {!!previousAmount && (
-          <Changes currentAmount={dynamicAmount || current!} previousAmount={previousAmount} />
-        )}
-      </div>
-    );
-  } else if (type === AccountType.Investment) {
-    return (
-      <div className="Balance">
-        <div>
-          {symbol}
-          {numberToCommaString(dynamicAmount)}
-        </div>
-        {!!previousAmount && (
-          <Changes currentAmount={dynamicAmount || current!} previousAmount={previousAmount} />
-        )}
-      </div>
-    );
-  } else {
-    return (
-      <div className="Balance">
-        <div>
-          {symbol}
-          {numberToCommaString(dynamicAmount)}
-        </div>
-        {!!previousAmount && (
-          <Changes currentAmount={dynamicAmount || current!} previousAmount={previousAmount} />
-        )}
+        {shouldShowChanges && <Changes {...changesProps} />}
       </div>
     );
   }
+  return (
+    <div className="Balance">
+      <div>
+        {symbol}
+        {numberToCommaString(dynamicAmount)}
+      </div>
+      {shouldShowChanges && <Changes {...changesProps} />}
+    </div>
+  );
 };
 
 interface ChangesProps {


### PR DESCRIPTION
Closes #357. Supersedes #373.

## Background

Original diagnosis on #357 inverted the bug. The donut's `BalanceInfo` math is correct — it sums `balanceTotal − Σ(prev || 0)` across all donut accounts, treating a missing/zero `previousAmount` as 0 → a new account with `current` contributes the full current to the headline change (the right "net-worth delta" semantic for "from last month"). The per-row `Balance.tsx` widget, however, gated `<Changes>` on `!!previousAmount`, so:

- New account (prev=0, current>0): row widget hidden → table sum understates by current
- Closed account (prev>0, current=0): row widget hidden → table sum understates by −prev

That's why the donut headline appeared to disagree with the visible row sum. #373 proposed silencing the donut to match the hidden rows (loses the change from the headline). This goes the other way: leave the donut alone, show the per-row widget for new and closed accounts too.

## Change

`src/client/components/AccountsTable/Balance.tsx`:

- Replace the `!!previousAmount` gate with `!!previousAmount || !!dynamicAmount` — shows `<Changes>` whenever either side has value. New accounts now render `+current`; closed accounts render `-previous`; empty-both still hides.
- The existing `<Changes>` component already returns a neutral `"-"` for `currentAmount === previousAmount`, so the zero-change case stays graceful.
- Refactored the three near-identical investment / crypto-exchange / default branches into a single shared closure to keep the gate consistent across all account shapes (credit unchanged — it has its own spent/available layout).

## Math verification

Issue body's repro showed a donut headline vs row-sum gap exactly equal to one prior-zero asset row's current balance — confirming the per-row widget's prev=0 gate was the source of the divergence. *[Edited 2026-05-20: original verification quoted prod-scrambled currency figures and a broker identifier — redacted per §2a; numeric reconstruction lives in #357 issue body.]*

After this PR:
- Donut headline unchanged (no change to BalanceInfo math)
- The previously-hidden new-account row now renders its `+current` delta
- Per-row sum + the new-account delta = donut headline ✓

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test:client` — 201 pass
- [ ] Sandbox E2E: load `/accounts` against the prod clone, verify donut headline change equals sum of visible per-row Changes (including any new-account row).
- [ ] Close #373 with a pointer to this PR.