### PR TITLE
chore: rephrase Hoie-attributed comments as design choices (round 2)

### DIFF
--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -41,11 +41,11 @@ export const HoldingProperties = () => {
   const snapshotId = activeParams.get("snapshot_id") || "";
   const isNew = !snapshotId;
 
-  // Edit gating mirrors AccountProperties' balance input (Hoie 2026-05-15):
-  // synced accounts are not editable at the current viewDate, because that
-  // state is broker-derived and would diverge from the next sync. Manual
-  // accounts are always editable. Past viewDates (manual or synced) edit
-  // the underlying snapshot, same model as account-snapshot balance edits.
+  // Edit gating mirrors AccountProperties' balance input: synced accounts
+  // are not editable at the current viewDate, because that state is
+  // broker-derived and would diverge from the next sync. Manual accounts
+  // are always editable. Past viewDates (manual or synced) edit the
+  // underlying snapshot, same model as account-snapshot balance edits.
   const account = data.accounts.get(accountId);
   const item = account ? data.items.get(account.item_id) : undefined;
   const isManualAccount = item?.provider === ItemProvider.MANUAL;

--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -5,7 +5,7 @@ import { InvestmentTransactionDictionary, HoldingSnapshotDictionary, SecuritySna
  * Investment-performance benchmarking math — money-weighted return (IRR) of
  * the user's non-cash positions plus an index TWR for the same window.
  *
- * **Scope (Hoie 2026-05-16): cash is excluded.** The "portfolio" tracked here
+ * **Scope: cash is excluded.** The "portfolio" tracked here
  * is the user's non-cash holdings only (VOO etc.); cash positions (QACDS,
  * pending-settlement orphans, USD sweep balances) are deliberately ignored.
  * Every asset BUY counts as an external deposit into the asset portfolio and
@@ -184,7 +184,7 @@ export const computeBenchmarkTWR = (params: {
  * Cash-shape holdings (per `isCashShapeHolding`) are excluded — the
  * widget's scope is the asset portfolio, not the total account.
  *
- * **`qty(t)` is txn-derived** (Hoie 2026-05-16). For each non-cash security:
+ * **`qty(t)` is txn-derived.** For each non-cash security:
  *   qty(t) = qty_from_holding_snapshot_at_windowStart
  *          + Σ(buy.quantity − sell.quantity from txns in (windowStart, t])
  *
@@ -316,7 +316,7 @@ export const earliestDataDate = (params: {
  * ≤ the query date; falls back to the earliest known entry when the
  * query predates everything.
  *
- * **Why both sources** (Hoie 2026-05-17):
+ * **Why both sources:**
  *   - `price_at_windowEnd` needs the **exact date** market price.
  *     security_snapshots give that for any date Plaid has synced (≈
  *     last year), and the resolve-security-snapshot endpoint backfills

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -54,9 +54,9 @@ export const getBudgetData = (
     //   - genuinely unlabeled (category_id null, confidence null)
     //   - explicitly rejected (category_id null, confidence 0)
     //   - auto-suggested but unreviewed (category_id set, 0 < confidence < 1)
-    // Per Hoie's directive on PR #332: the unsorted-count and the
-    // unsorted-amount-bar must reflect "needs my review" not just
-    // "literally lacking a category", so the gate is `confidence !== 1`.
+    // The unsorted-count and the unsorted-amount-bar reflect "needs my
+    // review", not just "literally lacking a category", so the gate is
+    // `confidence !== 1`.
     // A row only counts toward the sorted/category bucket if it's
     // confirmed AND has a category_id; the latter guards against a
     // malformed `confidence=1 AND category_id=null` row falling into the

--- a/src/client/lib/hooks/calculation/holdings.test.ts
+++ b/src/client/lib/hooks/calculation/holdings.test.ts
@@ -133,7 +133,7 @@ describe("getPriceForHolding", () => {
   const emptyIndex: SecurityPriceIndex = new Map();
 
   test("on equal source dates the security snapshot wins (tie-breaker)", () => {
-    // Both sources report on 2026-01-15. Per Hoie 2026-05-13: security wins on tie.
+    // Both sources report on 2026-01-15; the security snapshot wins on tie.
     const holding = createHoldingSnapshot("acc1", "sec1", 10, 100, 1000, null, "2026-01-15");
     const snapshots = new SecuritySnapshotDictionary();
     snapshots.set("snap1", createSecuritySnapshot("sec1", 95, "2026-01-15"));
@@ -442,8 +442,7 @@ describe("getHoldingsValueData", () => {
     // snapshot: institution_price === 1 AND cost_basis === null. Plaid
     // cash sweeps always satisfy both; real equities essentially never
     // do for any meaningful duration. Server doesn't need to ship a
-    // `type='cash'` flag (Hoie 2026-05-14: "FE should skip G/L
-    // calculation for cash holdings").
+    // `type='cash'` flag; the FE skips G/L for cash holdings entirely.
     const holdingSnapshots = new HoldingSnapshotDictionary();
     holdingSnapshots.set(
       "h-cash",

--- a/src/client/lib/hooks/calculation/holdings.ts
+++ b/src/client/lib/hooks/calculation/holdings.ts
@@ -97,15 +97,14 @@ const findLatestEntryLessThanOrEqual = (
 };
 
 /**
- * Gets the price for a holding. As of #323 follow-up: security and holding
- * snapshots are compared by their source dates rather than ordered by a
- * fixed-priority list. Whichever was recorded later wins; ties go to the
- * security snapshot (Hoie 2026-05-13: "if both security and holding have
- * the same timestamp, then security wins"). This matters because security
- * snapshots can be filled by polygon between Plaid syncs, so the broker's
- * `institution_price` can sometimes be the staler of the two even when both
- * exist; and for manual accounts where institution_price doesn't exist at
- * all, the security snapshot wins by default.
+ * Gets the price for a holding. Security and holding snapshots are
+ * compared by their source dates rather than ordered by a fixed-priority
+ * list. Whichever was recorded later wins; ties go to the security
+ * snapshot. This matters because security snapshots can be filled by
+ * polygon between Plaid syncs, so the broker's `institution_price` can
+ * sometimes be the staler of the two even when both exist; and for manual
+ * accounts where institution_price doesn't exist at all, the security
+ * snapshot wins by default.
  *
  * Walk-back semantics on the security side: we use the most recent security
  * entry whose `yearMonth` is on or before the requested view date. We never
@@ -309,8 +308,7 @@ export const getHoldingsValueData = ({
       // institution_price=1.0 and never carry a cost_basis (Plaid doesn't
       // track basis on cash). Real equities essentially never satisfy
       // both for any meaningful duration. This avoids needing server-side
-      // help to identify cash — Hoie 2026-05-14: "FE should skip G/L
-      // calculation for cash holdings."
+      // help to identify cash. G/L is suppressed for cash holdings.
       //
       // `cost_basis` on the wire is 0, not null — `SnapshotModel.toHoldingSnapshot`
       // does `this.cost_basis ?? 0`, collapsing DB NULL to a numeric zero.

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -544,11 +544,10 @@ export const useSync = () => {
         // If ANY of the warm-path fetches reported a network failure,
         // don't persist the partial result to IndexedDB — the existing
         // cache is still good; replacing it with a partial would
-        // permanently lose the dictionaries that fell through to empty
-        // (Hoie 2026-05-20: "Clear indexed DB only if network fetch
-        // succeeds"). Same reason for skipping `writeLastSyncedAt` — the
-        // next warm load needs the OLD timestamp so its refresh window
-        // still spans the gap that just failed.
+        // permanently lose the dictionaries that fell through to empty.
+        // Same reason for skipping `writeLastSyncedAt` — the next warm
+        // load needs the OLD timestamp so its refresh window still spans
+        // the gap that just failed.
         const warmFetchFailed =
           budgetsResult.networkFailed ||
           chartsResult.networkFailed ||
@@ -738,10 +737,9 @@ export const useSync = () => {
       setData(finalData);
 
       // Only persist when every cold-path fetch succeeded — same
-      // semantics as the warm path (Hoie 2026-05-20). If anything
-      // failed, leave whatever was in IndexedDB before this run alone
-      // and skip the timestamp write so the next sync still treats
-      // this gap as un-pulled.
+      // semantics as the warm path. If anything failed, leave whatever
+      // was in IndexedDB before this run alone and skip the timestamp
+      // write so the next sync still treats this gap as un-pulled.
       const coldFetchFailed =
         stage1Budgets.networkFailed ||
         stage1Charts.networkFailed ||

--- a/src/client/lib/models/Calculations.ts
+++ b/src/client/lib/models/Calculations.ts
@@ -353,7 +353,7 @@ export class HoldingValueSummary {
    * snapshot looks like cash (institution_price=1 + null/0 cost_basis).
    * Used in `HoldingsComposition` to label the row "Cash" instead of a
    * truncated security_id, and to suppress G/L. See holdings.ts for the
-   * full rationale (Hoie 2026-05-14).
+   * full rationale.
    */
   isCash: boolean = false;
 


### PR DESCRIPTION
Follow-up to merged #394. That PR left 7 attributions on the table because PR #386 had `benchmark.ts` / `PerformanceBenchmark/` in its active diff at the time, so cleaning those up would have collided with the open review. Since then #386 has merged (ff6f123) and #400 (sync.ts warm-load) has merged (f8dad0e) — both unblocking the deferred surfaces.

Same shape as #394 / inbox #500: each Hoie-attributed comment is rephrased as a direct design assertion, dropping the `(Hoie YYYY-MM-DD: "...")` parenthetical, per the directive on #383 / #352.

## Files

| File | Attributions | After |
|------|--------------|-------|
| `src/client/lib/hooks/calculation/benchmark.ts` | 3 (scope cash-exclusion, qty(t) txn-derived, both-sources rationale) | inline rationale, no name/date |
| `src/client/lib/hooks/sync.ts` | 2 (warm + cold "only persist on full success" — both introduced by #400) | inline rationale, no name/date |
| `src/client/lib/hooks/calculation/holdings.ts` | 1 (security-wins-on-tie) | direct assertion |
| `src/client/lib/hooks/calculation/holdings.test.ts` | 2 (tie-breaker + cash-FE-side rationale) | direct assertion |
| `src/client/lib/models/Calculations.ts` | 1 (isCash field jsdoc) | "full rationale (Hoie 2026-05-14)" → "full rationale" |
| `src/client/components/HoldingProperties/index.tsx` | 1 (edit-gating-mirrors-AccountProperties) | direct assertion |
| `src/client/lib/hooks/calculation/budgets.ts` | 1 (the unsorted-count "needs my review" gate) | direct assertion |

## Verification

- `grep -rn 'Hoie 2026\|Per Hoie' src/` → 0 hits.
- `bun run typecheck` clean.
- `bun run lint` clean.
- `bun test src/server` → 424 pass / 0 fail.
- `bun test src/client/lib/hooks/calculation/holdings.test.ts` and `benchmark.test.ts` — pre-existing failure set unchanged vs `upstream/main` (verified by stashing this branch's diff). Comment-only changes can't affect runtime behavior.

## Out of scope

- The substantive content of each rationale is preserved verbatim minus the attribution; no claim about behavior was reworded.
- No source/test logic touched.

## Test plan

- [x] grep verifies 0 surviving attributions
- [x] typecheck / lint clean
- [x] server tests green (424/424)
- [ ] E2E: not applicable — comments-only diff, zero runtime effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)