### PR TITLE
test(plaid-hook): route-level coverage via DI factory

### DIFF
--- a/src/server/routes/webhooks/index.ts
+++ b/src/server/routes/webhooks/index.ts
@@ -1,1 +1,1 @@
-export * from "./post-plaid-hook";
+export { postPlaidHookRoute } from "./post-plaid-hook";

--- a/src/server/routes/webhooks/post-plaid-hook.test.ts
+++ b/src/server/routes/webhooks/post-plaid-hook.test.ts
@@ -7,7 +7,7 @@
  * leaks across sibling test files in the same run.
  */
 
-import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
 
 import {
   createPostPlaidHookRoute,

--- a/src/server/routes/webhooks/post-plaid-hook.test.ts
+++ b/src/server/routes/webhooks/post-plaid-hook.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Tests for POST /api/plaid-hook (Closes #404 — route-level coverage).
+ *
+ * Mocking pattern: build the route from `createPostPlaidHookRoute({...})`
+ * with plain function mocks for every dep the route touches. No
+ * `mock.module("server", ...)` — Bun's module mock is process-wide and
+ * leaks across sibling test files in the same run.
+ */
+
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+import {
+  createPostPlaidHookRoute,
+  type PostPlaidHookDeps,
+} from "./post-plaid-hook";
+
+const ITEM_ID = "item-1";
+
+const fakeRes = () => {
+  const res = {
+    statusCode: 200,
+    headersSent: false,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    write() {
+      return true;
+    },
+    end() {},
+  };
+  return res as unknown as Parameters<
+    ReturnType<typeof createPostPlaidHookRoute>["execute"]
+  >[1];
+};
+
+function makeReq(
+  body: unknown,
+  opts: { rawBody?: string; verification?: string } = {},
+) {
+  return {
+    method: "POST",
+    path: "/plaid-hook",
+    url: "http://x/api/plaid-hook",
+    headers: {
+      "plaid-verification": opts.verification ?? "valid.jwt",
+    },
+    query: {},
+    body,
+    rawBody:
+      opts.rawBody !== undefined
+        ? opts.rawBody
+        : JSON.stringify(body ?? {}),
+    session: {
+      id: "s-1",
+      regenerate() {},
+      destroy() {},
+    },
+    ip: "127.0.0.1",
+  } as unknown as Parameters<
+    ReturnType<typeof createPostPlaidHookRoute>["execute"]
+  >[0];
+}
+
+function makeDeps(
+  overrides: Partial<PostPlaidHookDeps> = {},
+): PostPlaidHookDeps {
+  return {
+    verifyWebhook: mock(async () => true),
+    syncPlaidTransactions: mock(async () => ({
+      added: 1,
+      modified: 0,
+      removed: 0,
+    })) as unknown as PostPlaidHookDeps["syncPlaidTransactions"],
+    updateItemStatus: mock(async () => true) as unknown as PostPlaidHookDeps["updateItemStatus"],
+    getUserItem: mock(async () => ({
+      user: { user_id: "u-1", username: "alice" },
+      item: {
+        item_id: ITEM_ID,
+        access_token: "tok-1",
+        institution_id: "ins-1",
+        available_products: [],
+        billed_products: [],
+        consent_expiration_time: null,
+        cursor: null,
+        plaid_error: null,
+        status: "GOOD",
+      },
+    })) as unknown as PostPlaidHookDeps["getUserItem"],
+    upsertItems: mock(async () => undefined) as unknown as PostPlaidHookDeps["upsertItems"],
+    getItem: mock(async () => ({
+      item_id: ITEM_ID,
+      institution_id: "ins-1",
+      consented_products: ["transactions"],
+      products: ["accounts"],
+    })) as unknown as PostPlaidHookDeps["getItem"],
+    sendAlarm: mock(async () => undefined) as unknown as PostPlaidHookDeps["sendAlarm"],
+    ...overrides,
+  };
+}
+
+describe("post-plaid-hook auth gate", () => {
+  test("missing rawBody → 401 + does not call verifyWebhook", async () => {
+    const deps = makeDeps();
+    const route = createPostPlaidHookRoute(deps);
+    const res = fakeRes();
+    const req = makeReq(
+      { webhook_type: "ITEM", webhook_code: "PENDING_EXPIRATION", item_id: ITEM_ID },
+      { rawBody: "" },
+    );
+    const result = await route.execute(req, res);
+    expect((res as unknown as { statusCode: number }).statusCode).toBe(401);
+    expect(result?.status).toBe("failed");
+    expect(deps.verifyWebhook).not.toHaveBeenCalled();
+    expect(deps.syncPlaidTransactions).not.toHaveBeenCalled();
+  });
+
+  test("verifyWebhook returns false → 401, body branching short-circuited", async () => {
+    const deps = makeDeps({ verifyWebhook: mock(async () => false) });
+    const route = createPostPlaidHookRoute(deps);
+    const res = fakeRes();
+    const result = await route.execute(
+      makeReq({ webhook_type: "TRANSACTIONS", webhook_code: "SYNC_UPDATES_AVAILABLE", item_id: ITEM_ID }),
+      res,
+    );
+    expect((res as unknown as { statusCode: number }).statusCode).toBe(401);
+    expect(result?.status).toBe("failed");
+    expect(deps.verifyWebhook).toHaveBeenCalledTimes(1);
+    expect(deps.syncPlaidTransactions).not.toHaveBeenCalled();
+  });
+
+  test("verifyWebhook receives signedJwt from header (undefined → still gets called)", async () => {
+    const deps = makeDeps({ verifyWebhook: mock(async () => true) });
+    const route = createPostPlaidHookRoute(deps);
+    const req = makeReq(
+      { webhook_type: "ITEM", webhook_code: "WEBHOOK_UPDATE_ACKNOWLEDGED", item_id: ITEM_ID },
+      { verification: "sig.abc" },
+    );
+    const result = await route.execute(req, fakeRes());
+    expect(deps.verifyWebhook).toHaveBeenCalledWith(req.rawBody, "sig.abc");
+    expect(result?.status).toBe("success");
+  });
+
+  test("verified + invalid body shape → validationError, no dispatch", async () => {
+    const deps = makeDeps();
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(makeReq(null), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(deps.verifyWebhook).toHaveBeenCalledTimes(1);
+    expect(deps.syncPlaidTransactions).not.toHaveBeenCalled();
+    expect(deps.updateItemStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe("post-plaid-hook TRANSACTIONS dispatch", () => {
+  test("SYNC_UPDATES_AVAILABLE → syncPlaidTransactions called, success", async () => {
+    const deps = makeDeps();
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({ webhook_type: "TRANSACTIONS", webhook_code: "SYNC_UPDATES_AVAILABLE", item_id: ITEM_ID }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("success");
+    expect(deps.syncPlaidTransactions).toHaveBeenCalledWith(ITEM_ID);
+  });
+
+  test("SYNC_UPDATES_AVAILABLE + syncPlaidTransactions returns null → failed", async () => {
+    const deps = makeDeps({
+      syncPlaidTransactions: mock(
+        async () => null,
+      ) as unknown as PostPlaidHookDeps["syncPlaidTransactions"],
+    });
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({ webhook_type: "TRANSACTIONS", webhook_code: "SYNC_UPDATES_AVAILABLE", item_id: ITEM_ID }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+  });
+
+  test.each([
+    "DEFAULT_UPDATE",
+    "INITIAL_UPDATE",
+    "HISTORICAL_UPDATE",
+    "TRANSACTIONS_REMOVED",
+  ])("TRANSACTIONS %s → success without sync side-effect", async (code) => {
+    const deps = makeDeps();
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({ webhook_type: "TRANSACTIONS", webhook_code: code, item_id: ITEM_ID }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("success");
+    expect(deps.syncPlaidTransactions).not.toHaveBeenCalled();
+  });
+
+  test("TRANSACTIONS unknown code → no return value (warn path)", async () => {
+    const deps = makeDeps();
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({ webhook_type: "TRANSACTIONS", webhook_code: "MYSTERY_CODE", item_id: ITEM_ID }),
+      fakeRes(),
+    );
+    expect(result).toBeNull();
+    expect(deps.syncPlaidTransactions).not.toHaveBeenCalled();
+  });
+});
+
+describe("post-plaid-hook ITEM dispatch", () => {
+  test("WEBHOOK_UPDATE_ACKNOWLEDGED → success without side-effect", async () => {
+    const deps = makeDeps();
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({ webhook_type: "ITEM", webhook_code: "WEBHOOK_UPDATE_ACKNOWLEDGED", item_id: ITEM_ID }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("success");
+    expect(deps.updateItemStatus).not.toHaveBeenCalled();
+  });
+
+  test("PENDING_EXPIRATION → updateItemStatus(BAD) + sendAlarm", async () => {
+    const deps = makeDeps();
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({ webhook_type: "ITEM", webhook_code: "PENDING_EXPIRATION", item_id: ITEM_ID }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("success");
+    expect(deps.updateItemStatus).toHaveBeenCalledTimes(1);
+    expect(deps.sendAlarm).toHaveBeenCalledTimes(1);
+  });
+
+  test("ERROR + ITEM_LOGIN_REQUIRED → updateItemStatus(BAD) + sendAlarm", async () => {
+    const deps = makeDeps();
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({
+        webhook_type: "ITEM",
+        webhook_code: "ERROR",
+        item_id: ITEM_ID,
+        error: { error_code: "ITEM_LOGIN_REQUIRED" },
+      }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("success");
+    expect(deps.updateItemStatus).toHaveBeenCalledTimes(1);
+    expect(deps.sendAlarm).toHaveBeenCalledTimes(1);
+  });
+
+  test("ERROR + other error_code → no return (warn path), no side-effect", async () => {
+    const deps = makeDeps();
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({
+        webhook_type: "ITEM",
+        webhook_code: "ERROR",
+        item_id: ITEM_ID,
+        error: { error_code: "MFA_REQUIRED" },
+      }),
+      fakeRes(),
+    );
+    expect(result).toBeNull();
+    expect(deps.updateItemStatus).not.toHaveBeenCalled();
+  });
+
+  test("PENDING_EXPIRATION + updateItemStatus returns false → failed, sendAlarm not invoked", async () => {
+    const deps = makeDeps({
+      updateItemStatus: mock(async () => false) as unknown as PostPlaidHookDeps["updateItemStatus"],
+    });
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({ webhook_type: "ITEM", webhook_code: "PENDING_EXPIRATION", item_id: ITEM_ID }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(deps.sendAlarm).not.toHaveBeenCalled();
+  });
+
+  test.each(["USER_ACCOUNT_REVOKED", "ITEM_UPDATED"])(
+    "%s → refreshItemProducts (getUserItem + plaid.getItem + upsertItems)",
+    async (code) => {
+      const deps = makeDeps();
+      const route = createPostPlaidHookRoute(deps);
+      const result = await route.execute(
+        makeReq({ webhook_type: "ITEM", webhook_code: code, item_id: ITEM_ID }),
+        fakeRes(),
+      );
+      expect(result?.status).toBe("success");
+      expect(deps.getUserItem).toHaveBeenCalledWith(ITEM_ID);
+      expect(deps.getItem).toHaveBeenCalledWith("tok-1");
+      expect(deps.upsertItems).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test("refreshItemProducts when getUserItem returns null → failed", async () => {
+    const deps = makeDeps({
+      getUserItem: mock(async () => null) as unknown as PostPlaidHookDeps["getUserItem"],
+    });
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({ webhook_type: "ITEM", webhook_code: "ITEM_UPDATED", item_id: ITEM_ID }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(deps.upsertItems).not.toHaveBeenCalled();
+  });
+
+  test("ITEM unknown code → no return (warn path)", async () => {
+    const deps = makeDeps();
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({ webhook_type: "ITEM", webhook_code: "MYSTERY_ITEM_CODE", item_id: ITEM_ID }),
+      fakeRes(),
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("post-plaid-hook HOLDINGS & INVESTMENTS_TRANSACTIONS dispatch", () => {
+  test("HOLDINGS DEFAULT_UPDATE → syncPlaidTransactions called", async () => {
+    const deps = makeDeps();
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({ webhook_type: "HOLDINGS", webhook_code: "DEFAULT_UPDATE", item_id: ITEM_ID }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("success");
+    expect(deps.syncPlaidTransactions).toHaveBeenCalledWith(ITEM_ID);
+  });
+
+  test("HOLDINGS unknown code → no return (warn path)", async () => {
+    const deps = makeDeps();
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({ webhook_type: "HOLDINGS", webhook_code: "WEIRD", item_id: ITEM_ID }),
+      fakeRes(),
+    );
+    expect(result).toBeNull();
+    expect(deps.syncPlaidTransactions).not.toHaveBeenCalled();
+  });
+
+  test.each(["DEFAULT_UPDATE", "HISTORICAL_UPDATE"])(
+    "INVESTMENTS_TRANSACTIONS %s → syncPlaidTransactions called",
+    async (code) => {
+      const deps = makeDeps();
+      const route = createPostPlaidHookRoute(deps);
+      const result = await route.execute(
+        makeReq({ webhook_type: "INVESTMENTS_TRANSACTIONS", webhook_code: code, item_id: ITEM_ID }),
+        fakeRes(),
+      );
+      expect(result?.status).toBe("success");
+      expect(deps.syncPlaidTransactions).toHaveBeenCalledWith(ITEM_ID);
+    },
+  );
+
+  test("INVESTMENTS_TRANSACTIONS unknown code → no return (warn path)", async () => {
+    const deps = makeDeps();
+    const route = createPostPlaidHookRoute(deps);
+    const result = await route.execute(
+      makeReq({
+        webhook_type: "INVESTMENTS_TRANSACTIONS",
+        webhook_code: "MYSTERY",
+        item_id: ITEM_ID,
+      }),
+      fakeRes(),
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/src/server/routes/webhooks/post-plaid-hook.ts
+++ b/src/server/routes/webhooks/post-plaid-hook.ts
@@ -10,85 +10,111 @@ interface PlaidWebhookBody {
   error?: { error_code: string };
 }
 
-export const postPlaidHookRoute = new Route("POST", "/plaid-hook", async (req, res) => {
-  // Verify webhook signature from Plaid
-  const signedJwt = req.headers["plaid-verification"] as string | undefined;
-  const rawBody = (req as { rawBody?: string }).rawBody;
+export interface PostPlaidHookDeps {
+  verifyWebhook: (rawBody: string, signedJwt?: string) => Promise<boolean>;
+  syncPlaidTransactions: typeof syncPlaidTransactions;
+  updateItemStatus: typeof updateItemStatus;
+  getUserItem: typeof getUserItem;
+  upsertItems: typeof upsertItems;
+  getItem: typeof plaid.getItem;
+  sendAlarm: typeof sendAlarm;
+}
 
-  if (!rawBody) {
-    logger.error("[Plaid Webhook] Raw body not available for verification");
-    res.status(401);
-    return { status: "failed", message: "Webhook verification failed" };
-  }
+export const createPostPlaidHookRoute = (deps: PostPlaidHookDeps) =>
+  new Route("POST", "/plaid-hook", async (req, res) => {
+    // Verify webhook signature from Plaid
+    const signedJwt = req.headers["plaid-verification"] as string | undefined;
+    const rawBody = (req as { rawBody?: string }).rawBody;
 
-  const isValid = await plaid.verifyWebhook(rawBody, signedJwt);
-  if (!isValid) {
-    res.status(401);
-    return { status: "failed", message: "Invalid webhook signature" };
-  }
-
-  const bodyResult = requireBodyObject(req);
-  if (!bodyResult.success) return validationError(bodyResult.error!);
-
-  const { webhook_type, webhook_code, item_id, error } = bodyResult.data as PlaidWebhookBody;
-  if (webhook_type === "TRANSACTIONS") {
-    if (webhook_code === "SYNC_UPDATES_AVAILABLE") {
-      return await syncAndLog(item_id);
-    } else if (
-      ["DEFAULT_UPDATE", "INITIAL_UPDATE", "HISTORICAL_UPDATE", "TRANSACTIONS_REMOVED"].includes(
-        webhook_code
-      )
-    ) {
-      return { status: "success" };
+    if (!rawBody) {
+      logger.error("[Plaid Webhook] Raw body not available for verification");
+      res.status(401);
+      return { status: "failed", message: "Webhook verification failed" };
     }
-  } else if (webhook_type === "ITEM") {
-    if (webhook_code === "WEBHOOK_UPDATE_ACKNOWLEDGED") {
-      return { status: "success" };
-    } else if (webhook_code === "PENDING_EXPIRATION") {
-      return await markBadItem(item_id, "PENDING_EXPIRATION");
-    } else if (webhook_code === "ERROR") {
-      const error_code = error?.error_code;
-      if (error_code === "ITEM_LOGIN_REQUIRED") {
-        return await markBadItem(item_id, "ITEM_LOGIN_REQUIRED");
+
+    const isValid = await deps.verifyWebhook(rawBody, signedJwt);
+    if (!isValid) {
+      res.status(401);
+      return { status: "failed", message: "Invalid webhook signature" };
+    }
+
+    const bodyResult = requireBodyObject(req);
+    if (!bodyResult.success) return validationError(bodyResult.error!);
+
+    const { webhook_type, webhook_code, item_id, error } = bodyResult.data as PlaidWebhookBody;
+
+    const syncAndLog = async (id: string) => {
+      const response = await deps.syncPlaidTransactions(id);
+      if (!response) return { status: "failed" as const };
+      const { added, modified, removed } = response;
+      logger.info("Synced transactions via webhook", { itemId: id, added, modified, removed });
+      return { status: "success" as const };
+    };
+
+    const refreshItemProducts = async (id: string) => {
+      const userItem = await deps.getUserItem(id);
+      if (!userItem) return { status: "failed" as const };
+      const { user, item } = userItem;
+      const { consented_products = [], products = [] } = await deps.getItem(item.access_token);
+      const available_products = [...consented_products, ...products];
+      await deps.upsertItems(user, [{ ...item, available_products }]);
+      logger.info("Refreshed available_products for item", { itemId: id, available_products });
+      return { status: "success" as const };
+    };
+
+    const markBadItem = async (id: string, reason: string) => {
+      const response = await deps.updateItemStatus(id, ItemStatus.BAD);
+      if (!response) return { status: "failed" as const };
+      deps.sendAlarm("Item Bad Status", `**Item:** ${id}\n**Reason:** ${reason}`).catch(() => undefined);
+      return { status: "success" as const };
+    };
+
+    if (webhook_type === "TRANSACTIONS") {
+      if (webhook_code === "SYNC_UPDATES_AVAILABLE") {
+        return await syncAndLog(item_id);
+      } else if (
+        ["DEFAULT_UPDATE", "INITIAL_UPDATE", "HISTORICAL_UPDATE", "TRANSACTIONS_REMOVED"].includes(
+          webhook_code
+        )
+      ) {
+        return { status: "success" };
       }
-    } else if (webhook_code === "USER_ACCOUNT_REVOKED" || webhook_code === "ITEM_UPDATED") {
-      return await refreshItemProducts(item_id);
+    } else if (webhook_type === "ITEM") {
+      if (webhook_code === "WEBHOOK_UPDATE_ACKNOWLEDGED") {
+        return { status: "success" };
+      } else if (webhook_code === "PENDING_EXPIRATION") {
+        return await markBadItem(item_id, "PENDING_EXPIRATION");
+      } else if (webhook_code === "ERROR") {
+        const error_code = error?.error_code;
+        if (error_code === "ITEM_LOGIN_REQUIRED") {
+          return await markBadItem(item_id, "ITEM_LOGIN_REQUIRED");
+        }
+      } else if (webhook_code === "USER_ACCOUNT_REVOKED" || webhook_code === "ITEM_UPDATED") {
+        return await refreshItemProducts(item_id);
+      }
+    } else if (webhook_type === "HOLDINGS") {
+      if (webhook_code === "DEFAULT_UPDATE") {
+        return await syncAndLog(item_id);
+      }
+    } else if (webhook_type === "INVESTMENTS_TRANSACTIONS") {
+      if (["DEFAULT_UPDATE", "HISTORICAL_UPDATE"].includes(webhook_code)) {
+        return await syncAndLog(item_id);
+      }
     }
-  } else if (webhook_type === "HOLDINGS") {
-    if (webhook_code === "DEFAULT_UPDATE") {
-      return await syncAndLog(item_id);
-    }
-  } else if (webhook_type === "INVESTMENTS_TRANSACTIONS") {
-    if (["DEFAULT_UPDATE", "HISTORICAL_UPDATE"].includes(webhook_code)) {
-      return await syncAndLog(item_id);
-    }
-  }
 
-  logger.warn("Unhandled webhook", { itemId: item_id, webhookType: webhook_type, webhookCode: webhook_code, body: req.body });
+    logger.warn("Unhandled webhook", { itemId: item_id, webhookType: webhook_type, webhookCode: webhook_code, body: req.body });
+  });
+
+// Functions are referenced via arrow indirection so the bindings are looked
+// up at call time, not at module init. Top-level access to plaid.verifyWebhook
+// at init time crosses a circular import boundary (server/lib → routes →
+// here) and trips ESM TDZ.
+export const postPlaidHookRoute = createPostPlaidHookRoute({
+  verifyWebhook: (rawBody, signedJwt) => plaid.verifyWebhook(rawBody, signedJwt),
+  syncPlaidTransactions: (id) => syncPlaidTransactions(id),
+  updateItemStatus: (id, status) => updateItemStatus(id, status),
+  getUserItem: (id) => getUserItem(id),
+  upsertItems: (user, items) => upsertItems(user, items),
+  getItem: (accessToken) => plaid.getItem(accessToken),
+  sendAlarm: (title, message) => sendAlarm(title, message),
 });
-
-const syncAndLog = async (item_id: string) => {
-  const response = await syncPlaidTransactions(item_id);
-  if (!response) return { status: "failed" as const };
-  const { added, modified, removed } = response;
-  logger.info("Synced transactions via webhook", { itemId: item_id, added, modified, removed });
-  return { status: "success" as const };
-};
-
-const refreshItemProducts = async (item_id: string) => {
-  const userItem = await getUserItem(item_id);
-  if (!userItem) return { status: "failed" as const };
-  const { user, item } = userItem;
-  const { consented_products = [], products = [] } = await plaid.getItem(item.access_token);
-  const available_products = [...consented_products, ...products];
-  await upsertItems(user, [{ ...item, available_products }]);
-  logger.info("Refreshed available_products for item", { itemId: item_id, available_products });
-  return { status: "success" as const };
-};
-
-const markBadItem = async (item_id: string, reason: string) => {
-  const response = await updateItemStatus(item_id, ItemStatus.BAD);
-  if (!response) return { status: "failed" as const };
-  sendAlarm("Item Bad Status", `**Item:** ${item_id}\n**Reason:** ${reason}`).catch(() => undefined);
-  return { status: "success" as const };
-};


### PR DESCRIPTION
Closes #404

## Summary

`post-plaid-hook.ts` is the only authorization gate on a route that drives item-status updates, transaction syncs, and alarms — and it had zero route-level tests. `plaid/webhook.test.ts` covers `verifyWebhook` in isolation (4 negative cases), but the wiring above it — the rawBody gate, the body-validation short-circuit, and the 13+ webhook-type/code dispatch branches — was unverified.

This PR refactors the route into a `createPostPlaidHookRoute(deps)` factory (same DI pattern inbox#450 used for `push.ts`) so tests construct the route with plain function mocks. No `mock.module(\"server\", ...)` — that leaks process-wide (inbox classifier CD incident).

## What changed

- `post-plaid-hook.ts`: extracted `PostPlaidHookDeps` interface + `createPostPlaidHookRoute(deps)` factory. `postPlaidHookRoute` is now the factory invoked with arrow-wrapped real implementations. The arrows are load-bearing — direct property access on `plaid.verifyWebhook` at module init time crosses the server-lib → routes circular import boundary and trips ESM TDZ.
- `webhooks/index.ts`: switched from `export *` to named re-export of `postPlaidHookRoute`. Otherwise `Object.values(routes)` in `start.ts` would pick up the factory function and the union type would no longer satisfy `Route<T>`.
- `post-plaid-hook.test.ts`: 25 new tests.

## Coverage matrix

**Auth boundary (4 tests):**
- missing `rawBody` → 401 + does not call `verifyWebhook`
- `verifyWebhook` returns false → 401 + dispatch short-circuited
- `verifyWebhook` receives the `plaid-verification` header
- valid signature + invalid body shape → `validationError` + no dispatch

**TRANSACTIONS (7 tests):** `SYNC_UPDATES_AVAILABLE` happy path + null result; 4 no-op codes (DEFAULT_UPDATE, INITIAL_UPDATE, HISTORICAL_UPDATE, TRANSACTIONS_REMOVED); unknown code → warn path.

**ITEM (8 tests):** WEBHOOK_UPDATE_ACKNOWLEDGED no-op success; PENDING_EXPIRATION → updateItemStatus(BAD)+sendAlarm; ERROR+ITEM_LOGIN_REQUIRED same; ERROR+other error_code → warn; PENDING_EXPIRATION + updateItemStatus=false → failed (no alarm); USER_ACCOUNT_REVOKED + ITEM_UPDATED → refreshItemProducts (getUserItem + plaid.getItem + upsertItems); refreshItemProducts + getUserItem=null → failed; unknown code → warn.

**HOLDINGS & INVESTMENTS_TRANSACTIONS (5 tests):** DEFAULT_UPDATE/HISTORICAL_UPDATE → syncPlaidTransactions; unknown codes → warn.

## Test plan

- [x] \`bun test src/server/routes/webhooks/post-plaid-hook.test.ts\` — 25/0 pass
- [x] \`bun test src/server\` — 449/0 pass
- [x] \`bun x tsc --noEmit\` — clean