### PR TITLE
fix(sync): treat oldestDate=undefined as transient, don't clobber cache

### DIFF
--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -98,12 +98,23 @@ const writeLastSyncedAt = (date: Date) => {
   }
 };
 
-const getOldestTransactionDate = async (): Promise<Date | undefined> => {
+interface OldestTransactionDateResult {
+  /** First transaction date the server knows about for this user, if any. */
+  date?: Date;
+  /** True when the call itself errored — distinguishes "no transactions" (date undefined, no failure) from "API unreachable" (date undefined, network failure). */
+  networkFailed: boolean;
+}
+
+const getOldestTransactionDate = async (): Promise<OldestTransactionDateResult> => {
   const response = await call
     .get<OldestTransactionDateGetResponse>("/api/oldest-transaction-date")
     .catch(console.error);
-  if (!response?.body) return undefined;
-  return response.body ? new LocalDate(response.body) : undefined;
+  // `response.status === "error"` from `call` means the fetch itself blew up
+  // (network down, parse error). An undefined body with status==="success"
+  // means the user genuinely has no transactions — that's not a failure.
+  if (!response || response.status === "error") return { networkFailed: true };
+  if (!response.body) return { networkFailed: false };
+  return { date: new LocalDate(response.body), networkFailed: false };
 };
 
 interface FetchTransactionsResult {
@@ -685,7 +696,9 @@ export const useSync = () => {
       // covers months M with olderFrom < M.start < olderUntil, which
       // begins one month earlier than stage 2's window so the two stages
       // tile cleanly with no overlap and no gap.
-      const oldestDate = await oldestDatePromise;
+      const oldestResult = await oldestDatePromise;
+      const oldestDate = oldestResult.date;
+      const oldestNetworkFailed = oldestResult.networkFailed;
       const defaultFrom = currentViewDate.clone().previous().previous().previous().getStartDate();
       const olderFrom = oldestDate && oldestDate < defaultFrom ? oldestDate : defaultFrom;
       const olderUntil = currentViewDate.clone().previous().getStartDate();
@@ -740,7 +753,18 @@ export const useSync = () => {
       // semantics as the warm path. If anything failed, leave whatever
       // was in IndexedDB before this run alone and skip the timestamp
       // write so the next sync still treats this gap as un-pulled.
+      //
+      // Also gate on `oldestNetworkFailed`: when /api/oldest-transaction-date
+      // errors transiently, oldestDate is undefined → Stage 3's olderFrom
+      // falls back to `defaultFrom` (3 months ago) instead of the user's
+      // actual oldest data → Stage 3 fetches only ~1-2 months instead of
+      // the full history. Persisting that partial result would wipe the
+      // older months from IndexedDB and (because writeLastSyncedAt is
+      // also called) force every subsequent sync to the warm path, which
+      // only refreshes the last 14 days. Older-than-2-months data would
+      // stay missing indefinitely. Reported by Hoie 2026-05-20.
       const coldFetchFailed =
+        oldestNetworkFailed ||
         stage1Budgets.networkFailed ||
         stage1Charts.networkFailed ||
         stage1Institutions.networkFailed ||


### PR DESCRIPTION
Reported by Hoie 2026-05-20: post-PR-#400, *\"section/category bars, accumulated spending and unsorted transactions filtering for older than 2 months are not accurate.\"*

## Root cause

When \`/api/oldest-transaction-date\` errors transiently, \`getOldestTransactionDate()\` returns \`undefined\`. The cold-path \`olderFrom\` calc then falls back to \`defaultFrom = currentMonth.previous().previous().previous().getStartDate()\` (3 months ago), so:

- Stage 2 covers months \`[currentMonth − 1, currentMonth]\` (2 months)
- Stage 3 covers months \`[3 months ago, 1 month ago)\` (1–2 months)
- Total fetched: ~4 months. **Everything older than \~3 months is missing from the fetch result.**

The previous \`coldFetchFailed\` gate didn't include this endpoint's failure, so the partial result still passed → \`clearAllData() + saveAllData(finalData)\` wiped IndexedDB down to those 4 months → \`writeLastSyncedAt(now)\` set the warm-path gate. Every subsequent sync was warm and refreshed only the last 14 days. **Historical data never came back.**

## Why this is a PR-#400 regression

Pre-#400 sync ran the cold path on every visit — no \`lastSyncedAt\` gate. Even after one bad cold sync, the next visit retried \`getOldestTransactionDate\` and refilled the cache. The slicing dependence on \`oldestDate\` (latent since PR #364) was self-healing in that architecture.

PR #400 added the warm-path gate, which removed the retry property. One transient failure of \`oldestDate\` → stuck in a bad-cache warm-path loop.

## Fix

- \`getOldestTransactionDate\` returns \`{date?, networkFailed}\` so the caller can distinguish *\"no transactions yet\"* (\`date=undefined, networkFailed=false\`) from *\"API unreachable\"* (\`networkFailed=true\`).
- Cold-path \`coldFetchFailed\` gate now ORs in \`oldestNetworkFailed\`.
- When the gate is true, we skip both \`clearAllData/saveAllData\` AND \`writeLastSyncedAt\` — leaves the prior cache intact and forces the next sync to be cold, which will retry \`oldestDate\`. Self-healing property restored.

## Immediate user-side remediation

For anyone already stuck in the bad-cache state, clear \`localStorage.removeItem(\"budget:lastSyncedAt\")\` in devtools and reload. The next sync will be cold, and if \`oldestDate\` succeeds, the cache will refill.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`bun run test:client\` — 201 pass
- [ ] Sandbox E2E (cold start with \`/api/oldest-transaction-date\` artificially returning 500): verify (1) cache is NOT wiped to 4 months, (2) lastSyncedAt is NOT written, (3) next sync re-runs cold path.