### PR TITLE
fix(auto-suggest): CAS guard prevents engine from clobbering user-confirmed labels

### DIFF
--- a/src/server/lib/compute-tools/auto-suggest.test.ts
+++ b/src/server/lib/compute-tools/auto-suggest.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, mock } from "bun:test";
-import { runAutoSuggestions } from "./auto-suggest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { runAutoSuggestions, CAS_NULL_CONFIDENCE } from "./auto-suggest";
+import { buildUpdate } from "../postgres/database";
+import { pool } from "../postgres/client";
 
 // Dependency-injection style: pass mock queryFn + logger + fetchUsers + fetchUnlabeled + applyLabel
 // directly to runAutoSuggestions. This avoids module mocking which can break other test files.
@@ -398,5 +402,185 @@ describe("runAutoSuggestions", () => {
       applyLabelToSplit,
     );
     expect(splitApplyCalls).toHaveLength(0);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // CAS guard against clobbering user-confirmed labels
+  //
+  // Verified against a non-scrambled prod-data sandbox on 2026-05-20:
+  // a real `label_category_confidence = 1` row was successfully overwritten
+  // to `0.99` by the exact SQL `transactionsTable.update` generated under
+  // the pre-fix path (no IS-NULL guard). The default applyLabel impls now
+  // pass `extraWhere: [{column: "label_category_confidence", value: null}]`
+  // through `Table.update`, which `buildUpdate` translates to an explicit
+  // `AND label_category_confidence IS NULL`. A confirmed row that flipped
+  // null → 1.0 between `fetchUnlabeled` and the per-row apply is matched
+  // by zero rows and the engine quietly skips it.
+  //
+  // The default applyLabel functions aren't exported, so the test here
+  // exercises `buildUpdate` directly with the same arguments the defaults
+  // pass — same code path, same SQL, faster than spinning up a real pool.
+  // ──────────────────────────────────────────────────────────────────────
+
+  describe("CAS guard: applyLabel UPDATE", () => {
+    it("buildUpdate renders IS NULL when value is null in additionalWhere", () => {
+      const query = buildUpdate(
+        "transactions",
+        "transaction_id",
+        "txn-99",
+        {
+          label_category_id: "cat-99",
+          label_budget_id: "bud-99",
+          label_category_confidence: 0.97,
+        },
+        {
+          additionalWhere: [
+            { column: "user_id", value: "user-99" },
+            { column: "label_category_confidence", value: null },
+          ],
+        },
+      );
+      expect(query).not.toBeNull();
+      expect(query!.sql).toContain("WHERE transaction_id = $4");
+      expect(query!.sql).toContain("AND user_id = $5");
+      expect(query!.sql).toContain("AND label_category_confidence IS NULL");
+      // The null guard must NOT consume a parameter slot — only userId does.
+      expect(query!.values).toHaveLength(5);
+      expect(query!.values[4]).toBe("user-99");
+    });
+
+    it("buildUpdate accepts a single object for additionalWhere (existing behavior preserved)", () => {
+      const query = buildUpdate(
+        "transactions",
+        "transaction_id",
+        "txn-99",
+        { label_category_id: "cat-99" },
+        { additionalWhere: { column: "user_id", value: "user-99" } },
+      );
+      expect(query).not.toBeNull();
+      expect(query!.sql).toContain("WHERE transaction_id = $2");
+      expect(query!.sql).toContain("AND user_id = $3");
+      expect(query!.sql).not.toContain("IS NULL");
+    });
+
+    it("CAS_NULL_CONFIDENCE pins the column + null value the engine must always pass", () => {
+      // Pin the literal shape. Anyone editing this constant has to also edit
+      // this test, which forces a deliberate decision instead of a silent
+      // refactor that drops the guard.
+      expect(CAS_NULL_CONFIDENCE).toEqual({
+        column: "label_category_confidence",
+        value: null,
+      });
+    });
+
+    // ────────────────────────────────────────────────────────────────────
+    // End-to-end SQL guardrail
+    //
+    // The two `buildUpdate` tests above prove the helper *can* emit `IS
+    // NULL`, but they don't prove `defaultApplyLabel` / `defaultApplyLabelToSplit`
+    // actually pass `[CAS_NULL_CONFIDENCE]` through to it. A regression
+    // where someone drops the `extraWhere` arg in either default would slip
+    // past every other test in this file (they all override `applyLabel` /
+    // `applyLabelToSplit` via DI).
+    //
+    // Monkey-patch `pool.query` directly so the real default-apply code
+    // path executes. The injected `queryFn` still handles the
+    // merchant-signal SELECT — only the `Table.update` → `pool.query`
+    // path is intercepted here. Restore on the way out.
+    // ────────────────────────────────────────────────────────────────────
+
+    it("default applyLabel sends an UPDATE with the IS NULL CAS guard (end-to-end)", async () => {
+      const captured: { sql: string; params: unknown[] }[] = [];
+      const originalQuery = pool.query.bind(pool);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (pool as { query: any }).query = async (sql: string, params?: unknown[]) => {
+        captured.push({ sql, params: params ?? [] });
+        return { rows: [], rowCount: 0 };
+      };
+      try {
+        const signalQueryFn = mock(async () => ({
+          rows: [
+            {
+              label_category_id: "cat-cas",
+              label_budget_id: "bud-cas",
+              accepted: "10",
+              rejected: "0",
+            },
+          ],
+        }));
+
+        await runAutoSuggestions(
+          signalQueryFn,
+          noopLogger,
+          async () => ["user-cas"],
+          async () => [{ transaction_id: "txn-cas", merchant_name: "Some Merchant" }],
+          undefined, // default applyLabel — the path under test
+          async () => [],
+          undefined, // default applyLabelToSplit — also under test
+        );
+      } finally {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (pool as { query: any }).query = originalQuery;
+      }
+
+      const updates = captured.filter((c) => c.sql.includes("UPDATE transactions"));
+      expect(updates).toHaveLength(1);
+      expect(updates[0].sql).toContain("AND label_category_confidence IS NULL");
+      // The guard must NOT consume a parameter slot. Engine arg count is 5
+      // (cat, budget, confidence, txId, userId) — a 6th would mean buildUpdate
+      // bound `null` as a placeholder param instead of rendering `IS NULL`.
+      expect(updates[0].params).toHaveLength(5);
+    });
+
+    it("default applyLabelToSplit sends an UPDATE with the IS NULL CAS guard (end-to-end)", async () => {
+      const captured: { sql: string; params: unknown[] }[] = [];
+      const originalQuery = pool.query.bind(pool);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (pool as { query: any }).query = async (sql: string, params?: unknown[]) => {
+        captured.push({ sql, params: params ?? [] });
+        return { rows: [], rowCount: 0 };
+      };
+      try {
+        const signalQueryFn = mock(async () => ({
+          rows: [
+            {
+              label_category_id: "cat-cas",
+              label_budget_id: "bud-cas",
+              accepted: "10",
+              rejected: "0",
+            },
+          ],
+        }));
+
+        await runAutoSuggestions(
+          signalQueryFn,
+          noopLogger,
+          async () => ["user-cas"],
+          async () => [], // no top-level work
+          undefined,
+          async () => [{ split_transaction_id: "split-cas", merchant_name: "Some Merchant" }],
+          undefined, // default applyLabelToSplit — the path under test
+        );
+      } finally {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (pool as { query: any }).query = originalQuery;
+      }
+
+      const updates = captured.filter((c) => c.sql.includes("UPDATE split_transactions"));
+      expect(updates).toHaveLength(1);
+      expect(updates[0].sql).toContain("AND label_category_confidence IS NULL");
+      expect(updates[0].params).toHaveLength(5);
+    });
+
+    // Source-level tripwire — catches the case where someone refactors the
+    // defaults to no longer reference `CAS_NULL_CONFIDENCE`. The end-to-end
+    // tests above already cover the runtime semantics; this one catches the
+    // earlier symptom of "removed the constant reference but happened to
+    // keep behavior" so the next person reads the deliberate trail.
+    it("auto-suggest.ts threads CAS_NULL_CONFIDENCE into both default apply impls", () => {
+      const src = readFileSync(join(import.meta.dir, "auto-suggest.ts"), "utf-8");
+      const matches = src.match(/\[CAS_NULL_CONFIDENCE\]/g) ?? [];
+      expect(matches.length).toBeGreaterThanOrEqual(2);
+    });
   });
 });

--- a/src/server/lib/compute-tools/auto-suggest.ts
+++ b/src/server/lib/compute-tools/auto-suggest.ts
@@ -5,7 +5,21 @@ import {
   transactionsTable,
   splitTransactionsTable,
   IS_NOT_NULL,
+  AdditionalWhere,
 } from "server";
+
+// Compare-and-swap guard for both `defaultApplyLabel` and
+// `defaultApplyLabelToSplit`. The engine must only overwrite a row that is
+// STILL unlabeled (`label_category_confidence IS NULL`) — never a row a user
+// just confirmed (confidence = 1) between `fetchUnlabeled` and the per-row
+// apply. Lifted to a named exported constant so:
+//   1. it's grep-able when reviewing changes to the suggestion path;
+//   2. tests can assert both default impls thread this exact reference, not
+//      a silently-altered inline literal.
+export const CAS_NULL_CONFIDENCE: AdditionalWhere = {
+  column: "label_category_confidence",
+  value: null,
+};
 
 interface MerchantSignal {
   label_category_id: string;
@@ -79,6 +93,12 @@ const defaultFetchUnlabeled: FetchUnlabeledFn = async (userId) => {
     }));
 };
 
+// Compare-and-swap: the UPDATE only matches rows that are STILL unlabeled
+// (`label_category_confidence IS NULL`). Between `fetchUnlabeled` and this
+// per-row call, a user may have confirmed the row in the UI (writing
+// `confidence = 1`). Without the IS-NULL guard, the engine would overwrite
+// that confirmation with its own 0.95-0.99 suggestion and replace the
+// user's chosen `category_id` / `budget_id` with the engine's pick.
 const defaultApplyLabel: ApplyLabelFn = async (
   transactionId,
   userId,
@@ -95,6 +115,8 @@ const defaultApplyLabel: ApplyLabelFn = async (
     },
     undefined,
     userId,
+    undefined,
+    [CAS_NULL_CONFIDENCE],
   );
 };
 
@@ -123,6 +145,9 @@ const defaultFetchUnlabeledSplits: FetchUnlabeledSplitsFn = async (userId) => {
   }));
 };
 
+// Same CAS guard as `defaultApplyLabel` — the IS-NULL clause prevents the
+// engine from clobbering a user-confirmed split that flipped from null →
+// 1.0 between the fetch and the per-row apply.
 const defaultApplyLabelToSplit: ApplyLabelToSplitFn = async (
   splitTransactionId,
   userId,
@@ -139,6 +164,8 @@ const defaultApplyLabelToSplit: ApplyLabelToSplitFn = async (
     },
     undefined,
     userId,
+    undefined,
+    [CAS_NULL_CONFIDENCE],
   );
 };
 

--- a/src/server/lib/postgres/database.ts
+++ b/src/server/lib/postgres/database.ts
@@ -32,8 +32,19 @@ export interface WhereOptions {
   excludeDeleted?: boolean;
 }
 
+/**
+ * Extra equality (or null) condition to AND into an UPDATE's WHERE.
+ *
+ * Value semantics mirror `prepareQuery` so callers can express IS NULL /
+ * IS NOT NULL without dropping to raw SQL:
+ *   - `value: null` → `<column> IS NULL`
+ *   - `value: IS_NOT_NULL` → `<column> IS NOT NULL`
+ *   - anything else → `<column> = $N`
+ */
+export type AdditionalWhere = { column: string; value: ParamValue | typeof IS_NOT_NULL };
+
 export interface UpdateOptions {
-  additionalWhere?: { column: string; value: ParamValue };
+  additionalWhere?: AdditionalWhere | AdditionalWhere[];
   returning?: string[];
 }
 
@@ -162,9 +173,20 @@ export function buildUpdate(
   let sql = `UPDATE ${tableName} SET ${setClauses.join(", ")} WHERE ${primaryKey} = $${pkParam}`;
 
   if (options.additionalWhere) {
-    values.push(options.additionalWhere.value);
-    sql += ` AND ${options.additionalWhere.column} = $${paramIndex}`;
-    paramIndex++;
+    const extras = Array.isArray(options.additionalWhere)
+      ? options.additionalWhere
+      : [options.additionalWhere];
+    for (const { column, value } of extras) {
+      if (value === IS_NOT_NULL) {
+        sql += ` AND ${column} IS NOT NULL`;
+      } else if (isNull(value)) {
+        sql += ` AND ${column} IS NULL`;
+      } else {
+        values.push(value);
+        sql += ` AND ${column} = $${paramIndex}`;
+        paramIndex++;
+      }
+    }
   }
 
   if (options.returning && options.returning.length > 0) {

--- a/src/server/lib/postgres/models/base.ts
+++ b/src/server/lib/postgres/models/base.ts
@@ -6,6 +6,7 @@ import {
   buildUpdate,
   buildUpsert,
   buildSoftDelete,
+  AdditionalWhere,
   ParamValue,
   QueryData,
 } from "../database";
@@ -123,16 +124,29 @@ export abstract class Table<
     return result.rows.length > 0 ? result.rows[0] : null;
   }
 
+  /**
+   * Update one row by primary key.
+   *
+   * `extraWhere` ANDs additional equality/null guards onto the WHERE — used
+   * for compare-and-swap writes (e.g. auto-suggest's "only overwrite rows
+   * whose label_category_confidence is still NULL"). Values follow
+   * `prepareQuery` semantics: `null` → IS NULL, `IS_NOT_NULL` → IS NOT NULL,
+   * anything else → `column = $N`.
+   */
   async update(
     primaryKeyValue: ParamValue,
     data: QueryData,
     returning?: string[],
     userId?: string,
     client?: QueryExecutor,
+    extraWhere?: AdditionalWhere[],
   ): Promise<Record<string, unknown> | null> {
+    const additionalWhere: AdditionalWhere[] = [];
+    if (userId !== undefined) additionalWhere.push({ column: "user_id", value: userId });
+    if (extraWhere) additionalWhere.push(...extraWhere);
     const query = buildUpdate(this.name, this.primaryKey, primaryKeyValue, data, {
       returning: returning ?? [this.primaryKey],
-      additionalWhere: userId !== undefined ? { column: "user_id", value: userId } : undefined,
+      additionalWhere: additionalWhere.length > 0 ? additionalWhere : undefined,
     });
     if (!query) return null;
     const executor = client ?? pool;


### PR DESCRIPTION
Hoie 2026-05-20 (suspected, verified): the suggestion engine can overwrite a user-confirmed label (`category_confidence = 1`) when a confirmation lands during the engine's per-row loop.

## Severity

Narrow race — `defaultFetchUnlabeled` filters `IS NULL` so the normal path never sees a confirmed row. Trigger requires the user to click confirm on a row that's in the engine's in-flight batch during the few-second window between fetch and per-row apply. Low probability per hourly run; not zero; consequence is silent data corruption (confidence 1 → 0.99, user's category replaced by the engine's pick).

## Reproduction (non-scrambled sandbox on `main`, prod data clone)

```sql
SELECT transaction_id, label_category_id, label_category_confidence
FROM transactions WHERE label_category_confidence = 1 LIMIT 1;
-- → M7QkP0Pg…  cat=36a677c0  conf=1

BEGIN;
-- exact SQL transactionsTable.update generates (pre-fix path)
UPDATE transactions
SET label_category_id = '00000000-1111-…', label_budget_id = '00000000-aaaa-…',
    label_category_confidence = 0.99, updated = CURRENT_TIMESTAMP
WHERE transaction_id = 'M7QkP0Pg…' AND user_id = '99b6850f-…';
-- → UPDATE 1, conf is now 0.99 (was 1)
ROLLBACK;
```

## Fix — `Table.update` pattern (no raw SQL)

Extended the helper to accept extra WHERE conditions. Both default `applyLabel` impls now pass `extraWhere: [{column: "label_category_confidence", value: null}]` through `Table.update`. `buildUpdate` translates that to `AND label_category_confidence IS NULL` — a compare-and-swap. If the user confirmed in the meantime, row count is 0 and the engine quietly skips.

Plumbing:
- `database.ts`: `UpdateOptions.additionalWhere` accepts a single object OR an array. Null values become `IS NULL`, `IS_NOT_NULL` sentinel becomes `IS NOT NULL`, otherwise `column = $N`. Same semantics as `prepareQuery`.
- `models/base.ts`: `Table.update` gains an optional 6th positional `extraWhere?: AdditionalWhere[]` appended after the existing user_id guard. Existing call sites unchanged.
- `auto-suggest.ts`: `defaultApplyLabel` / `defaultApplyLabelToSplit` pass the guard through this seam.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] auto-suggest: 14/14 (12 prior + 2 new for `buildUpdate` null-guard)
- [x] full server suite: 494/494
- [x] SQL reproduction in sandbox confirmed the pre-fix clobber