### PR TITLE
fix(routing): tighten /api prefix so /api-* SPA routes are reachable on refresh

### DIFF
--- a/src/client/sw.ts
+++ b/src/client/sw.ts
@@ -1,4 +1,5 @@
 /// <reference lib="webworker" />
+import { isApiPath } from "common/utils";
 
 const sw = self as unknown as ServiceWorkerGlobalScope;
 const CACHE_NAME = "budget-v1";
@@ -57,8 +58,9 @@ sw.addEventListener("fetch", (event) => {
     return;
   }
 
-  // Never intercept other API calls
-  if (url.pathname.startsWith("/api")) return;
+  // Never intercept other API calls. `isApiPath` rejects /api-anything
+  // (e.g. the /api-key-detail SPA route, #391).
+  if (isApiPath(url.pathname)) return;
 
   // Cache-first for hashed assets (JS, CSS under /assets/)
   // Vite embeds a content hash in every filename, so the URL itself

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -162,6 +162,14 @@ export const excludeEnumeration = (obj: object, propertyNames: string[]) => {
   });
 };
 
+/**
+ * True when the path is the literal /api or a child of /api (/api/...).
+ * Returns false for /api-anything (e.g. /api-key-detail SPA route, #391).
+ * Shared by server start.ts and client sw.ts so both layers agree.
+ */
+export const isApiPath = (path: string): boolean =>
+  path === "/api" || path.startsWith("/api/");
+
 export * from "./search";
 export * from "./date";
 export * from "./math";

--- a/src/common/utils/isApiPath.test.ts
+++ b/src/common/utils/isApiPath.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "bun:test";
+import { isApiPath } from "./index";
+
+describe("isApiPath", () => {
+  it("matches the literal /api", () => {
+    expect(isApiPath("/api")).toBe(true);
+  });
+
+  it("matches /api/<anything>", () => {
+    expect(isApiPath("/api/health")).toBe(true);
+    expect(isApiPath("/api/transactions/12345")).toBe(true);
+    expect(isApiPath("/api/")).toBe(true);
+  });
+
+  it("rejects /api-<anything> (regression for #391)", () => {
+    // SPA routes whose names happen to start with the characters "api".
+    expect(isApiPath("/api-key-detail")).toBe(false);
+    expect(isApiPath("/apikey-detail")).toBe(false);
+    expect(isApiPath("/api-anything")).toBe(false);
+  });
+
+  it("rejects unrelated SPA paths", () => {
+    expect(isApiPath("/")).toBe(false);
+    expect(isApiPath("/budgets")).toBe(false);
+    expect(isApiPath("/budget-detail")).toBe(false);
+    expect(isApiPath("/transactions")).toBe(false);
+  });
+});

--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -18,6 +18,7 @@ import { resolveBearerAuth } from "server/lib/bearer-auth";
 import type { MaskedUser } from "server/lib/postgres/models/user";
 import type { SessionData } from "server/lib/postgres/models/session";
 import * as routes from "server/routes";
+import { isApiPath } from "common/utils";
 
 // ---------------------------------------------------------------------------
 // Session management
@@ -234,8 +235,9 @@ const server = Bun.serve({
     const url = new URL(request.url);
     const fullPath = url.pathname;
 
-    // Serve static files for non-API paths
-    if (!fullPath.startsWith("/api")) {
+    // Serve static files for non-API paths. `isApiPath` rejects /api-anything
+    // (e.g. /api-key-detail SPA route, #391) so those fall through to the SPA.
+    if (!isApiPath(fullPath)) {
       const filePath = path.join(clientPath, fullPath === "/" ? "index.html" : fullPath);
       const file = Bun.file(filePath);
       if (await file.exists()) return new Response(file);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,15 @@ export default defineConfig({
       "/api": {
         target: "http://localhost:3005",
         changeOrigin: true,
+        // Skip the proxy for /api-anything (e.g. the /api-key-detail SPA
+        // route, #391) — let Vite serve the SPA shell instead. Only true
+        // /api or /api/... requests should reach the backend.
+        bypass: (req) => {
+          const url = req.url ?? "";
+          if (url === "/api" || url.startsWith("/api/") || url.startsWith("/api?"))
+            return undefined; // proxy as usual
+          return req.url; // fall through to Vite's static / SPA handling
+        },
       },
     },
   },


### PR DESCRIPTION
Closes #391

## Summary

`startsWith(\"/api\")` matches any path whose first 4 characters are `/api`, including `/api-key-detail` (the only SPA route in the current `PATH` enum that trips this). Server-side, that path was routed to the API handler instead of the SPA fallback — refreshing the page returned 401 JSON instead of the SPA HTML, breaking bookmarks, shared links, and any browser refresh while on the API-key-detail page.

The bug existed at three sites:
- `src/server/start.ts:238` — production prefix check (the user-visible one)
- `src/client/sw.ts:61` — service worker's \"skip API\" check
- `vite.config.ts:32` — Vite dev proxy

## What changed

- `src/common/utils/index.ts` — add `isApiPath(path)` helper that returns true only for the literal `/api` or `/api/...`. Shared by server start.ts and client sw.ts so both layers agree on the rule (and a future SPA route starting with the chars `api` won't silently regress).
- `src/server/start.ts` — call `isApiPath(fullPath)`.
- `src/client/sw.ts` — call `isApiPath(url.pathname)`.
- `vite.config.ts` — keep the `/api` key but add a `bypass` function with the same rule (Vite's regex-key form `^/api(/|$)` returned 500 in local testing — the function form is simpler and matches the helper's logic exactly).
- `src/common/utils/isApiPath.test.ts` — 4 unit tests covering the literal match, the `/api/...` happy path, the `/api-anything` regression class (`/api-key-detail`, `/apikey-detail`, `/api-anything`), and unrelated SPA paths.

## Test plan

- [x] `bun test src/common/utils/isApiPath.test.ts` — 4/0 pass
- [x] `bun test src/server` — 444/0 pass (no regressions)
- [x] `bun test src/common` — 58/0 pass
- [x] `bun x tsc --noEmit` — clean
- [x] E2E against `bun run dev`, both Vite proxy (3000) and Bun backend (3005):

```
=== Vite proxy (port 3000) ===
/api-key-detail                -> 200 text/html       (was 401 application/json)
/apikey-detail                 -> 200 text/html       (was 401 application/json)
/budget-detail                 -> 200 text/html       (unchanged — control)
/api/health                    -> 200 application/json (unchanged — API still works)

=== Bun backend (port 3005) ===
/api-key-detail                -> 200 text/html;charset=utf-8 (was 401 JSON)
/apikey-detail                 -> 200 text/html;charset=utf-8 (was 401 JSON)
/api/health                    -> 200 application/json        (unchanged)
```

The 27 pre-existing benchmark test failures on `upstream/main` (`buildSecurityPriceIndex`, `getPriceForHolding`, `inferCostBasis`, `getHoldingsValueData`, `extractCashFlows`, `valueAt`) are unrelated to this PR — confirmed by running `bun test src/client/lib/hooks/calculation/benchmark.test.ts` on bare `upstream/main` (8 fail in that file alone, same shape).