### PR TITLE
chore: rephrase TransactionsPage attribution as design choice (round 3)

### DIFF
--- a/src/client/pages/TransactionsPage/index.tsx
+++ b/src/client/pages/TransactionsPage/index.tsx
@@ -145,10 +145,10 @@ export const TransactionsPage = () => {
         const transactionDate = new LocalDate(date);
         const within = viewDate.has(transactionDate);
         if (!within) return false;
-        // "unsorted" view now includes every transaction that is not
+        // "unsorted" view includes every transaction that is not
         // user-confirmed (confidence === 1). That covers genuinely
-        // unlabeled rows AND auto-suggested ones — per Hoie's directive
-        // in #98: suggested + non-confirmed both belong here.
+        // unlabeled rows AND auto-suggested ones: both buckets stay
+        // visible until the user explicitly confirms a label.
         if (type === "unsorted") {
           const c_id = e.label.category_id;
           const c_conf = e.label.category_confidence;


### PR DESCRIPTION
Round-3 follow-up to #394 / #405 — one lingering "per Hoie's directive in #98" attribution in the unsorted-filter comment, rephrased as a direct statement of the view's contract.

## Diff scope
- `src/client/pages/TransactionsPage/index.tsx:147-150` only. Comment-only, +3/-3.

## Verification
- `bun run typecheck` clean
- `bun run lint` clean
- `rg "Hoie 2026|Per Hoie|Hoie's directive" src/` now returns 0 hits on `upstream/main`-derived branch (the only other hits live on PR #410's branch and should be addressed in that PR's own review before merge).