### PR TITLE
chore: remove dead deleteTransactionsByAccount export

### DIFF
--- a/src/server/lib/postgres/repositories/transactions.ts
+++ b/src/server/lib/postgres/repositories/transactions.ts
@@ -167,18 +167,6 @@ export const deleteTransactions = async (
   return { deleted };
 };
 
-export const deleteTransactionsByAccount = async (
-  user: MaskedUser,
-  account_id: string,
-): Promise<{ deleted: number }> => {
-  const { transactions } = await searchTransactions(user, { account_id });
-  if (!transactions.length) return { deleted: 0 };
-  return deleteTransactions(
-    user,
-    transactions.map((t) => t.transaction_id),
-  );
-};
-
 export const searchTransactionsByAccountId = async (
   user: MaskedUser,
   account_ids: string[],


### PR DESCRIPTION
**Sweep 5 (module boundary / dead exports).** `deleteTransactionsByAccount` in `src/server/lib/postgres/repositories/transactions.ts` is exported but never imported anywhere in `src/`. Added during the elasticsearch → Postgres repository split (commits `969e8a0` "Split repository files and use Table methods" and `d1d0d40` "applies consistent code formatting on postgres modules…") and never wired into any route or background job — there is no per-account transaction-delete code path in the app.

Removing it follows the CLAUDE.md rule against half-finished implementations: dead exports add maintenance surface (linter exemption, future-reader confusion about whether anyone calls it) for code that is one git-restore away if account-deletion ever ships.

## Diff scope
- `src/server/lib/postgres/repositories/transactions.ts:184-194` removed. -12 LOC.

## Verification
- `rg "deleteTransactionsByAccount" src/` returns 0 hits after removal
- `bun run typecheck` clean
- `bun run lint` clean
- `bun test src/server/lib/postgres/repositories/transactions.test.ts` → 20/20 (no test referenced the removed export)