### PR TITLE
fix(benchmark): computeMWR returns no_solution for empty portfolio (not −99%)

### DIFF
--- a/src/client/lib/hooks/calculation/benchmark.test.ts
+++ b/src/client/lib/hooks/calculation/benchmark.test.ts
@@ -184,6 +184,23 @@ describe("computeMWR", () => {
     expect(r.status).toBe("no_solution");
   });
 
+  test("returns no_solution when portfolio is empty at both boundaries (regression for #390)", () => {
+    // Manual investment account with no investment_transactions and no
+    // priced security_snapshots: valueAt returns 0 at both ends, flows is
+    // empty. Pre-fix this returned annualized=-0.99 (a fake −99% return)
+    // because the bisection converged on its lower bound.
+    const r = computeMWR({
+      flows: [],
+      vStart: 0,
+      vEnd: 0,
+      windowStart: "2025-05-18",
+      windowEnd: "2026-05-18",
+    });
+    expect(r.status).toBe("no_solution");
+    expect(r.annualized).toBeNull();
+    expect(r.cumulative).toBeNull();
+  });
+
   test("cumulative = (1 + annualized)^years − 1", () => {
     const r = computeMWR({
       flows: [{ date: "2026-04-01", amount: 500 }],

--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -131,6 +131,14 @@ export const computeMWR = (params: {
   windowEnd: string;
 }): MwrResult => {
   const { flows, vStart, vEnd, windowStart, windowEnd } = params;
+
+  // Degenerate input: no asset value at either boundary and no flows in
+  // between. npv ≡ 0 for all rates, and the bisection below would happily
+  // converge on the lower bound (−0.99) and report a fake −99% return.
+  if (vStart === 0 && vEnd === 0 && flows.length === 0) {
+    return { status: "no_solution", annualized: null, cumulative: null };
+  }
+
   const years = yearsBetween(windowStart, windowEnd);
   const tEnd = years;
 
@@ -146,7 +154,9 @@ export const computeMWR = (params: {
 
   const lo0 = -0.99;
   const hi0 = 10.0;
-  if (npv(lo0) * npv(hi0) > 0) {
+  // Defense-in-depth: if either endpoint NPV is exactly 0 (or signs already
+  // agree), there is no sign change to bisect on, so don't bisect.
+  if (npv(lo0) * npv(hi0) >= 0) {
     return { status: "no_solution", annualized: null, cumulative: null };
   }
   let lo = lo0;


### PR DESCRIPTION
Closes #390

## Bug

`computeMWR` returns `annualized: -0.99, cumulative: -0.99` whenever `vStart === 0 && vEnd === 0 && flows.length === 0`. The Investment Performance widget then renders **\"−99.00% / −99.00%/yr\"** — a fake number, not an empty/\"no data\" placeholder. Reproduced live on the IBM-RBA manual account during user-testing.

## Root cause

`benchmark.ts:126-162`. For the all-zero input, `npv(rate) ≡ 0` at every rate. The bisection's early sign-product guard (`npv(lo0) * npv(hi0) > 0`) saw `0` (not strictly positive) and skipped. The 200-iteration loop then trivially satisfied `npv(mid) * npv(lo) <= 0` at every step, so `hi` collapsed onto `lo0 = -0.99` and the mean was returned as the \"annualized rate.\"

## Fix

Both recommended changes from the issue:

**(A) Top-of-function degenerate-input guard.** Self-documenting at the call boundary:

```ts
if (vStart === 0 && vEnd === 0 && flows.length === 0) {
  return { status: \"no_solution\", annualized: null, cumulative: null };
}
```

**(B) Tighten the sign-product check from `>` to `>=`.** Defense-in-depth: an endpoint NPV of exactly 0 still has no sign change to bisect on. Catches adjacent shapes like `vStart > 0, vEnd = 0, flows = []` where one NPV happens to land on 0.

Widget already renders `mwr.status !== \"ok\"` as a \"—\" placeholder (`PerformanceBenchmark/index.tsx:191-200`), so `no_solution` naturally hides the MWR row while keeping the benchmark row visible — the intended UX for \"no asset data to measure.\"

## Tests

New `computeMWR` test pins the all-zero degenerate case → `no_solution`. The existing degenerate test (`vStart=0, vEnd=1000, flows=[]`) still passes — those NPVs are strictly negative at both endpoints, so the bisection guard exits cleanly.

## E2E verification

Standalone repro from the issue body:

```ts
import { computeMWR } from \"client/lib/hooks/calculation/benchmark\";

computeMWR({ flows: [], vStart: 0, vEnd: 0,
  windowStart: \"2025-05-18\", windowEnd: \"2026-05-18\" });
// → { status: \"no_solution\", annualized: null, cumulative: null }   ✅ (was -0.99)

computeMWR({ flows: [], vStart: 0, vEnd: 1000,
  windowStart: \"2026-01-01\", windowEnd: \"2027-01-01\" });
// → { status: \"no_solution\", ... }   ✅ (unchanged from main)

computeMWR({ flows: [{ date: \"2026-04-01\", amount: 500 }],
  vStart: 1000, vEnd: 1700,
  windowStart: \"2026-01-01\", windowEnd: \"2026-12-31\" });
// → { status: \"ok\", annualized: 0.1464…, cumulative: 0.1460… }   ✅ (unchanged)
```

Existing `computeMWR` test suite: 6/6 pass (was 5/5 + 1 new). The 8 unrelated `valueAt` / `buildPriceAt` failures in this file pre-exist on `main` and are not touched by this PR.