### PR TITLE
chore: rename PbulicTokenPostResponse → PublicTokenPostResponse

### DIFF
--- a/src/client/components/Configuration/index.tsx
+++ b/src/client/components/Configuration/index.tsx
@@ -1,5 +1,5 @@
 import { ItemProvider, ItemStatus, toUpperCamelCase } from "common";
-import { PbulicTokenPostResponse } from "server";
+import { PublicTokenPostResponse } from "server";
 import {
   Data,
   Item,
@@ -86,7 +86,7 @@ export const Configuration = () => {
       go(PATH.CONNECTION_DETAIL, { params: clientPathParams });
     } else {
       const params = new URLSearchParams({ provider: ItemProvider.MANUAL });
-      const { body } = await call.post<PbulicTokenPostResponse>(
+      const { body } = await call.post<PublicTokenPostResponse>(
         `/api/public-token?${params.toString()}`,
         {},
       );

--- a/src/client/components/PlaidLinkButton.tsx
+++ b/src/client/components/PlaidLinkButton.tsx
@@ -1,6 +1,6 @@
 import { MouseEventHandler, ReactNode, useEffect, useState } from "react";
 import { ItemProvider, ItemStatus } from "common";
-import { PbulicTokenPostResponse, LinkTokenGetResponse } from "server";
+import { PublicTokenPostResponse, LinkTokenGetResponse } from "server";
 import {
   Data,
   Item,
@@ -43,7 +43,7 @@ export const PlaidLinkButton = ({ item, children }: Props) => {
     const institution_id = institution && institution.institution_id;
     const params = new URLSearchParams({ provider: ItemProvider.PLAID });
     call
-      .post<PbulicTokenPostResponse>(`/api/public-token?${params.toString()}`, {
+      .post<PublicTokenPostResponse>(`/api/public-token?${params.toString()}`, {
         public_token,
         institution_id,
       })

--- a/src/client/components/SimpleFinLinkButton.tsx
+++ b/src/client/components/SimpleFinLinkButton.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 import { ItemProvider, ItemStatus } from "common";
-import { PbulicTokenPostResponse } from "server";
+import { PublicTokenPostResponse } from "server";
 import { Data, Item, ItemDictionary, useAppContext, call, useSync, indexedDb } from "client";
 
 interface Props {
@@ -16,7 +16,7 @@ export const SimpleFinLinkButton = ({ children }: Props) => {
     if (!public_token) return;
     const params = new URLSearchParams({ provider: ItemProvider.SIMPLE_FIN });
     call
-      .post<PbulicTokenPostResponse>(`/api/public-token?${params.toString()}`, {
+      .post<PublicTokenPostResponse>(`/api/public-token?${params.toString()}`, {
         public_token,
       })
       .then((r) => {

--- a/src/server/routes/users/post-public-token.ts
+++ b/src/server/routes/users/post-public-token.ts
@@ -14,11 +14,11 @@ import {
 } from "server";
 import { getDateString, JSONItem, ItemProvider, ItemStatus, getRandomId } from "common";
 
-export interface PbulicTokenPostResponse {
+export interface PublicTokenPostResponse {
   item: JSONItem;
 }
 
-export const postPublicTokenRoute = new Route<PbulicTokenPostResponse>(
+export const postPublicTokenRoute = new Route<PublicTokenPostResponse>(
   "POST",
   "/public-token",
   async (req) => {


### PR DESCRIPTION
## Finding

The response type for the `POST /api/public-token` route is named `PbulicTokenPostResponse` — \"Pbulic\" instead of \"Public\". All 7 use sites in the repo spell it consistently, so nothing's broken, but the name lies.

Principle 1 (\"code tells the truth about itself\"): a reader sees the route path `/public-token`, the handler `postPublicTokenRoute`, the components `PlaidLinkButton`/`SimpleFinLinkButton` that hit `/api/public-token` — and then an oddly-spelled type that says `Pbulic`. Either it's wrong or it's referring to something else. It's the former.

## Fix

Single-symbol rename across 4 files (`-8/+8`):

- `src/server/routes/users/post-public-token.ts` — declaration + Route generic
- `src/client/components/Configuration/index.tsx` — import + `call.post<…>`
- `src/client/components/SimpleFinLinkButton.tsx` — import + `call.post<…>`
- `src/client/components/PlaidLinkButton.tsx` — import + `call.post<…>`

`grep` for the misspelling returns zero hits after the change.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (after #418 lands; pre-existing lint break unrelated to this PR)
- [ ] CI green