### PR TITLE
chore(repositories): remove 9 dead per-X delete exports from postgres-split scaffolding

### DIFF
--- a/src/server/lib/postgres/repositories/accounts.ts
+++ b/src/server/lib/postgres/repositories/accounts.ts
@@ -139,15 +139,3 @@ export const deleteAccounts = async (
     return { deleted };
   });
 };
-
-export const deleteAccountsByItem = async (
-  user: MaskedUser,
-  item_id: string,
-): Promise<{ deleted: number }> => {
-  const accounts = await getAccountsByItem(user, item_id);
-  if (!accounts.length) return { deleted: 0 };
-  return deleteAccounts(
-    user,
-    accounts.map((a) => a.account_id),
-  );
-};

--- a/src/server/lib/postgres/repositories/budgets.ts
+++ b/src/server/lib/postgres/repositories/budgets.ts
@@ -92,18 +92,6 @@ export const deleteBudget = async (user: MaskedUser, budget_id: string): Promise
   });
 };
 
-export const deleteBudgets = async (
-  user: MaskedUser,
-  budget_ids: string[],
-): Promise<{ deleted: number }> => {
-  if (!budget_ids.length) return { deleted: 0 };
-  let deleted = 0;
-  for (const id of budget_ids) {
-    if (await deleteBudget(user, id)) deleted++;
-  }
-  return { deleted };
-};
-
 export const getSections = async (user: MaskedUser, budget_id?: string): Promise<JSONSection[]> => {
   const filters: Record<string, unknown> = { [USER_ID]: user.user_id };
   if (budget_id) filters[BUDGET_ID] = budget_id;
@@ -156,18 +144,6 @@ export const deleteSection = async (user: MaskedUser, section_id: string): Promi
   });
 };
 
-export const deleteSections = async (
-  user: MaskedUser,
-  section_ids: string[],
-): Promise<{ deleted: number }> => {
-  if (!section_ids.length) return { deleted: 0 };
-  let deleted = 0;
-  for (const id of section_ids) {
-    if (await deleteSection(user, id)) deleted++;
-  }
-  return { deleted };
-};
-
 export const getCategories = async (
   user: MaskedUser,
   section_id?: string,
@@ -217,13 +193,4 @@ export const updateCategory = async (
 
 export const deleteCategory = async (user: MaskedUser, category_id: string): Promise<boolean> => {
   return await categoriesTable.softDelete(category_id, user.user_id);
-};
-
-export const deleteCategories = async (
-  user: MaskedUser,
-  category_ids: string[],
-): Promise<{ deleted: number }> => {
-  if (!category_ids.length) return { deleted: 0 };
-  const deleted = await categoriesTable.bulkSoftDelete(category_ids, { user_id: user.user_id });
-  return { deleted };
 };

--- a/src/server/lib/postgres/repositories/charts.ts
+++ b/src/server/lib/postgres/repositories/charts.ts
@@ -70,15 +70,3 @@ export const updateChart = async (
 export const deleteChart = async (user: MaskedUser, chart_id: string): Promise<boolean> => {
   return await chartsTable.softDelete(chart_id, user.user_id);
 };
-
-export const deleteCharts = async (
-  user: MaskedUser,
-  chart_ids: string[],
-): Promise<{ deleted: number }> => {
-  if (!chart_ids.length) return { deleted: 0 };
-  let deleted = 0;
-  for (const id of chart_ids) {
-    if (await chartsTable.softDelete(id, user.user_id)) deleted++;
-  }
-  return { deleted };
-};

--- a/src/server/lib/postgres/repositories/holdings.ts
+++ b/src/server/lib/postgres/repositories/holdings.ts
@@ -119,18 +119,6 @@ export const deleteHoldings = async (
   return { deleted };
 };
 
-export const deleteHoldingsByAccount = async (
-  user: MaskedUser,
-  account_id: string,
-): Promise<{ deleted: number }> => {
-  const holdings = await getHoldingsByAccount(user, account_id);
-  if (!holdings.length) return { deleted: 0 };
-  return deleteHoldings(
-    user,
-    holdings.map((h) => h.holding_id),
-  );
-};
-
 export const searchHoldingsByAccountId = async (
   user: MaskedUser,
   account_ids: string[],

--- a/src/server/lib/postgres/repositories/investment_transactions.ts
+++ b/src/server/lib/postgres/repositories/investment_transactions.ts
@@ -129,15 +129,3 @@ export const deleteInvestmentTransactions = async (
   );
   return { deleted };
 };
-
-export const deleteInvestmentTransactionsByAccount = async (
-  user: MaskedUser,
-  account_id: string,
-): Promise<{ deleted: number }> => {
-  const txs = await searchInvestmentTransactions(user, { account_id });
-  if (!txs.length) return { deleted: 0 };
-  return deleteInvestmentTransactions(
-    user,
-    txs.map((t) => t.investment_transaction_id),
-  );
-};

--- a/src/server/lib/postgres/repositories/snapshots.ts
+++ b/src/server/lib/postgres/repositories/snapshots.ts
@@ -320,19 +320,6 @@ export const upsertSnapshots = async (snapshots: JSONSnapshotData[]): Promise<Up
   return results;
 };
 
-export const deleteOldSnapshots = async (beforeDate: string): Promise<{ deleted: number }> => {
-  const result = await pool.query(
-    `UPDATE ${SNAPSHOTS} SET is_deleted = TRUE, updated = CURRENT_TIMESTAMP WHERE ${SNAPSHOT_DATE} < $1 AND (is_deleted IS NULL OR is_deleted = FALSE) RETURNING ${SNAPSHOT_ID}`,
-    [beforeDate],
-  );
-  return { deleted: result.rowCount || 0 };
-};
-
-export const deleteSnapshotsByUser = async (user: MaskedUser): Promise<{ deleted: number }> => {
-  const deleted = await snapshotsTable.bulkSoftDeleteByColumn(USER_ID, user.user_id);
-  return { deleted };
-};
-
 export const deleteSnapshotById = async (
   user: MaskedUser,
   snapshot_id: string,


### PR DESCRIPTION
## Finding

Follow-up to **PR #412** (`chore: remove dead deleteTransactionsByAccount export`). The same scaffolding pattern from the elasticsearch → Postgres migration left **9 more dead per-X / bulk-delete exports** across 6 repository files. Each has zero callers anywhere in `src/`, including test files.

\`\`\`
src/server/lib/postgres/repositories/
├── accounts.ts                  → deleteAccountsByItem               (12 LOC)
├── holdings.ts                  → deleteHoldingsByAccount            (12 LOC)
├── investment_transactions.ts   → deleteInvestmentTransactionsByAccount (12 LOC)
├── charts.ts                    → deleteCharts                       (12 LOC)
├── budgets.ts                   → deleteBudgets, deleteSections, deleteCategories (33 LOC)
└── snapshots.ts                 → deleteOldSnapshots, deleteSnapshotsByUser       (13 LOC)
\`\`\`

Confirmed dead via:
\`\`\`
for sym in <each>; do grep -rn "\bsym\b" --include='*.ts' --include='*.tsx' src/; done
\`\`\`
→ only hit is the declaration itself in `repositories/<file>.ts`. No test refs (the parallel scan against `*.test.ts` returns empty).

## Origin

`git log -S "export const <each>" --all` traces every one to commits `969e8a0` (\"Split repository files and use Table methods\") and `d1d0d40` (\"applies consistent code formatting on postgres modules, removes references & legacy naming patterns for elasticsearch…\") — same window that introduced `deleteTransactionsByAccount` in #412. The migration generated CRUD helpers preemptively; only the singular-entity helpers (`deleteBudget`, `deleteSection`, `deleteCategory`, `deleteSnapshotById`, etc.) and the *plural* `deleteAccounts` / `deleteHoldings` / `deleteInvestmentTransactions` / `deleteSplitTransactions` got wired in. The 9 here didn't, and haven't been needed for 3 months.

## Why bundle vs split

All 9 share: same shape (\"delete X by foreign key Y\" or \"bulk delete by IDs\"), same origin commit, same fate (never wired), same fix (delete the export). Splitting into 6 per-file PRs would obscure the pattern that says \"this was generated scaffolding, not deliberate API\". Bundling makes it one coherent cleanup.

## Diff

-94 LOC across 6 files, 0 LOC additions. No test files touched.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test src/server/lib/postgres/repositories/` — 90/90 pass
- [x] `bun run lint` clean (after #418 lands; pre-existing lint break unrelated)
- [ ] CI green