### PR TITLE
fix(transactions): reset confidence on clear, cover split-tx writes (#415)

### DIFF
--- a/src/client/components/TransactionProperties/SplitTransactionRow.tsx
+++ b/src/client/components/TransactionProperties/SplitTransactionRow.tsx
@@ -100,6 +100,12 @@ const SplitTransactionRow = ({ splitTransaction }: Props) => {
         const newSplit = new SplitTransaction(splitTransaction);
         newSplit.label.budget_id = value || null;
         newSplit.label.category_id = null;
+        // Local IndexedDB write must mirror the server's confidence
+        // inference (`inferLabelConfidence`, `lib/infer-label-confidence.ts`)
+        // — otherwise the UI flashes the stale prior `c_conf` value until
+        // the next reload (#415). Budget-only edit always clears the
+        // category, so confidence resets to 0.
+        newSplit.label.category_confidence = 0;
         indexedDb.save(newSplit).catch(console.error);
         const newSplits = new SplitTransactionDictionary(newData.splitTransactions);
         newSplits.set(split_transaction_id, newSplit);
@@ -133,6 +139,10 @@ const SplitTransactionRow = ({ splitTransaction }: Props) => {
           newSplit.label.budget_id = account?.label.budget_id;
         }
         newSplit.label.category_id = value || null;
+        // Mirror server-side `inferLabelConfidence`: 1 = picked a category,
+        // 0 = cleared. Without this, IndexedDB carries the stale prior
+        // confidence on the local row until next reload (#415).
+        newSplit.label.category_confidence = +!!value;
         indexedDb.save(newSplit).catch(console.error);
         const newSplits = new SplitTransactionDictionary(newData.splitTransactions);
         newSplits.set(split_transaction_id, newSplit);


### PR DESCRIPTION
Closes #415

## Summary

When `TransactionProperties` cleared a category (selecting the empty option) the POST body omitted `category_confidence`. `applyUserConfirmedConfidence` short-circuited on `category_id === null`, so the prior `c_conf = 1` value stuck and the row became an orphan: `{ category_id: null, category_confidence: 1 }`. That state is invisible to the auto-suggest engine — `defaultFetchUnlabeled` and the post-#408 CAS guard both filter on `label_category_confidence IS NULL` — so once a row entered the orphan state, the user never got a fresh suggestion on it.

Split rows had the same omission **and** the server-side `updateSplitTransactions` ran no helper at all, so set-category from the detail page also silently failed to record `c_conf = 1` on splits.

## Fix (Option A + B from the issue body)

**Server (defense-in-depth)**
- `applyUserConfirmedConfidence` in `transactions.ts` now also handles the clear direction: `category_id === null` → `category_confidence = 0`. Memo-only updates (`category_id === undefined`) untouched.
- New mirror helper in `split_transactions.ts` wired through `updateSplitTransactions` so both set and clear paths get the right confidence.

**Client (parity with list-page handlers)**
- `TransactionProperties/index.tsx`: `onChangeBudgetSelect` sends `category_confidence: 0`; `onChangeCategorySelect` sends `1` on set, `0` on clear — matches `TransactionsTable/TransactionRow.tsx` (`d4162bc`).
- `TransactionProperties/SplitTransactionRow.tsx`: same change in both select handlers plus the local state update.

## Test plan

- `bun run test:server` → **498 pass / 0 fail**
- `bun run test:client` → **201 pass / 0 fail**
- `bun run typecheck` → clean
- Updated existing "does not inject confidence when category_id is null" test to assert the new positive behavior (UPDATE params contain `0`)

**E2E (live dev server + curl + psql against `/Users/hoiekim/budget`)**:

```
Step 1 — POST {transaction_id, label: {category_id: "0520...088ec"}}
  DB after: label_category_id = 0520..., label_category_confidence = 1 ✓

Step 2 — POST {transaction_id, label: {category_id: null}}
  DB after: label_category_id = NULL, label_category_confidence = 0 ✓
            (pre-fix this was c_id=NULL, c_conf=1 — the orphan)
```

## Backfill (out of scope for this PR, flagged for follow-up)

Any rows already in the orphan state from prior code paths can be repaired with:

```sql
UPDATE transactions
   SET label_category_confidence = NULL
 WHERE label_category_id IS NULL
   AND label_category_confidence = 1;

UPDATE split_transactions
   SET label_category_confidence = NULL
 WHERE label_category_id IS NULL
   AND label_category_confidence = 1;
```

Holding off on shipping this migration until target value is confirmed — `NULL` (return to unlabeled pool) is the natural choice but `0` (keep as explicit reject) is defensible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)