### PR TITLE
fix(routes): infer label confidence at the router layer

### DIFF
--- a/src/server/lib/index.ts
+++ b/src/server/lib/index.ts
@@ -10,3 +10,4 @@ export * from "./compute-tools";
 export * from "./validation";
 export * from "./alarm";
 export * from "./rate-limit";
+export * from "./infer-label-confidence";

--- a/src/server/lib/infer-label-confidence.test.ts
+++ b/src/server/lib/infer-label-confidence.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "bun:test";
+import { inferLabelConfidence } from "./infer-label-confidence";
+
+// Generic helper that maps user intent (expressed as { category_id?, confidence? }
+// on the request body's label) to a concrete confidence value before the row
+// hits the repo. Mirror the contract described in the helper's docstring.
+
+describe("inferLabelConfidence", () => {
+  it("no label → returns input unchanged", () => {
+    const tx = { transaction_id: "txn-1" };
+    expect(inferLabelConfidence(tx)).toBe(tx);
+  });
+
+  it("label without category_id property → no-op (caller didn't touch category)", () => {
+    const tx = { transaction_id: "txn-1", label: { budget_id: "bud-1" } };
+    const out = inferLabelConfidence(tx);
+    expect(out.label).toEqual({ budget_id: "bud-1" });
+    expect("category_confidence" in out.label!).toBe(false);
+  });
+
+  it("category_id set + confidence undefined → confidence = 1 (user-confirmed)", () => {
+    const out = inferLabelConfidence({
+      transaction_id: "txn-1",
+      label: { category_id: "cat-1" },
+    });
+    expect(out.label).toEqual({ category_id: "cat-1", category_confidence: 1 });
+  });
+
+  it("category_id null + confidence undefined → confidence = 0 (rejection signal)", () => {
+    // This is the gap the previous repo-layer helper missed: a budget-change
+    // path that clears category should be treated as a rejection so the
+    // auto-suggest engine doesn't re-suggest the same thing on the next
+    // hourly run (engine filter is `confidence IS NULL`).
+    const out = inferLabelConfidence({
+      transaction_id: "txn-1",
+      label: { budget_id: "bud-1", category_id: null },
+    });
+    expect(out.label).toEqual({
+      budget_id: "bud-1",
+      category_id: null,
+      category_confidence: 0,
+    });
+  });
+
+  it("category_id set + confidence explicitly set → preserve caller's value", () => {
+    const out = inferLabelConfidence({
+      transaction_id: "txn-1",
+      label: { category_id: "cat-1", category_confidence: 0.99 },
+    });
+    expect(out.label?.category_confidence).toBe(0.99);
+  });
+
+  it("category_id null + confidence explicitly 0 → preserve caller's value (idempotent)", () => {
+    const out = inferLabelConfidence({
+      transaction_id: "txn-1",
+      label: { category_id: null, category_confidence: 0 },
+    });
+    expect(out.label?.category_confidence).toBe(0);
+  });
+
+  it("does not mutate the input", () => {
+    const tx = { transaction_id: "txn-1", label: { category_id: "cat-1" } };
+    const before = JSON.stringify(tx);
+    inferLabelConfidence(tx);
+    expect(JSON.stringify(tx)).toBe(before);
+  });
+
+  it("works generically — accepts split-transaction shapes", () => {
+    const split = {
+      split_transaction_id: "split-1",
+      label: { category_id: "cat-1" },
+    };
+    const out = inferLabelConfidence(split);
+    expect(out).toMatchObject({
+      split_transaction_id: "split-1",
+      label: { category_id: "cat-1", category_confidence: 1 },
+    });
+  });
+});

--- a/src/server/lib/infer-label-confidence.ts
+++ b/src/server/lib/infer-label-confidence.ts
@@ -1,0 +1,34 @@
+import type { JSONTransactionLabel } from "common";
+
+interface MaybeLabeled {
+  label?: Partial<JSONTransactionLabel>;
+}
+
+/**
+ * Route-layer helper that lifts user intent from a label update into the
+ * `category_confidence` column when the caller didn't set it explicitly.
+ *
+ * Mapping:
+ *  - caller omits `category_id` entirely → don't touch confidence (no-op call)
+ *  - `category_id: <string>` + confidence undefined → confidence = 1
+ *    (user explicitly chose a category — treat as confirmed)
+ *  - `category_id: null`    + confidence undefined → confidence = 0
+ *    (user cleared the category — treat as a rejection signal so the
+ *    auto-suggest engine doesn't immediately re-suggest the same thing)
+ *  - caller sets confidence explicitly → preserve (e.g. Accept-All sends 1
+ *    when the row already has a category_id; the API caller path on the
+ *    `/suggest-category` route sends fractional values; tests may set 0
+ *    directly)
+ *
+ * Owned by the route boundary, not the repo: the repo just persists
+ * what it's given; route handlers call this helper before passing the
+ * body downstream so the "user intent" mapping happens next to HTTP
+ * request parsing, not inside the persistence layer.
+ */
+export const inferLabelConfidence = <T extends MaybeLabeled>(input: T): T => {
+  if (!input.label) return input;
+  if (!("category_id" in input.label)) return input;
+  if (input.label.category_confidence !== undefined) return input;
+  const category_confidence = input.label.category_id === null ? 0 : 1;
+  return { ...input, label: { ...input.label, category_confidence } };
+};

--- a/src/server/lib/postgres/repositories/transactions.test.ts
+++ b/src/server/lib/postgres/repositories/transactions.test.ts
@@ -244,31 +244,16 @@ describe("upsertTransactions", () => {
 });
 
 // ---------------------------------------------------------------------------
-// updateTransactions — user-confirmed confidence
+// updateTransactions — pass-through.
+//
+// Confidence inference moved to the route layer
+// (`src/server/routes/accounts/infer-label-confidence.ts` + its test file).
+// The repo just persists whatever the caller hands it now, so the prior
+// "sets confidence=1 by default" tests don't apply here. Covered there.
 // ---------------------------------------------------------------------------
 
 describe("updateTransactions", () => {
-  test("sets label_category_confidence=1.0 when user assigns category without explicit confidence", async () => {
-    mockQuery.mockResolvedValue({ rows: [{ transaction_id: "tx-1" }], rowCount: 1 });
-
-    const tx = {
-      transaction_id: "tx-1",
-      label: { category_id: "cat-1" },
-    } as Parameters<typeof updateTransactions>[1][0];
-
-    await updateTransactions(testUser, [tx]);
-
-    // The UPDATE call's parameters should include 1.0 for confidence
-    const updateCall = mockQuery.mock.calls.find(
-      (c) => typeof c[0] === "string" && c[0].includes("UPDATE"),
-    );
-    expect(updateCall).toBeDefined();
-    const values = updateCall![1] as unknown[];
-    expect(values).toContain(1.0);
-    expect(values).toContain("cat-1");
-  });
-
-  test("preserves caller-supplied category_confidence (e.g. 0.0 = rejected)", async () => {
+  test("preserves caller-supplied category_confidence as-is (repo is pass-through)", async () => {
     mockQuery.mockResolvedValue({ rows: [{ transaction_id: "tx-2" }], rowCount: 1 });
 
     const tx = {
@@ -286,12 +271,16 @@ describe("updateTransactions", () => {
     expect(values).not.toContain(1.0);
   });
 
-  test("does not inject confidence when category_id is null (clearing)", async () => {
-    mockQuery.mockResolvedValue({ rows: [{ transaction_id: "tx-3" }], rowCount: 1 });
+  test("does not inject confidence when caller omits it (repo no longer infers)", async () => {
+    // The route layer now handles inference. The repo should not silently
+    // upgrade `{ category_id: 'X' }` to `confidence = 1` anymore —
+    // otherwise callers that bypass the route (tests, internal helpers)
+    // get unintended writes.
+    mockQuery.mockResolvedValue({ rows: [{ transaction_id: "tx-1" }], rowCount: 1 });
 
     const tx = {
-      transaction_id: "tx-3",
-      label: { category_id: null },
+      transaction_id: "tx-1",
+      label: { category_id: "cat-1" },
     } as Parameters<typeof updateTransactions>[1][0];
 
     await updateTransactions(testUser, [tx]);
@@ -299,25 +288,9 @@ describe("updateTransactions", () => {
     const updateCall = mockQuery.mock.calls.find(
       (c) => typeof c[0] === "string" && c[0].includes("UPDATE"),
     );
-    const values = (updateCall?.[1] ?? []) as unknown[];
+    const values = updateCall![1] as unknown[];
     expect(values).not.toContain(1.0);
-  });
-
-  test("does not inject confidence when label is absent (e.g. memo-only update)", async () => {
-    mockQuery.mockResolvedValue({ rows: [{ transaction_id: "tx-4" }], rowCount: 1 });
-
-    const tx = {
-      transaction_id: "tx-4",
-      name: "Renamed",
-    } as Parameters<typeof updateTransactions>[1][0];
-
-    await updateTransactions(testUser, [tx]);
-
-    const updateCall = mockQuery.mock.calls.find(
-      (c) => typeof c[0] === "string" && c[0].includes("UPDATE"),
-    );
-    const values = (updateCall?.[1] ?? []) as unknown[];
-    expect(values).not.toContain(1.0);
+    expect(values).toContain("cat-1");
   });
 });
 

--- a/src/server/lib/postgres/repositories/transactions.ts
+++ b/src/server/lib/postgres/repositories/transactions.ts
@@ -123,19 +123,6 @@ export const upsertTransactions = async (
   return results;
 };
 
-/**
- * When a user explicitly assigns a category (no confidence supplied), treat the
- * label as user-confirmed: confidence = 1.0. This is the upstream signal the
- * auto-suggestion engine reads as "accepted" when computing per-merchant stats.
- * Caller-supplied confidences (e.g. 0.0 = rejected) are preserved as-is.
- */
-const applyUserConfirmedConfidence = (tx: PartialTransaction): PartialTransaction => {
-  if (!tx.label) return tx;
-  if (tx.label.category_id == null) return tx;
-  if (tx.label.category_confidence !== undefined) return tx;
-  return { ...tx, label: { ...tx.label, category_confidence: 1.0 } };
-};
-
 export const updateTransactions = async (
   user: MaskedUser,
   transactions: PartialTransaction[],
@@ -145,8 +132,7 @@ export const updateTransactions = async (
 
   for (const tx of transactions) {
     try {
-      const adjusted = applyUserConfirmedConfidence(tx);
-      const row = TransactionModel.fromJSON(adjusted, user.user_id);
+      const row = TransactionModel.fromJSON(tx, user.user_id);
       delete row.transaction_id;
       delete row.user_id;
 

--- a/src/server/routes/accounts/post-split-transaction.ts
+++ b/src/server/routes/accounts/post-split-transaction.ts
@@ -1,4 +1,11 @@
-import { Route, updateSplitTransactions, requireBodyObject, requireStringField, validationError } from "server";
+import {
+  Route,
+  updateSplitTransactions,
+  requireBodyObject,
+  requireStringField,
+  validationError,
+  inferLabelConfidence,
+} from "server";
 import type { PartialSplitTransaction } from "server";
 import { logger } from "server/lib/logger";
 
@@ -27,7 +34,8 @@ export const postSplitTransactionRoute = new Route<SplitTransactionPostResponse>
     if (!idResult.success) return validationError(idResult.error!);
 
     try {
-      const response = await updateSplitTransactions(user, [body as PartialSplitTransaction]);
+      const split = inferLabelConfidence(body as PartialSplitTransaction);
+      const response = await updateSplitTransactions(user, [split]);
       const split_transaction_id = response[0].update?._id || "";
       return { status: "success", body: { split_transaction_id } };
     } catch (error: unknown) {

--- a/src/server/routes/accounts/post-transaction.ts
+++ b/src/server/routes/accounts/post-transaction.ts
@@ -1,4 +1,11 @@
-import { Route, updateTransactions, requireBodyObject, requireStringField, validationError } from "server";
+import {
+  Route,
+  updateTransactions,
+  requireBodyObject,
+  requireStringField,
+  validationError,
+  inferLabelConfidence,
+} from "server";
 import type { PartialTransaction } from "server";
 import { logger } from "server/lib/logger";
 
@@ -31,7 +38,7 @@ export const postTransactionRoute = new Route<TransactionPostResponse>(
 
     try {
       // Cast is safe after validation above
-      const transaction = bodyResult.data! as PartialTransaction;
+      const transaction = inferLabelConfidence(bodyResult.data! as PartialTransaction);
       const response = await updateTransactions(user, [transaction]);
       const result = response[0];
       if (!result || result.status >= 400) {


### PR DESCRIPTION
Hoie 2026-05-28: *\"Apply confidence overwrite in router layer (post-transactions / post-split-transactions).\"*

## Symptom

Split-transaction updates from the FE (`SplitTransactionRow.tsx`'s `onChangeBudgetSelect` / `onChangeCategorySelect`) omit `category_confidence` in the POST body. The server's `updateSplitTransactions` repo function has no equivalent of the `applyUserConfirmedConfidence` helper that `updateTransactions` runs — so the column stays at whatever it was (typically NULL for an auto-suggested split). The auto-suggest engine's fetch filter is `confidence IS NULL`, so the user's manual category gets re-overwritten by the engine on the next hourly run.

The existing repo-layer helper also had a related gap: it bailed on `category_id == null`, treating *\"caller didn't touch category\"* (undefined) and *\"caller explicitly cleared category\"* (null) as the same no-op. The latter should write `confidence = 0` (rejection signal) so the engine doesn't re-suggest the same category.

## Fix shape (per your design direction)

- New `src/server/routes/accounts/infer-label-confidence.ts` with a generic `inferLabelConfidence<T>(input: T): T`. Mapping:

  | input | output |
  |-------|--------|
  | label absent OR `category_id` not in label | no-op |
  | `category_id: <string>` + confidence undefined | `confidence = 1` (user-confirmed) |
  | `category_id: null` + confidence undefined | `confidence = 0` (rejection signal) |
  | caller sets `confidence` explicitly | preserved |

- `post-transaction.ts` and `post-split-transaction.ts` both call the helper before passing the body to the repo. Symmetric coverage on both routes.
- Removed `applyUserConfirmedConfidence` from `repositories/transactions.ts` — the repo is now pure pass-through. Inference responsibility lives next to where the HTTP request is parsed, not where the row is persisted.

## Test plan

- [x] `bun run typecheck` clean.
- [x] 8 new unit tests on the helper (`infer-label-confidence.test.ts`).
- [x] `updateTransactions` repo test updated: prior \"sets confidence=1.0 by default\" reframed as \"does NOT inject confidence when caller omits it\" (the repo no longer infers; the route does, and that's covered above).
- [x] Full server suite: 450/450 pass.
- [x] Lint clean on changed files. 3 pre-existing `TransactionDetailPage/index.tsx` warnings on main are out of scope.

Sandbox next.