### PR TITLE
chore: drop unused imports from TransactionDetailPage (unblock CI)

### DIFF
--- a/src/client/pages/TransactionDetailPage/index.tsx
+++ b/src/client/pages/TransactionDetailPage/index.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { Transaction, useAppContext, PATH } from "client";
+import { useAppContext, PATH } from "client";
 import { TransactionProperties } from "client/components";
 
 import "./index.css";


### PR DESCRIPTION
Pure cleanup. `useEffect`, `useState`, `Transaction` were imported but never referenced after commit `6cd07f2` (\"fixes transaction detail hydration bug\"). `upstream/main` has been failing the lint job since then, which blocks CI on every downstream PR (including #431).

```
src/client/pages/TransactionDetailPage/index.tsx
  1:10  error  'useEffect' is defined but never used
  1:21  error  'useState' is defined but never used
  2:10  error  'Transaction' is defined but never used
```

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] 444/444 server tests pass