### PR TITLE
fix(config): "Add New Period" no longer wiped by capacityData useEffect

### DIFF
--- a/src/client/pages/BudgetConfigPage/index.tsx
+++ b/src/client/pages/BudgetConfigPage/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getDateTimeString, LocalDate } from "common";
 import { Capacity, useAppContext, PATH } from "client";
 import { NameInput, Bar, ActionButtons, BudgetProperties } from "client/components";
@@ -55,8 +55,23 @@ export const BudgetConfigPage = () => {
     setBudgetLike((oldBudgetLike) => newBudgetLike?.clone() || oldBudgetLike);
   }, [id, categories, sections, budgets]);
 
+  // Track which budget identity (id) we've already hydrated form state from.
+  // Without this, the effect below re-runs on every `capacityData` change
+  // (e.g. when the user clicks "Add New Period", which calls
+  // `calculate.cache.capacityData(...)` to update the donut) — resetting
+  // `capacitiesInput` back to the persisted defaults a frame after the
+  // user's edit landed. Net effect for the user: the new row paints once
+  // then disappears.
+  const hydratedIdRef = useRef<string>("");
+
   useEffect(() => {
     if (!budgetLike) return;
+    // Cross-budget navigation (id changes) is the only path that should
+    // reset user-edited form state. Same-budget renders (clone refresh
+    // after data sync, capacityData updates from in-page edits, viewDate
+    // changes) must NOT clobber pending edits.
+    if (hydratedIdRef.current === id) return;
+    hydratedIdRef.current = id;
 
     const { name, roll_over, roll_over_start_date: roll_date } = budgetLike;
 
@@ -82,7 +97,7 @@ export const BudgetConfigPage = () => {
     setIsRollOverInput(roll_over);
     setRollDateInput(roll_date || new Date());
     setIsSyncedInput(defaultIsSyncInput);
-  }, [budgetLike, capacityData, viewDate]);
+  }, [id, budgetLike, capacityData, viewDate]);
 
   const { sorted_amount, unsorted_amount } = budgetData.get(id, date);
   const { name, roll_over, roll_over_start_date: roll_date } = budgetLike || {};


### PR DESCRIPTION
Hoie 2026-05-28: *\"adding period is not working\"*.

## Repro

Sandbox `claoie.tplinkdns.com:20431` → /budget-config?budget_id=53c90bc8 → click \"Add New Period\". Playwright row-count snapshots:

```
c0_before (just before click):  2   ← 1 button row + 1 capacity row
c1_sync (synchronous):          2   ← React state update batched
c2_rAF (after first paint):     3   ← new capacity row painted
c3_50ms:                        2   ← capacity row wiped
c4_500ms / c5_2000ms:           2   ← stays wiped
```

So the click DOES add a row (visible at frame N), then a frame later the row vanishes.

## Root cause

`BudgetConfigPage` (`src/client/pages/BudgetConfigPage/index.tsx:58-85`) has a \"reset form state from budgetLike\" useEffect with `capacityData` in its dep array. The body unconditionally calls `setCapacitiesInput(defaultCapInput)` (and other form setters).

`CapacitiesInput`'s `onClickAdd` (`src/client/components/BudgetProperties/CapacitiesInput/index.tsx:124-155`) does two things in sequence:
1. `setCapacitiesInput((old) => [...old, newCap])` — adds the new period to form state.
2. `calculate.cache.capacityData((data) => …)` — refreshes the donut by updating `calculations.capacityData`.

Step 2 mutates `capacityData` → the useEffect fires → form state is reset to the persisted defaults a frame after the user's edit landed. Net effect for the user: the new row paints once then disappears.

Any other in-page edit that touches `capacityData` would have hit the same wipe (delete period, capacity-amount blur on a donut).

## Fix

Gate the form-state hydration on a \"have we seen this budget id before\" ref check. Cross-budget navigation (`id` changes) still rehydrates form state from the new entity; same-budget re-renders (data-sync clone, capacityData mutation, viewDate change) leave pending edits alone.

```ts
const hydratedIdRef = useRef<string>(\"\");

useEffect(() => {
  if (!budgetLike) return;
  if (hydratedIdRef.current === id) return;
  hydratedIdRef.current = id;
  // ... reset form state ...
}, [id, budgetLike, capacityData, viewDate]);
```

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Sandbox Playwright repro post-fix: c2_rAF=3 / c5_2000ms=3 (stays 3). Verified.

Sandbox follow-up next.