### PR TITLE
docs(ARCHITECTURE,DATABASE): split_transactions has confidence column; yellow dot

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -71,7 +71,7 @@ The `label_category_confidence` field encodes four distinct states:
 |---|---|---|
 | `null` | Unlabeled (`label_category_id IS NULL`) | Red dot in `TransactionRow` |
 | `0` | User rejected a prior suggestion | Counted as a rejection signal for that merchant |
-| `0 < c < 1` | Auto-suggest applied a label — user has not yet confirmed or rejected | Grey dot in `TransactionRow` |
+| `0 < c < 1` | Auto-suggest applied a label — user has not yet confirmed or rejected | Yellow dot in `TransactionRow` |
 | `1` | User explicitly confirmed | No dot |
 
 A prod backfill on 2026-05-13 set `label_category_confidence = 1` for every labeled row in `transactions`, so the `(category_id IS NOT NULL, confidence IS NULL)` combination is no longer expected in production data.
@@ -84,7 +84,7 @@ const isConfirmed = category_confidence === 1 && !!category_id;
 
 Used in `src/client/lib/hooks/calculation/budgets.ts` (budget-bar / unsorted-count) and `src/client/pages/TransactionsPage/index.tsx` (the `unsorted` filter). The `&& !!category_id` guard exists so a malformed `confidence=1, category_id=null` row goes to the unsorted bucket rather than into a `categories.get(null)` lookup that would silently drop it.
 
-**Split transactions and confidence.** The `split_transactions` table does not carry `label_category_confidence` — it only has `label_category_id` and `label_budget_id`. When budget calc folds splits into the family via `SplitTransaction.toTransaction()`, the resulting label has `category_confidence === undefined`, which fails the `=== 1` check above. Splits with a category set therefore currently fall into the unsorted bucket in budget-bar / unsorted-count math. This is a known limitation tracked separately from the data-model backfill.
+**Split transactions and confidence.** `split_transactions` carries `label_category_confidence` alongside `label_category_id` and `label_budget_id`, mirroring `transactions`. When budget calc folds splits into the family via `SplitTransaction.toTransaction()`, the split's own label flows through the `isConfirmed` check, so a user-confirmed split (`confidence === 1`) lands in the sorted bucket and an auto-suggested split (`0 < confidence < 1`) lands in unsorted. The route layer applies `inferLabelConfidence` (see `src/server/lib/infer-label-confidence.ts`) on `POST /split-transaction` to write `1` when the user explicitly sets a category and `0` when they clear it.
 
 **Auto-suggest pipeline.** Suggestions are written by the hourly background job in `src/server/lib/compute-tools/auto-suggest.ts` (`runAutoSuggestions`), scheduled from `schedule.ts`'s `scheduledSync`. Per-merchant signal scoring (`evaluateSignal`) is documented in [DESIGN_PATTERNS.md](DESIGN_PATTERNS.md#auto-suggest-merchant-signal-scoring).
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -62,13 +62,13 @@ See `deleteAccounts` in `src/server/lib/postgres/repositories/accounts.ts` for a
 
 ## Transaction Categorization Columns
 
-A labeled transaction stores its category across three correlated columns. Both the `transactions` table and the `split_transactions` table carry `label_category_id` and `label_budget_id`; only `transactions` carries `label_category_confidence`.
+A labeled transaction stores its category across three correlated columns. Both the `transactions` table and the `split_transactions` table carry all three (`label_category_id`, `label_budget_id`, `label_category_confidence`).
 
 | Column | Type | On `transactions` | On `split_transactions` |
 |---|---|---|---|
 | `label_category_id` | UUID, nullable | ✓ | ✓ |
 | `label_budget_id` | UUID, nullable | ✓ | ✓ |
-| `label_category_confidence` | NUMERIC(3,2), nullable | ✓ | — (column does not exist) |
+| `label_category_confidence` | FLOAT, nullable | ✓ | ✓ (added by #344) |
 
 **Write both `label_category_id` and `label_budget_id` together.** The UI category `<select>` filters options by the row's budget. Writing only `label_category_id` leaves the dropdown unable to render the value. See `defaultApplyLabel` in `src/server/lib/compute-tools/auto-suggest.ts` for the canonical pattern.
 
@@ -83,6 +83,6 @@ A labeled transaction stores its category across three correlated columns. Both 
 
 **Prod backfill.** A backfill on 2026-05-13 set `label_category_confidence = 1` for every row with `label_category_id IS NOT NULL`. The application code's confirmation predicate (`category_confidence === 1 && !!category_id` in `src/client/lib/hooks/calculation/budgets.ts`) does not tolerate `NULL`, so this backfill is load-bearing — any new INSERT that sets `label_category_id` without also setting `label_category_confidence` would reintroduce the "labeled but counted as unsorted" miscount.
 
-**Split transactions.** Because `split_transactions` has no `label_category_confidence` column, split rows with a category set still hit `category_confidence === undefined` after `SplitTransaction.toTransaction()` rebuilds the label, and currently fall into the unsorted bucket in budget-bar / unsorted-count math. Known limitation.
+**Split transactions.** Splits inherit the same four-state encoding as transactions. `SplitTransaction.toTransaction()` rebuilds the label using the split's own `category_confidence`, so a user-confirmed split (`1`) lands in the sorted bucket and an auto-suggested split (`0 < c < 1`) lands in unsorted. The two-pass auto-suggest engine (#344) writes per-split suggestions; the `POST /split-transaction` route applies `inferLabelConfidence` so FE-driven updates write `1` on user-set categories and `0` on user-cleared categories.
 
 See [ARCHITECTURE.md — Transaction Categorization](ARCHITECTURE.md#transaction-categorization-auto-suggest) for the full data-model view and [DESIGN_PATTERNS.md — Auto-Suggest Merchant Signal Scoring](DESIGN_PATTERNS.md#auto-suggest-merchant-signal-scoring) for the suggestion engine itself.


### PR DESCRIPTION
Two stale claims about `split_transactions.label_category_confidence` and one stale UI signal label.

## Drift

**Both files claimed `split_transactions` has no `label_category_confidence` column.** PR #344 added it in 2026-02 to mirror `transactions` so the two-pass auto-suggest engine could write per-split suggestions. PR #431 (2026-05-28) wired the route layer through `inferLabelConfidence` so user-driven splits also write the column. Docs never caught up.

- `docs/ARCHITECTURE.md:87` — "split_transactions table does not carry label_category_confidence … Splits with a category set therefore currently fall into the unsorted bucket"
- `docs/DATABASE.md:65,71,86` — "only transactions carries label_category_confidence", table cell "— (column does not exist)", and a "Known limitation" paragraph repeating the wrong claim

Verified against the schema: `src/server/lib/postgres/models/split_transaction.ts:41` declares `[LABEL_CATEGORY_CONFIDENCE]: "FLOAT"`. `SplitTransaction.toTransaction()` (client/lib/models/SplitTransaction.ts:40-45) builds the Transaction with the split's own label, so `isConfirmed = category_confidence === 1 && !!category_id` in `client/lib/hooks/calculation/budgets.ts:65` evaluates against the real value.

**`docs/ARCHITECTURE.md:74`** said "Grey dot in `TransactionRow`" for an unreviewed suggestion. The source has been "yellow dot" since `d4162bc` updated `TransactionRow.tsx` and `DESIGN_PATTERNS.md` together. ARCHITECTURE was the only place still saying grey.

**`docs/DATABASE.md:71`** typed the column as `NUMERIC(3,2)`; the schema in both `models/transaction.ts` and `models/split_transaction.ts` declares it `FLOAT`. Fixed alongside the presence claim since the same table cell carries both.

## Test plan

- [x] `grep -rn "split_transactions.*no.*confidence\|column does not exist" docs/` → 0 hits.
- [x] `grep -rn "[Gg]rey dot\|[Gg]ray dot" docs/` → 0 hits.
- [x] `grep "LABEL_CATEGORY_CONFIDENCE" src/server/lib/postgres/models/{transaction,split_transaction}.ts` → both schemas declare `"FLOAT"`.
- [x] Markdown-only; no code changed.