### PR TITLE
ci: also run on push to main so direct pushes don't bypass lint/typecheck/test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
The CI workflow triggered only on `pull_request: branches: [main]`. Direct pushes to `main` skipped lint/typecheck/test entirely, so a breakage from a direct push silently blocked every open PR's required-status check until a follow-up PR landed to repair it.

## Recurring symptom

| Direct push | Symptom | Cleanup PR |
|-------------|---------|------------|
| 2026-05-23 `6cd07f2` "fixes transaction detail hydration bug" | 3 dead imports in `TransactionDetailPage/index.tsx` → lint red on every open PR | #418 |
| 2026-05-28 `77e03c7` "fixes transaction unsorted filtering" | More dead imports in the same file → lint red again | #432 |

Both follow-up PRs existed only to unblock CI for unrelated PRs. The two events are five days apart on the same file, which suggests the pattern will keep happening as long as direct pushes can land without a lint gate.

## Fix

Add `push: branches: [main]` to the trigger list in `.github/workflows/ci.yml`. The same jobs run; they just also fire on direct pushes, so breakage shows up at push time (visible to Hoie immediately) rather than getting discovered by the next PR opened against `main`.

No new jobs, no extra cost beyond the marginal CI run on each push to `main`.

## Test plan

- [x] Diff is 2 lines added to `.github/workflows/ci.yml`.
- [x] No other files changed.
- [ ] After merge, the next direct push to `main` should trigger a CI run visible at `https://github.com/hoiekim/budget/actions`. Once observed once, the gate is confirmed working.

## Out of scope

- Branch-protection rules that require CI to pass before push are a different, heavier change (Hoie's call). This PR just lets CI *run*; whether to *enforce* it on push stays Hoie's decision.
- The same pattern likely applies to the inbox repo, but inbox hasn't had a recurring direct-push-breakage symptom in the 14-day window, so deferring that until either a symptom shows up or this approach proves out here.