### PR TITLE
fix(auto-suggest): symmetric SQL-side date filter on defaultFetchUnlabeled

### DIFF
--- a/docs/DESIGN_PATTERNS.md
+++ b/docs/DESIGN_PATTERNS.md
@@ -162,7 +162,7 @@ The signal itself comes from a pg_trgm fuzzy match on `merchant_name` (`MERCHANT
 
 **Apply-with-budget.** When the engine applies a suggestion it writes both `label_category_id` and `label_budget_id`. The UI's category `<select>` filters options by the row's budget, so a category whose parent budget isn't recorded would render as a blank placeholder even though the yellow dot indicates a suggestion is present. See `defaultApplyLabel`.
 
-**What never receives a suggestion.** `defaultFetchUnlabeled` filters on `label_category_confidence: null`. This deliberately excludes rejected suggestions (`confidence === 0`) so the engine doesn't repeatedly resurface a label the user already rejected.
+**What never receives a suggestion.** Both unlabeled fetches filter on `label_category_confidence IS NULL` AND `date > NOW() - INTERVAL '1 week'`. The confidence gate deliberately excludes rejected suggestions (`confidence === 0`) so the engine doesn't repeatedly resurface a label the user already rejected. The recency gate keeps the engine focused on transactions the user is actually looking at — older never-labeled rows are assumed abandoned and would otherwise pull a multi-month backfill through the merchant-signal lookup on every run.
 
 ## Collection Lookup Performance
 

--- a/src/server/lib/compute-tools/auto-suggest.ts
+++ b/src/server/lib/compute-tools/auto-suggest.ts
@@ -4,7 +4,6 @@ import {
   usersTable,
   transactionsTable,
   splitTransactionsTable,
-  IS_NOT_NULL,
   AdditionalWhere,
 } from "server";
 
@@ -79,22 +78,26 @@ type ApplyLabelToSplitFn = (
 const MERCHANT_SIMILARITY_THRESHOLD = 0.5;
 const MERCHANT_SIGNAL_LIMIT = 30;
 
+// Mirror of `defaultFetchUnlabeledSplits` below — same predicate set, same
+// recency window. `transactionsTable.query` has no range comparator, so the
+// `date > NOW() - INTERVAL '1 week'` clause forces a raw query here just as
+// it does on the splits side. Keeping both impls in raw SQL with the same
+// shape is intentional: one canonical predicate, expressed once per query.
 const defaultFetchUnlabeled: FetchUnlabeledFn = async (userId) => {
-  const rows = await transactionsTable.query({
-    user_id: userId,
-    label_category_confidence: null,
-    merchant_name: IS_NOT_NULL,
-  });
-  const oneWeekAgo = new Date();
-  oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
-  return rows
-    .filter((r) => {
-      return r.merchant_name != null && new Date(r.date) > oneWeekAgo;
-    })
-    .map((r) => ({
-      transaction_id: r.transaction_id as string,
-      merchant_name: r.merchant_name as string,
-    }));
+  const result = await pool.query(
+    `SELECT transaction_id, merchant_name
+       FROM transactions
+      WHERE user_id = $1
+        AND label_category_confidence IS NULL
+        AND merchant_name IS NOT NULL
+        AND (is_deleted IS NULL OR is_deleted = FALSE)
+        AND date > NOW() - INTERVAL '1 week'`,
+    [userId],
+  );
+  return result.rows.map((r) => ({
+    transaction_id: r.transaction_id as string,
+    merchant_name: r.merchant_name as string,
+  }));
 };
 
 // Compare-and-swap: the UPDATE only matches rows that are STILL unlabeled
@@ -184,10 +187,12 @@ const defaultApplyLabelToSplit: ApplyLabelToSplitFn = async (
  * - If enough signal (>= 3 labeled, <= 10% reject rate, >= 95% confidence for best category),
  *   apply the suggestion with confidence = accepted / total_labeled (capped at 0.99)
  *
- * Direct SQL is reserved for the merchant-signal query, which uses pg_trgm
- * `similarity(...)` and a SUM(CASE WHEN ...) aggregation that the standard
- * Table helpers cannot express. The unlabeled fetch and the label-apply
- * use `transactionsTable.query` / `transactionsTable.update` (the standard pattern).
+ * Direct SQL is reserved for predicates the standard Table helpers cannot
+ * express: the merchant-signal query (pg_trgm `similarity(...)` + a
+ * SUM(CASE WHEN ...) aggregation) and the two unlabeled fetches (date range
+ * comparator on `date > NOW() - INTERVAL '1 week'`). The label-apply uses
+ * `transactionsTable.update` / `splitTransactionsTable.update` (the
+ * standard pattern with the CAS guard threaded through).
  */
 export const runAutoSuggestions = async (
   queryFn: QueryFn = (sql, params) => pool.query(sql, params),


### PR DESCRIPTION
## What

`defaultFetchUnlabeled` and `defaultFetchUnlabeledSplits` share the same "never-labeled AND date > 1 week ago" predicate but expressed it two different ways:

| Path | Predicate location |
|---|---|
| **splits** (`defaultFetchUnlabeledSplits`) | SQL — `AND t.date > NOW() - INTERVAL '1 week'` |
| **transactions** (`defaultFetchUnlabeled`) | `transactionsTable.query({…})` → JS-side `new Date(r.date) > oneWeekAgo` filter |

Pushes the transactions side to SQL with the same shape as the splits side.

## Why

**Principle 2 drift** (one canonical way per thing). The recency window was added by direct push 4e9cb54 to both fetchers on the same day; the two impls diverged at the moment they were introduced.

**Perf consequence.** The JS-side filter pulls every never-labeled row for the user out of Postgres, then drops most of them. On a fresh-connected account with a multi-month backfill that's tens of thousands of rows fetched per cron tick. Pushing to SQL lets the existing `date` index do the work and matches the splits path's behavior.

**Coverage gap (side note).** `auto-suggest.test.ts` injects `fetchUnlabeled` as a mock — so the previous JS-side filter was untested. With the predicate in SQL alongside the user-scope + soft-delete + IS NULL conditions, the only path that fires is the integration with the DB, which is the right shape for a query like this.

`transactionsTable.query` has no range comparator (`prepareQuery` only supports equality / IS NULL / IS NOT NULL — see `src/server/lib/postgres/database.ts`), so this is the same "raw SQL is reserved for predicates the standard Table helpers can't express" pattern the splits side and the merchant-signal query already established.

## Changes

- `src/server/lib/compute-tools/auto-suggest.ts` — replace `defaultFetchUnlabeled` JS filter with raw SQL mirroring `defaultFetchUnlabeledSplits`; drop now-unused `IS_NOT_NULL` import; update the function-level docstring at `runAutoSuggestions` to name the recency predicate as the second canonical reason for raw SQL alongside the merchant-signal aggregation.
- `docs/DESIGN_PATTERNS.md` — "What never receives a suggestion" now lists the recency gate alongside the confidence gate, with reasoning.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test src/server/lib/compute-tools/auto-suggest.test.ts` — 18/18 pass
- [x] Full suite — 624 pass / 27 fail, identical to upstream/main baseline (the 27 pre-existing failures are in client benchmark/holdings tests, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)