### PR TITLE
feat: custom test runner with subprocess-per-file isolation (#440)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     "test:client": "bun test --preload ./src/client/test-setup.ts src/client src/common",
     "test:server": "bun test src/server src/common",
     "test:coverage": "bun test --preload ./src/client/test-setup.ts --coverage --coverage-reporter=lcov && bun scripts/check-coverage.ts",
+    "test:next": "bun scripts/test-runner/index.ts",
+    "test:next:coverage": "bun scripts/test-runner/index.ts --coverage && bun scripts/check-coverage.ts",
     "lint": "bun --bun eslint src",
     "lint:fix": "bun --bun eslint src --fix",
-    "typecheck": "bun run --bun tsc --noEmit",
+    "typecheck": "bun run --bun tsc --noEmit && bun run --bun tsc --noEmit -p tsconfig.scripts.json",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/scripts/test-runner/config.ts
+++ b/scripts/test-runner/config.ts
@@ -1,0 +1,50 @@
+import { pathToFileURL } from "node:url";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+export interface ModuleConfig {
+  pattern: string | string[];
+  preload: string[];
+}
+
+export interface CoverageConfig {
+  include: string[];
+  exclude: string[];
+}
+
+export interface WatchConfig {
+  ignore: string[];
+}
+
+export interface Config {
+  modules: Record<string, ModuleConfig>;
+  parallelism: number | "auto";
+  coverage: CoverageConfig;
+  watch: WatchConfig;
+}
+
+export const defaultConfig: Config = {
+  modules: {},
+  parallelism: "auto",
+  coverage: { include: ["src/**"], exclude: ["**/*.test.ts", "**/*.test.tsx"] },
+  watch: { ignore: ["**/node_modules/**", "**/build/**", "**/.git/**"] },
+};
+
+export const loadConfig = async (repoRoot: string): Promise<Config> => {
+  const configPath = resolve(repoRoot, "test.config.ts");
+  if (!existsSync(configPath)) return defaultConfig;
+  const mod = await import(pathToFileURL(configPath).href);
+  const loaded = mod.default as Partial<Config> | undefined;
+  if (!loaded) return defaultConfig;
+  return {
+    modules: loaded.modules ?? defaultConfig.modules,
+    parallelism: loaded.parallelism ?? defaultConfig.parallelism,
+    coverage: { ...defaultConfig.coverage, ...loaded.coverage },
+    watch: { ...defaultConfig.watch, ...loaded.watch },
+  };
+};
+
+export const resolveParallelism = (p: number | "auto"): number => {
+  if (p === "auto") return Math.max(1, navigator.hardwareConcurrency || 4);
+  return Math.max(1, p);
+};

--- a/scripts/test-runner/coverage.ts
+++ b/scripts/test-runner/coverage.ts
@@ -1,0 +1,125 @@
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+/**
+ * LCOV merge: union of records across subprocess outputs.
+ *
+ * Bun's `--coverage-reporter=lcov` emits a slimmed LCOV: `SF:` for the
+ * source file, `DA:<line>,<hits>` for each executed line, and AGGREGATE
+ * `FNF:` / `FNH:` / `LF:` / `LH:` counters per file. It does NOT emit
+ * `FN:` / `FNDA:` records (per-function names + hit counts) nor branch
+ * data. So we merge what we get:
+ *
+ *   DA       — sum hit counts per (file, line); recompute LF/LH from it.
+ *   FNF      — same per-file across procs (it's static); take any non-zero.
+ *   FNH      — take the MAX across procs. If two procs hit disjoint
+ *              function sets in the same file (rare in practice — each
+ *              test file usually drives one module), this undercounts.
+ *              Bun would need to emit FN:/FNDA: records for a precise
+ *              merge; tracked as a future enhancement.
+ */
+
+interface FileRecord {
+  sf: string;
+  /** line → summed hit count across procs */
+  da: Map<number, number>;
+  /** functions found in file (static; max across procs to be safe) */
+  fnf: number;
+  /** functions hit (max across procs — approximate) */
+  fnh: number;
+}
+
+const parseLcovText = (text: string, into: Map<string, FileRecord>): void => {
+  let current: FileRecord | null = null;
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line === "end_of_record") {
+      current = null;
+      continue;
+    }
+    const colon = line.indexOf(":");
+    if (colon === -1) continue;
+    const tag = line.slice(0, colon);
+    const value = line.slice(colon + 1);
+    if (tag === "SF") {
+      let rec = into.get(value);
+      if (!rec) {
+        rec = { sf: value, da: new Map(), fnf: 0, fnh: 0 };
+        into.set(value, rec);
+      }
+      current = rec;
+    } else if (current && tag === "DA") {
+      const [ln, hit] = value.split(",");
+      const n = Number(ln);
+      const h = Number(hit);
+      current.da.set(n, (current.da.get(n) ?? 0) + h);
+    } else if (current && tag === "FNF") {
+      current.fnf = Math.max(current.fnf, Number(value));
+    } else if (current && tag === "FNH") {
+      current.fnh = Math.max(current.fnh, Number(value));
+    }
+  }
+};
+
+const formatLcov = (records: Map<string, FileRecord>): string => {
+  const out: string[] = [];
+  for (const rec of records.values()) {
+    out.push("TN:");
+    out.push(`SF:${rec.sf}`);
+    out.push(`FNF:${rec.fnf}`);
+    out.push(`FNH:${rec.fnh}`);
+    let lf = 0;
+    let lh = 0;
+    for (const [line, hit] of rec.da) {
+      out.push(`DA:${line},${hit}`);
+      lf++;
+      if (hit > 0) lh++;
+    }
+    out.push(`LF:${lf}`);
+    out.push(`LH:${lh}`);
+    out.push("end_of_record");
+  }
+  return out.join("\n") + "\n";
+};
+
+const matchesAny = (path: string, patterns: string[]): boolean => {
+  for (const p of patterns) {
+    const g = new Bun.Glob(p);
+    if (g.match(path)) return true;
+  }
+  return false;
+};
+
+/**
+ * Merge every `<dir>/lcov.info` from the per-file coverage dirs, apply
+ * include/exclude filters (paths are repo-root-relative), and write the
+ * merged result to `outPath`.
+ */
+export const mergeCoverage = async (
+  workerDirs: string[],
+  outPath: string,
+  repoRoot: string,
+  include: string[],
+  exclude: string[],
+): Promise<void> => {
+  const records = new Map<string, FileRecord>();
+  for (const dir of workerDirs) {
+    const file = join(dir, "lcov.info");
+    if (!existsSync(file)) continue;
+    const text = await readFile(file, "utf8");
+    parseLcovText(text, records);
+  }
+
+  const filtered = new Map<string, FileRecord>();
+  for (const [sf, rec] of records) {
+    const rel = relative(repoRoot, sf).replace(/\\/g, "/");
+    if (include.length > 0 && !matchesAny(rel, include)) continue;
+    if (matchesAny(rel, exclude)) continue;
+    filtered.set(sf, rec);
+  }
+
+  await mkdir(dirname(outPath), { recursive: true });
+  await writeFile(outPath, formatLcov(filtered));
+};

--- a/scripts/test-runner/dep-graph.ts
+++ b/scripts/test-runner/dep-graph.ts
@@ -1,0 +1,166 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import ts from "typescript";
+
+/**
+ * A lazy, incrementally-patchable forward/reverse dep graph built from
+ * `ts.preProcessFile` import scanning + `ts.resolveModuleName` resolution.
+ *
+ * Scope: TypeScript/TSX source files under the repo. Bare-package specifiers
+ * (anything that doesn't resolve to a file inside the repo) are dropped —
+ * watch-mode invalidation only cares about in-repo edges.
+ *
+ * Dynamic `import("…")` with a string-literal argument IS captured
+ * (preProcessFile reports it via `importedFiles`). Non-literal dynamic
+ * imports cannot be resolved statically and are silently skipped — callers
+ * relying on them should add a `// @test preload=…` header instead.
+ */
+export class DepGraph {
+  private compilerOptions: ts.CompilerOptions;
+  private repoRoot: string;
+  /** file → set of in-repo files it imports (forward edges). */
+  private forward = new Map<string, Set<string>>();
+  /** file → set of in-repo files that import it (reverse edges). */
+  private reverse = new Map<string, Set<string>>();
+  /** Files that have been parsed at least once and are in `forward`. */
+  private parsed = new Set<string>();
+
+  constructor(repoRoot: string, compilerOptions: ts.CompilerOptions) {
+    this.repoRoot = repoRoot;
+    this.compilerOptions = compilerOptions;
+  }
+
+  /** Parse a file (if not already cached) and patch the graph. */
+  ensureParsed(filePath: string): void {
+    if (this.parsed.has(filePath)) return;
+    this.refresh(filePath);
+  }
+
+  /**
+   * Re-parse a file; diff its outgoing edges against the cached set and
+   * patch both `forward` and `reverse`. Idempotent.
+   */
+  refresh(filePath: string): void {
+    const newImports = this.scan(filePath);
+    const oldImports = this.forward.get(filePath) ?? new Set<string>();
+    for (const old of oldImports) {
+      if (!newImports.has(old)) {
+        const set = this.reverse.get(old);
+        if (set) {
+          set.delete(filePath);
+          if (set.size === 0) this.reverse.delete(old);
+        }
+      }
+    }
+    for (const next of newImports) {
+      if (!oldImports.has(next)) {
+        let set = this.reverse.get(next);
+        if (!set) {
+          set = new Set();
+          this.reverse.set(next, set);
+        }
+        set.add(filePath);
+      }
+    }
+    this.forward.set(filePath, newImports);
+    this.parsed.add(filePath);
+  }
+
+  /** Remove a file from the graph (e.g. when it's deleted on disk). */
+  remove(filePath: string): void {
+    const outgoing = this.forward.get(filePath);
+    if (outgoing) {
+      for (const target of outgoing) {
+        const set = this.reverse.get(target);
+        if (set) {
+          set.delete(filePath);
+          if (set.size === 0) this.reverse.delete(target);
+        }
+      }
+    }
+    this.forward.delete(filePath);
+    const incoming = this.reverse.get(filePath);
+    if (incoming) {
+      for (const importer of incoming) {
+        const set = this.forward.get(importer);
+        if (set) set.delete(filePath);
+      }
+    }
+    this.reverse.delete(filePath);
+    this.parsed.delete(filePath);
+  }
+
+  /**
+   * BFS over the reverse graph from `changed`. Returns the set of files
+   * that transitively depend on it (including `changed` itself).
+   */
+  affected(changed: string): Set<string> {
+    const out = new Set<string>([changed]);
+    const queue: string[] = [changed];
+    while (queue.length > 0) {
+      const next = queue.shift()!;
+      const importers = this.reverse.get(next);
+      if (!importers) continue;
+      for (const importer of importers) {
+        if (out.has(importer)) continue;
+        out.add(importer);
+        queue.push(importer);
+      }
+    }
+    return out;
+  }
+
+  /** Build the forward graph eagerly from a starting set of files (BFS). */
+  buildFrom(seeds: string[]): void {
+    const queue: string[] = [...seeds];
+    while (queue.length > 0) {
+      const next = queue.shift()!;
+      if (this.parsed.has(next)) continue;
+      this.refresh(next);
+      const outgoing = this.forward.get(next);
+      if (outgoing) for (const t of outgoing) queue.push(t);
+    }
+  }
+
+  private scan(filePath: string): Set<string> {
+    const out = new Set<string>();
+    let text: string;
+    try {
+      text = readFileSync(filePath, "utf8");
+    } catch {
+      return out;
+    }
+    const info = ts.preProcessFile(text, true, true);
+    const specifiers = new Set<string>();
+    for (const ref of info.importedFiles) specifiers.add(ref.fileName);
+    for (const ref of info.referencedFiles) specifiers.add(ref.fileName);
+    for (const spec of specifiers) {
+      const resolved = ts.resolveModuleName(
+        spec,
+        filePath,
+        this.compilerOptions,
+        ts.sys,
+      ).resolvedModule?.resolvedFileName;
+      if (!resolved) continue;
+      const abs = resolve(dirname(filePath), resolved);
+      if (!abs.startsWith(this.repoRoot)) continue;
+      if (abs.includes("/node_modules/")) continue;
+      out.add(abs);
+    }
+    return out;
+  }
+}
+
+/**
+ * Load tsconfig.json from `repoRoot` and return parsed compiler options.
+ * Falls back to a minimal set if tsconfig is missing.
+ */
+export const loadCompilerOptions = (repoRoot: string): ts.CompilerOptions => {
+  const tsconfigPath = ts.findConfigFile(repoRoot, ts.sys.fileExists, "tsconfig.json");
+  if (!tsconfigPath) return { allowJs: true, baseUrl: repoRoot };
+  const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+  const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, repoRoot);
+  // `moduleResolution: "bundler"` is supported by ts.resolveModuleName via
+  // ModuleResolutionKind.Bundler — keep whatever the tsconfig says.
+  return parsed.options;
+};

--- a/scripts/test-runner/discover.ts
+++ b/scripts/test-runner/discover.ts
@@ -1,0 +1,115 @@
+import { readFile } from "node:fs/promises";
+import { resolve, relative } from "node:path";
+import { Glob } from "bun";
+import type { Config, ModuleConfig } from "./config.ts";
+
+export interface DiscoveredFile {
+  /** Absolute path. */
+  path: string;
+  /** Repo-root-relative POSIX path. */
+  relPath: string;
+  /** Resolved preload paths (absolute), in declaration order, de-duplicated. */
+  preload: string[];
+  /** Name of the matched module, or undefined if outside every module pattern. */
+  module?: string;
+}
+
+const HEADER_LINES_SCAN = 10;
+const HEADER_RE = /^\s*\/\/\s*@test\s+(.+)$/;
+
+/**
+ * Parse the `// @test key=val,val2` header from the first N lines of a file.
+ * Returns the additional preload paths declared via the header.
+ *
+ * Example: `// @test preload=fixtures/foo.ts,fixtures/bar.ts`
+ */
+const parseFileHeader = async (absPath: string): Promise<string[]> => {
+  let text: string;
+  try {
+    text = await readFile(absPath, "utf8");
+  } catch {
+    return [];
+  }
+  const lines = text.split("\n", HEADER_LINES_SCAN);
+  const extra: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === "") continue;
+    if (!trimmed.startsWith("//")) break;
+    const m = HEADER_RE.exec(line);
+    if (!m) continue;
+    for (const pair of m[1].split(/\s+/)) {
+      const [k, v] = pair.split("=", 2);
+      if (k === "preload" && v) extra.push(...v.split(",").map((s) => s.trim()).filter(Boolean));
+    }
+  }
+  return extra;
+};
+
+const matchModule = (
+  relPath: string,
+  modules: Record<string, ModuleConfig>,
+): { name: string; module: ModuleConfig } | undefined => {
+  for (const [name, module] of Object.entries(modules)) {
+    const patterns = Array.isArray(module.pattern) ? module.pattern : [module.pattern];
+    for (const pat of patterns) {
+      const g = new Glob(pat);
+      if (g.match(relPath)) return { name, module };
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Discover all `*.test.ts(x)` files under `targets` (or under `src/` if none),
+ * resolve each file's preload list (module-level + per-file header), and
+ * return them sorted by path for stable ordering.
+ */
+export const discoverTests = async (
+  repoRoot: string,
+  config: Config,
+  targets: string[],
+): Promise<DiscoveredFile[]> => {
+  const roots = targets.length === 0 ? ["src"] : targets;
+  const found = new Set<string>();
+  for (const t of roots) {
+    const abs = resolve(repoRoot, t);
+    try {
+      const stat = await Bun.file(abs).stat();
+      if (stat.isFile()) {
+        if (/\.test\.tsx?$/.test(abs)) found.add(abs);
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    const glob = new Glob("**/*.test.{ts,tsx}");
+    for await (const rel of glob.scan({ cwd: abs, absolute: false })) {
+      found.add(resolve(abs, rel));
+    }
+  }
+
+  const discovered: DiscoveredFile[] = [];
+  for (const absPath of found) {
+    const relPath = relative(repoRoot, absPath).replace(/\\/g, "/");
+    const matched = matchModule(relPath, config.modules);
+    const modulePreload = matched ? matched.module.preload : [];
+    const headerPreload = await parseFileHeader(absPath);
+    const preloadSet = new Set<string>();
+    const preloadOrdered: string[] = [];
+    for (const p of [...modulePreload, ...headerPreload]) {
+      const absP = resolve(repoRoot, p);
+      if (preloadSet.has(absP)) continue;
+      preloadSet.add(absP);
+      preloadOrdered.push(absP);
+    }
+    discovered.push({
+      path: absPath,
+      relPath,
+      preload: preloadOrdered,
+      module: matched?.name,
+    });
+  }
+  discovered.sort((a, b) => (a.relPath < b.relPath ? -1 : a.relPath > b.relPath ? 1 : 0));
+  return discovered;
+};

--- a/scripts/test-runner/index.ts
+++ b/scripts/test-runner/index.ts
@@ -1,0 +1,126 @@
+/**
+ * Custom test runner for the budget repo.
+ *
+ * Each `*.test.ts(x)` file runs in its own `bun test` subprocess so
+ * `mock.module()` is local to that file — no global pollution. Subprocess
+ * pool runs files in parallel; coverage is merged across processes.
+ *
+ * Usage:
+ *   bun scripts/test-runner/index.ts                         # all tests
+ *   bun scripts/test-runner/index.ts src/server              # subset
+ *   bun scripts/test-runner/index.ts src/server/foo.test.ts  # one file
+ *   bun scripts/test-runner/index.ts --watch                 # watch mode
+ *   bun scripts/test-runner/index.ts --coverage              # with LCOV merge
+ *   bun scripts/test-runner/index.ts -p 4                    # parallelism = 4
+ *
+ * Plumbed through package.json as `bun run test:next`.
+ */
+import { parseArgs } from "node:util";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadConfig, resolveParallelism } from "./config.ts";
+import { discoverTests } from "./discover.ts";
+import { DepGraph, loadCompilerOptions } from "./dep-graph.ts";
+import { runPool, defaultProgressReporter, cleanupRunDir } from "./pool.ts";
+import { formatSummary } from "./reporter.ts";
+import { mergeCoverage } from "./coverage.ts";
+import { runWatch } from "./watch.ts";
+
+const main = async (): Promise<void> => {
+  const { values, positionals } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      watch: { type: "boolean", default: false },
+      coverage: { type: "boolean", default: false },
+      parallelism: { type: "string", short: "p" },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    allowPositionals: true,
+  });
+
+  if (values.help) {
+    process.stdout.write(
+      `usage: test-runner [options] [target ...]\n` +
+        `  --watch              re-run affected tests on file change\n` +
+        `  --coverage           emit merged LCOV at coverage/lcov.info\n` +
+        `  -p, --parallelism N  worker pool size (default: cpu count)\n`,
+    );
+    return;
+  }
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = resolve(here, "..", "..");
+
+  const config = await loadConfig(repoRoot);
+  const parallelism = values.parallelism
+    ? resolveParallelism(Number(values.parallelism))
+    : resolveParallelism(config.parallelism);
+
+  const discovered = await discoverTests(repoRoot, config, positionals);
+  if (discovered.length === 0) {
+    process.stdout.write("no test files matched\n");
+    return;
+  }
+
+  process.stdout.write(
+    `running ${discovered.length} test file(s) at parallelism=${parallelism}` +
+      (values.coverage ? " with coverage" : "") +
+      "\n",
+  );
+
+  const compilerOptions = loadCompilerOptions(repoRoot);
+  const graph = new DepGraph(repoRoot, compilerOptions);
+  // Build the graph eagerly from all discovered test files. Watch mode
+  // needs the reverse graph to map source-file changes to affected tests;
+  // run-once mode doesn't strictly need it but the cost is small and it
+  // surfaces parse errors early.
+  graph.buildFrom(discovered.map((d) => d.path));
+
+  if (values.watch) {
+    // Run once first, then watch.
+    const start = performance.now();
+    const { results, runRoot } = await runPool(discovered, {
+      repoRoot,
+      parallelism,
+      coverage: false,
+      onProgress: defaultProgressReporter,
+    });
+    const totalMs = performance.now() - start;
+    process.stdout.write(`\n${formatSummary(results, totalMs)}\n\n`);
+    await cleanupRunDir(runRoot);
+    await runWatch({ repoRoot, config, graph, parallelism, discovered });
+    return;
+  }
+
+  const start = performance.now();
+  const { results, workerCoverageDirs, runRoot } = await runPool(discovered, {
+    repoRoot,
+    parallelism,
+    coverage: values.coverage,
+    onProgress: defaultProgressReporter,
+  });
+  const totalMs = performance.now() - start;
+  process.stdout.write(`\n${formatSummary(results, totalMs)}\n`);
+
+  if (values.coverage) {
+    const outPath = join(repoRoot, "coverage", "lcov.info");
+    await mergeCoverage(
+      workerCoverageDirs,
+      outPath,
+      repoRoot,
+      config.coverage.include,
+      config.coverage.exclude,
+    );
+    process.stdout.write(`coverage → ${outPath}\n`);
+  }
+
+  await cleanupRunDir(runRoot);
+
+  const anyFail = results.some((r) => r.exitCode !== 0 || r.cases.some((c) => c.status === "fail"));
+  process.exit(anyFail ? 1 : 0);
+};
+
+main().catch((err) => {
+  process.stderr.write(`test-runner crashed: ${err?.stack ?? err}\n`);
+  process.exit(2);
+});

--- a/scripts/test-runner/pool.ts
+++ b/scripts/test-runner/pool.ts
@@ -1,0 +1,126 @@
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { DiscoveredFile } from "./discover.ts";
+import { parseJUnitXml, type FileResult } from "./reporter.ts";
+
+export interface PoolOptions {
+  repoRoot: string;
+  parallelism: number;
+  coverage: boolean;
+  /** Called once per file as it completes (used for streaming progress). */
+  onProgress?: (result: FileResult, index: number, total: number) => void;
+}
+
+export interface PoolResult {
+  results: FileResult[];
+  /** Per-file coverage output dirs (only populated when coverage=true). */
+  workerCoverageDirs: string[];
+  /** Tempdir holding per-file junit/coverage subdirs; clean up after merge. */
+  runRoot: string;
+}
+
+const COLOR_DIM = "\x1b[90m";
+const COLOR_GREEN = "\x1b[32m";
+const COLOR_RED = "\x1b[31m";
+const COLOR_RESET = "\x1b[0m";
+
+/**
+ * Spawn `bun test <file>` once per discovered file, up to `parallelism` in
+ * flight. Each subprocess is fully isolated (fresh module cache, no shared
+ * mock state). Results are returned in the same order as `files`.
+ */
+export const runPool = async (
+  files: DiscoveredFile[],
+  options: PoolOptions,
+): Promise<PoolResult> => {
+  const runRoot = join(tmpdir(), `bun-test-runner-${Date.now()}-${process.pid}`);
+  await mkdir(runRoot, { recursive: true });
+  const workerCoverageDirs: string[] = [];
+
+  const results: FileResult[] = new Array(files.length);
+  let nextIndex = 0;
+  let completed = 0;
+
+  const runOne = async (fileIndex: number): Promise<void> => {
+    const file = files[fileIndex];
+    const fileRoot = join(runRoot, `f${fileIndex}`);
+    await mkdir(fileRoot, { recursive: true });
+    const junitPath = join(fileRoot, "report.xml");
+    const coverageDir = options.coverage ? join(fileRoot, "coverage") : undefined;
+    if (coverageDir) await mkdir(coverageDir, { recursive: true });
+
+    const args = ["test", file.path];
+    for (const p of file.preload) {
+      args.push("--preload", p);
+    }
+    args.push("--reporter=junit", `--reporter-outfile=${junitPath}`);
+    if (coverageDir) {
+      args.push("--coverage", "--coverage-reporter=lcov", `--coverage-dir=${coverageDir}`);
+    }
+
+    const start = performance.now();
+    const proc = Bun.spawn(["bun", ...args], {
+      cwd: options.repoRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FORCE_COLOR: "0", NO_COLOR: "1" },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    const durationMs = performance.now() - start;
+
+    const cases = await parseJUnitXml(junitPath);
+    const result: FileResult = {
+      relPath: file.relPath,
+      exitCode,
+      durationMs,
+      cases,
+      output: exitCode !== 0 ? `${stdout}\n${stderr}` : undefined,
+    };
+    results[fileIndex] = result;
+    if (coverageDir) workerCoverageDirs.push(coverageDir);
+
+    completed++;
+    if (options.onProgress) options.onProgress(result, completed, files.length);
+  };
+
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < Math.min(options.parallelism, files.length); i++) {
+    workers.push(
+      (async () => {
+        while (true) {
+          const idx = nextIndex++;
+          if (idx >= files.length) return;
+          await runOne(idx);
+        }
+      })(),
+    );
+  }
+  await Promise.all(workers);
+
+  return { results, workerCoverageDirs, runRoot };
+};
+
+export const defaultProgressReporter = (
+  result: FileResult,
+  index: number,
+  total: number,
+): void => {
+  const ok = result.exitCode === 0 && !result.cases.some((c) => c.status === "fail");
+  const mark = ok ? `${COLOR_GREEN}✓${COLOR_RESET}` : `${COLOR_RED}✗${COLOR_RESET}`;
+  const pad = String(index).padStart(String(total).length, " ");
+  const ms = `${COLOR_DIM}${result.durationMs.toFixed(0)}ms${COLOR_RESET}`;
+  process.stdout.write(`  ${mark} [${pad}/${total}] ${result.relPath} ${ms}\n`);
+};
+
+export const cleanupRunDir = async (dir: string): Promise<void> => {
+  try {
+    await rm(dir, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+};

--- a/scripts/test-runner/reporter.ts
+++ b/scripts/test-runner/reporter.ts
@@ -1,0 +1,145 @@
+import { readFile } from "node:fs/promises";
+
+export interface TestCaseResult {
+  classname: string;
+  name: string;
+  time: number;
+  status: "pass" | "fail" | "skip";
+  failure?: string;
+}
+
+export interface FileResult {
+  /** Repo-root-relative POSIX path. */
+  relPath: string;
+  exitCode: number;
+  durationMs: number;
+  cases: TestCaseResult[];
+  /** Bun stdout/stderr — only surfaced for failed files. */
+  output?: string;
+}
+
+const decodeXmlEntities = (s: string): string =>
+  s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+
+/**
+ * Minimal JUnit XML parser. Targeted at bun's `--reporter=junit` output, NOT
+ * a general-purpose XML parser. Pulls `<testcase>` elements and their nested
+ * `<failure>` / `<skipped>` markers.
+ */
+export const parseJUnitXml = async (path: string): Promise<TestCaseResult[]> => {
+  let xml: string;
+  try {
+    xml = await readFile(path, "utf8");
+  } catch {
+    return [];
+  }
+  const cases: TestCaseResult[] = [];
+  const testcaseRe =
+    /<testcase\b([^>]*?)(?:\/>|>([\s\S]*?)<\/testcase>)/g;
+  let m: RegExpExecArray | null;
+  while ((m = testcaseRe.exec(xml)) !== null) {
+    const attrs = m[1];
+    const body = m[2] ?? "";
+    const name = /\bname="([^"]*)"/.exec(attrs)?.[1] ?? "";
+    const classname = /\bclassname="([^"]*)"/.exec(attrs)?.[1] ?? "";
+    const timeAttr = /\btime="([^"]*)"/.exec(attrs)?.[1];
+    const time = timeAttr ? Number(timeAttr) : 0;
+    let status: "pass" | "fail" | "skip" = "pass";
+    let failure: string | undefined;
+    if (/<skipped\b/.test(body)) status = "skip";
+    // bun emits `<failure type="..." />` (self-closing) for assertion
+    // failures and `<failure ...>stack</failure>` for thrown errors —
+    // handle both shapes.
+    const failMatch = /<failure\b([^>]*?)(?:\/>|>([\s\S]*?)<\/failure>)/.exec(body);
+    if (failMatch) {
+      status = "fail";
+      const attrs = failMatch[1];
+      const inner = failMatch[2] ? decodeXmlEntities(failMatch[2].trim()) : "";
+      const msg = /\bmessage="([^"]*)"/.exec(attrs)?.[1];
+      const type = /\btype="([^"]*)"/.exec(attrs)?.[1];
+      const header = msg ? decodeXmlEntities(msg) : type ?? "test failed";
+      failure = inner ? `${header}\n${inner}` : header;
+    }
+    cases.push({
+      classname: decodeXmlEntities(classname),
+      name: decodeXmlEntities(name),
+      time,
+      status,
+      failure,
+    });
+  }
+  return cases;
+};
+
+const COLOR = {
+  reset: "\x1b[0m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  gray: "\x1b[90m",
+  bold: "\x1b[1m",
+};
+
+export const formatSummary = (results: FileResult[], totalMs: number): string => {
+  let pass = 0;
+  let fail = 0;
+  let skip = 0;
+  for (const f of results) {
+    for (const c of f.cases) {
+      if (c.status === "pass") pass++;
+      else if (c.status === "fail") fail++;
+      else skip++;
+    }
+  }
+  const fileFails = results.filter((f) => f.exitCode !== 0 || f.cases.some((c) => c.status === "fail"));
+
+  const lines: string[] = [];
+  for (const f of fileFails) {
+    lines.push(`${COLOR.red}✗${COLOR.reset} ${f.relPath}`);
+    const failedCases = f.cases.filter((c) => c.status === "fail");
+    for (const c of failedCases) {
+      const label = c.classname ? `${c.classname} > ${c.name}` : c.name;
+      lines.push(`  ${COLOR.red}× ${label}${COLOR.reset}`);
+      if (c.failure) {
+        for (const fl of c.failure.split("\n")) lines.push(`      ${COLOR.gray}${fl}${COLOR.reset}`);
+      }
+    }
+    // bun's JUnit reporter only emits `<failure type="…" />` for assertion
+    // failures — the diff/stack lives in stdout. Surface stdout when we have
+    // failures OR when the file crashed before reporting at all (preload
+    // crash, syntax error, unhandled rejection).
+    if (f.output) {
+      const header =
+        f.cases.length === 0
+          ? `  ${COLOR.gray}(no JUnit output — file crashed before reporting)${COLOR.reset}`
+          : `  ${COLOR.gray}── stdout (last 40 lines) ──${COLOR.reset}`;
+      lines.push(header);
+      const tail = f.output.split("\n").slice(-40);
+      for (const fl of tail) lines.push(`      ${COLOR.gray}${fl}${COLOR.reset}`);
+    }
+    lines.push("");
+  }
+
+  const totalFiles = results.length;
+  const failedFiles = fileFails.length;
+  const passedFiles = totalFiles - failedFiles;
+  const totalMsFmt = `${(totalMs / 1000).toFixed(2)}s`;
+  lines.push(
+    `${COLOR.bold}Files${COLOR.reset}  ${COLOR.green}${passedFiles} pass${COLOR.reset}` +
+      (failedFiles > 0 ? `, ${COLOR.red}${failedFiles} fail${COLOR.reset}` : "") +
+      `  (${totalFiles})`,
+  );
+  lines.push(
+    `${COLOR.bold}Tests${COLOR.reset}  ${COLOR.green}${pass} pass${COLOR.reset}` +
+      (fail > 0 ? `, ${COLOR.red}${fail} fail${COLOR.reset}` : "") +
+      (skip > 0 ? `, ${COLOR.yellow}${skip} skip${COLOR.reset}` : "") +
+      `  (${pass + fail + skip})`,
+  );
+  lines.push(`${COLOR.bold}Time${COLOR.reset}   ${totalMsFmt}`);
+  return lines.join("\n");
+};

--- a/scripts/test-runner/watch.ts
+++ b/scripts/test-runner/watch.ts
@@ -1,0 +1,160 @@
+import { watch } from "node:fs";
+import { resolve, relative } from "node:path";
+import { Glob } from "bun";
+import type { Config } from "./config.ts";
+import type { DiscoveredFile } from "./discover.ts";
+import { discoverTests } from "./discover.ts";
+import type { DepGraph } from "./dep-graph.ts";
+import { runPool, defaultProgressReporter, cleanupRunDir } from "./pool.ts";
+import { formatSummary } from "./reporter.ts";
+
+interface WatchOptions {
+  repoRoot: string;
+  config: Config;
+  graph: DepGraph;
+  parallelism: number;
+  /** Initial discovery — used to map paths back to per-file preload lists. */
+  discovered: DiscoveredFile[];
+}
+
+const DEBOUNCE_MS = 100;
+
+const COLOR_DIM = "\x1b[90m";
+const COLOR_RESET = "\x1b[0m";
+const COLOR_BOLD = "\x1b[1m";
+
+const isIgnored = (relPath: string, patterns: string[]): boolean => {
+  for (const p of patterns) {
+    const g = new Glob(p);
+    if (g.match(relPath)) return true;
+  }
+  return false;
+};
+
+/**
+ * Start the watch loop. Returns a promise that never resolves naturally —
+ * the caller should run this until Ctrl-C.
+ *
+ * On each batch of file changes:
+ *   1. Patch the dep graph for changed source files.
+ *   2. Walk the reverse graph to find every test file transitively affected.
+ *   3. If a *test* file itself was changed (or added), include it directly.
+ *   4. Run the affected subset through `runPool`.
+ */
+export const runWatch = async (options: WatchOptions): Promise<void> => {
+  const { repoRoot, config, graph, parallelism } = options;
+  let discovered = options.discovered;
+  const byPath = new Map<string, DiscoveredFile>();
+  for (const f of discovered) byPath.set(f.path, f);
+
+  const pendingChanges = new Set<string>();
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let inFlight: Promise<void> | null = null;
+
+  process.stdout.write(`${COLOR_BOLD}watching${COLOR_RESET} ${COLOR_DIM}${repoRoot}${COLOR_RESET}\n`);
+  process.stdout.write(`${COLOR_DIM}(press Ctrl-C to stop)${COLOR_RESET}\n\n`);
+
+  const isTestFile = (absPath: string): boolean =>
+    /\.test\.tsx?$/.test(absPath) && absPath.startsWith(resolve(repoRoot, "src"));
+
+  const refreshDiscovered = async (): Promise<void> => {
+    discovered = await discoverTests(repoRoot, config, []);
+    byPath.clear();
+    for (const f of discovered) byPath.set(f.path, f);
+  };
+
+  const processBatch = async (): Promise<void> => {
+    if (pendingChanges.size === 0) return;
+    const changed = Array.from(pendingChanges);
+    pendingChanges.clear();
+
+    const affectedTestFiles = new Set<string>();
+    let needRediscover = false;
+    for (const abs of changed) {
+      if (isTestFile(abs) && !byPath.has(abs)) needRediscover = true;
+    }
+    if (needRediscover) await refreshDiscovered();
+
+    for (const abs of changed) {
+      // Patch the graph for any in-repo file change.
+      graph.refresh(abs);
+      const reverse = graph.affected(abs);
+      for (const dep of reverse) if (isTestFile(dep)) affectedTestFiles.add(dep);
+      if (isTestFile(abs)) affectedTestFiles.add(abs);
+    }
+
+    const toRun: DiscoveredFile[] = [];
+    for (const abs of affectedTestFiles) {
+      const f = byPath.get(abs);
+      if (f) toRun.push(f);
+    }
+
+    if (toRun.length === 0) {
+      process.stdout.write(
+        `${COLOR_DIM}no tests affected by ${changed.length} change(s)${COLOR_RESET}\n\n`,
+      );
+      return;
+    }
+
+    process.stdout.write(
+      `${COLOR_BOLD}re-running ${toRun.length} affected test file(s)${COLOR_RESET}\n`,
+    );
+    const start = performance.now();
+    const { results, runRoot } = await runPool(toRun, {
+      repoRoot,
+      parallelism,
+      coverage: false,
+      onProgress: defaultProgressReporter,
+    });
+    const totalMs = performance.now() - start;
+    process.stdout.write(`\n${formatSummary(results, totalMs)}\n\n`);
+    await cleanupRunDir(runRoot);
+  };
+
+  const enqueue = (abs: string): void => {
+    pendingChanges.add(abs);
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      // Serialize: if a run is in flight, queue the next one to start after.
+      const start = inFlight ? inFlight.then(processBatch) : processBatch();
+      inFlight = start.catch((err) => {
+        process.stderr.write(`watch error: ${err}\n`);
+      });
+    }, DEBOUNCE_MS);
+  };
+
+  const srcRoot = resolve(repoRoot, "src");
+  const makeChangeHandler =
+    (base: string) =>
+    (eventType: string, filename: string | null): void => {
+      void eventType;
+      if (!filename) return;
+      const abs = resolve(base, filename);
+      const rel = relative(repoRoot, abs).replace(/\\/g, "/");
+      if (isIgnored(rel, config.watch.ignore)) return;
+      if (!/\.(ts|tsx|js|jsx|json)$/.test(abs)) return;
+      enqueue(abs);
+    };
+
+  // `fs.watch` recursive is supported on macOS + Windows. On Linux it
+  // silently ignores `recursive: true` and only watches the top directory;
+  // we'd need chokidar/fsevents for true cross-platform support. The dev
+  // box is macOS — accept the macOS-only path here and note it.
+  // fs.watch passes `filename` relative to the watched directory, so the
+  // src-watcher resolves against `srcRoot` and the test.config watcher
+  // against `repoRoot`.
+  const watcher = watch(srcRoot, { recursive: true }, makeChangeHandler(srcRoot));
+  const testConfigWatcher = watch(
+    resolve(repoRoot, "test.config.ts"),
+    makeChangeHandler(repoRoot),
+  );
+
+  await new Promise<void>(() => {
+    process.on("SIGINT", () => {
+      watcher.close();
+      testConfigWatcher.close();
+      process.exit(0);
+    });
+  });
+};

--- a/test.config.ts
+++ b/test.config.ts
@@ -1,0 +1,45 @@
+/**
+ * Root config for the custom test runner (`scripts/test-runner`).
+ *
+ * Modules group test files by glob; each group has its own preload list.
+ * A test file inherits its group's preload, plus any per-file additions from
+ * a `// @test preload=…` header (see scripts/test-runner/discover.ts).
+ *
+ * Files outside every module pattern are still discovered and run, just
+ * with no module-level preload (the per-file header still applies).
+ */
+import type { Config } from "./scripts/test-runner/config.ts";
+
+const config: Config = {
+  modules: {
+    client: {
+      pattern: ["src/client/**/*.test.ts", "src/client/**/*.test.tsx"],
+      preload: ["src/client/test-setup.ts"],
+    },
+    server: {
+      pattern: ["src/server/**/*.test.ts"],
+      preload: [],
+    },
+    common: {
+      pattern: ["src/common/**/*.test.ts"],
+      preload: [],
+    },
+  },
+  parallelism: "auto",
+  coverage: {
+    include: ["src/**"],
+    exclude: ["**/*.test.ts", "**/*.test.tsx", "**/__fixtures__/**", "**/test-setup.ts"],
+  },
+  watch: {
+    ignore: [
+      "**/node_modules/**",
+      "**/build/**",
+      "**/coverage/**",
+      "**/.git/**",
+      "**/.cache/**",
+      "**/*.log",
+    ],
+  },
+};
+
+export default config;

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true
+  },
+  "include": ["scripts/test-runner/**/*.ts", "test.config.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

Closes #440.

Adds `bun run test:next` and `bun run test:next:coverage` alongside the existing `test` / `test:client` / `test:server` / `test:coverage`. The new runner is opt-in and is not wired into CI until it stabilizes — the old commands keep working unchanged.

The core unlock: each `*.test.{ts,tsx}` runs in its own `bun test` subprocess, so `mock.module()` is local to that file. No more global mock pollution → the DI plumbing the server uses today can be retired in a follow-up.

## What's in the box (P1, end-to-end)

- **subprocess pool** (`pool.ts`) — N workers (default = CPU count, `-p N` to override). Spawns `bun test <file> --preload … --reporter=junit --reporter-outfile=… [--coverage --coverage-dir=…]`, captures JUnit XML + LCOV per file, surfaces stdout when a file fails.
- **discovery** (`discover.ts`) — globs `*.test.{ts,tsx}`, resolves each file's preload from per-module config + a per-file `// @test preload=…` header.
- **real dep graph** (`dep-graph.ts`) — `ts.preProcessFile()` to scan imports + `ts.resolveModuleName()` to honor tsconfig path aliases. Forward + reverse maps, incremental patching on each file change, in-repo edges only.
- **watch mode** (`watch.ts`) — `fs.watch` recursive over `src/` and `test.config.ts`. On each debounced change, patches the graph and reruns exactly the test files transitively affected.
- **reporter** (`reporter.ts`) — minimal JUnit XML parser tuned to bun's emitted shape (handles both `<failure />` self-closing and `<failure>…</failure>`). Surfaces the bun stdout tail for failed files so diffs/stacks aren't lost.
- **coverage merge** (`coverage.ts`) — unions per-file LCOV across all worker outputs. Bun's LCOV only emits aggregate `FNF`/`FNH` per file (no `FN:`/`FNDA:` records), so the merge does line-count exactly and function-count via a documented max-across-procs approximation.
- **config** — `test.config.ts` at the repo root declares module groups (client / server / common) and their preloads, parallelism, coverage filters, watch ignore globs. `tsconfig.scripts.json` typechecks `scripts/test-runner/` + `test.config.ts`; `bun run typecheck` now covers both.

## Verified locally

- `bun run test:next` — 48 files / 651 tests / **~8.5s** on 4 workers.
- `bun run test` (existing `client && server` split) — unchanged, still passes.
- `bun run test:next:coverage` — writes `coverage/lcov.info`; `bun scripts/check-coverage.ts` passes (lines **26.26%**, functions **41.85%** — both above the existing thresholds).
- Watch mode: touched `src/client/lib/models/Capacity.ts` → exactly the 7 transitively-affected test files rerun, others untouched.
- Failing tests: tested with a deliberately-failing assertion → testcase name surfaced + bun stdout (diff + stack) appended.
- `bun run typecheck` / `bun run lint` clean.

## Not in this PR (intentional)

- Removing the DI plumbing — separate refactor unlocked by this runner.
- Wiring into CI / replacing existing `test` scripts — deferred until the new runner has been driven for a while.
- HTML coverage report — LCOV-only for MVP per the design discussion.

## Test plan

- [ ] `bun run test:next` — confirm 48 / 651 / green on your machine
- [ ] `bun run test:next src/server/lib` — subset filter works
- [ ] `bun run test:next --watch` — touch a source file, confirm only its transitively-dependent test files rerun
- [ ] `bun run test:next:coverage` — confirm `coverage/lcov.info` written and `check-coverage.ts` passes
- [ ] `bun run test` — confirm existing flow untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)