### PR TITLE
fix(docker): include scripts/ in builder so CD's bun run test works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY package.json bun.lockb* ./
 COPY tsconfig.json tsconfig.node.json ./
 COPY vite.config.ts ./
 COPY src src
+COPY scripts scripts
 
 RUN bun install
 RUN bun run typecheck


### PR DESCRIPTION
**CD on main broke after #443 merged.** The new \`bun run test\` chains through \`bun scripts/test-bundled/index.ts\`, but the Dockerfile builder only \`COPY\`'d \`src\` — not \`scripts\`. The test step exits 1 with \`error: Module not found "scripts/test-bundled/index.ts"\`.

Fix: add \`COPY scripts scripts\` to the builder stage so the test orchestrator + the existing \`scripts/check-coverage.ts\` (used by \`test:coverage\`) both ship into the builder.

Failing run: https://github.com/hoiekim/budget/actions/runs/26703537703/job/78700438030

## Test plan

- [ ] CI passes on this PR
- [ ] Once merged, the next push to main builds the docker image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)