### PR TITLE
refactor: migrate 3 monkey-patch tests to per-test-bundle (batch B)

### DIFF
--- a/src/server/routes/api-keys/post-api-keys.test.bundle.ts
+++ b/src/server/routes/api-keys/post-api-keys.test.bundle.ts
@@ -1,41 +1,32 @@
-/**
- * Tests for POST /api/api-keys (Closes #358 — POST coverage).
- *
- * Mocking pattern: monkey-patch `apiKeysTable.insert` (the lowest-level
- * write the route's `createApiKey` helper performs), following the same
- * approach as `accounts/post-suggest-category.test.ts`. Avoids
- * `mock.module("server", ...)` because Bun's module mock is process-wide
- * and leaks into sibling test files in the same run.
- */
+// Per-test-bundle isolation — see scripts/test-bundled/.
+// @bundles src/server/routes/api-keys/post-api-keys.ts
+import { describe, test, expect, mock, beforeEach } from "bun:test";
 
-import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+const mockQuery = mock(async (_sql: string, _values?: unknown[]) => ({
+  rows: [] as unknown[],
+  rowCount: 0 as number | null,
+}));
 
-import { apiKeysTable } from "server/lib/postgres/models";
-import { postApiKeysRoute } from "./post-api-keys";
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+}
 
-const originalInsert = apiKeysTable.insert.bind(apiKeysTable);
+mock.module("pg", () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {} },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+}));
 
-const mockInsert = mock(
-  async (
-    _row: unknown,
-    _returning?: string[],
-  ): Promise<Record<string, unknown> | null> => ({ key_id: "k-1" }),
-);
-
-(apiKeysTable as unknown as { insert: typeof mockInsert }).insert = mockInsert;
-
-afterAll(() => {
-  (apiKeysTable as unknown as { insert: typeof originalInsert }).insert = originalInsert;
-});
+const { postApiKeysRoute } = await import("./post-api-keys");
 
 beforeEach(() => {
-  mockInsert.mockReset();
-  mockInsert.mockResolvedValue({ key_id: "k-1" });
+  mockQuery.mockReset();
 });
 
 function makeReq(body: unknown, opts: { user?: { user_id: string; username: string } | null } = {}) {
-  const user =
-    opts.user === undefined ? { user_id: "u-1", username: "test" } : opts.user;
+  const user = opts.user === undefined ? { user_id: "u-1", username: "test" } : opts.user;
   return {
     method: "POST",
     path: "/api-keys",
@@ -66,12 +57,21 @@ const fakeRes = () =>
     end() {},
   }) as unknown as Parameters<typeof postApiKeysRoute.execute>[1];
 
+/** Find the INSERT INTO api_keys SQL call and return its parameters. */
+const findInsertCall = (): { sql: string; values: unknown[] } | null => {
+  for (const call of mockQuery.mock.calls) {
+    const sql = call[0] as string;
+    if (/INSERT\s+INTO\s+api_keys/i.test(sql)) return { sql, values: call[1] as unknown[] };
+  }
+  return null;
+};
+
 describe("post-api-keys", () => {
   test("rejects unauthenticated requests", async () => {
     const result = await postApiKeysRoute.execute(makeReq({}, { user: null }), fakeRes());
     expect(result?.status).toBe("failed");
     expect(result?.message).toMatch(/not authenticated/);
-    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
   test("rejects missing body", async () => {
@@ -181,7 +181,7 @@ describe("post-api-keys", () => {
   });
 
   test("happy path returns key_id + prefix + plaintext, trimmed name", async () => {
-    mockInsert.mockResolvedValueOnce({ key_id: "k-42" });
+    mockQuery.mockResolvedValueOnce({ rows: [{ key_id: "k-42" }], rowCount: 1 });
 
     const result = await postApiKeysRoute.execute(
       makeReq({ name: "  laptop  ", scopes: ["transactions:suggest"] }),
@@ -190,20 +190,22 @@ describe("post-api-keys", () => {
 
     expect(result?.status).toBe("success");
     expect(result?.body?.key_id).toBe("k-42");
-    // Plaintext is generated client-side here; verify the bk_ scheme is preserved.
+    // Plaintext is generated server-side; verify the bk_ scheme is preserved.
     expect(result?.body?.plaintext.startsWith("bk_")).toBe(true);
     expect(result?.body?.prefix).toBe(result!.body!.plaintext.slice(0, 11));
 
-    expect(mockInsert).toHaveBeenCalledTimes(1);
-    const [row] = mockInsert.mock.calls[0] as [Record<string, unknown>, string[]];
-    expect(row.user_id).toBe("u-1");
-    expect(row.name).toBe("laptop");
-    expect(row.scopes).toEqual(["transactions:suggest"]);
-    expect(row.expires_at).toBeNull();
+    const ins = findInsertCall();
+    expect(ins).not.toBeNull();
+    // INSERT carries the row fields: user_id, trimmed name, scopes array,
+    // null expires_at, plus the derived key_hash + key_prefix.
+    expect(ins!.values).toContain("u-1");
+    expect(ins!.values).toContain("laptop");
+    expect(ins!.values.find((v) => Array.isArray(v))).toEqual(["transactions:suggest"]);
+    expect(ins!.values).toContain(null);
   });
 
   test("plaintext is generated each request and never persisted", async () => {
-    mockInsert.mockResolvedValueOnce({ key_id: "k-1" });
+    mockQuery.mockResolvedValueOnce({ rows: [{ key_id: "k-1" }], rowCount: 1 });
     const result = await postApiKeysRoute.execute(
       makeReq({ name: "k", scopes: ["transactions:suggest"] }),
       fakeRes(),
@@ -211,29 +213,31 @@ describe("post-api-keys", () => {
     const plaintext = result?.body?.plaintext;
     expect(plaintext).toBeDefined();
 
-    const [row] = mockInsert.mock.calls[0] as [Record<string, unknown>, string[]];
-    // The DB row stores a hash + prefix; the raw plaintext must never be persisted.
-    expect(Object.values(row).some((v) => v === plaintext)).toBe(false);
-    expect(row.key_hash).toBeDefined();
-    expect(row.key_prefix).toBe(plaintext!.slice(0, 11));
+    const ins = findInsertCall();
+    expect(ins).not.toBeNull();
+    // The raw plaintext must NEVER appear in the persisted row.
+    expect(ins!.values).not.toContain(plaintext);
+    // The derived prefix (11-char public identifier) MUST appear.
+    expect(ins!.values).toContain(plaintext!.slice(0, 11));
   });
 
   test("happy path normalizes a valid future expires_at to ISO", async () => {
     const future = new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
+    mockQuery.mockResolvedValueOnce({ rows: [{ key_id: "k-1" }], rowCount: 1 });
     const result = await postApiKeysRoute.execute(
       makeReq({ name: "k", scopes: ["transactions:suggest"], expires_at: future }),
       fakeRes(),
     );
     expect(result?.status).toBe("success");
-    const [row] = mockInsert.mock.calls[0] as [Record<string, unknown>, string[]];
-    expect(row.expires_at).toBe(future);
+    const ins = findInsertCall();
+    expect(ins).not.toBeNull();
+    expect(ins!.values).toContain(future);
   });
 
   test("insert returning null surfaces as a Route-layer failure", async () => {
-    // `createApiKey` throws when `apiKeysTable.insert` resolves to null.
-    // The Route layer catches the throw and returns an error envelope —
-    // pin that the failure is surfaced (not silently turned into success).
-    mockInsert.mockResolvedValueOnce(null);
+    // INSERT … RETURNING * with no row → `createApiKey` throws → Route
+    // surfaces an error envelope rather than success.
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
     const result = await postApiKeysRoute.execute(
       makeReq({ name: "k", scopes: ["transactions:suggest"] }),
       fakeRes(),

--- a/src/server/routes/users/post-login.test.bundle.ts
+++ b/src/server/routes/users/post-login.test.bundle.ts
@@ -1,25 +1,37 @@
-/**
- * Tests for POST /api/login (#393 — partial: post-login.ts coverage).
- *
- * Mocking pattern: monkey-patch `usersTable.queryOne` (the lowest-level
- * read that `searchUser` performs), mirroring `api-keys/post-api-keys.test.ts`.
- * Avoids `mock.module("server", ...)` because Bun's module mock is
- * process-wide and leaks across sibling test files.
- *
- * bcrypt.compare runs unmocked — fixture user passwords are real hashes
- * generated at test-module load.
- */
-
-import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+// Per-test-bundle isolation — see scripts/test-bundled/.
+//
+// bcrypt is in the framework's DEFAULT_NODE_EXTERNALS list, so the
+// bundle's `import bcrypt from "bcrypt"` resolves at runtime through
+// the real package — same as the original test. Password hash + compare
+// run unmocked.
+// @bundles src/server/routes/users/post-login.ts
+import { describe, test, expect, mock, beforeEach } from "bun:test";
 import bcrypt from "bcrypt";
 
-import { usersTable } from "server/lib/postgres/models";
-import { postLoginRoute } from "./post-login";
+const mockQuery = mock(async (_sql: string, _values?: unknown[]) => ({
+  rows: [] as unknown[],
+  rowCount: 0 as number | null,
+}));
+
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+}
+
+mock.module("pg", () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {} },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+}));
+
+const { postLoginRoute } = await import("./post-login");
 
 const REAL_PASSWORD = "correct-horse-battery-staple";
 const REAL_HASH = await bcrypt.hash(REAL_PASSWORD, 10);
 
-const realUserRow = {
+/** Raw users row matching UserModel's schema. */
+const userRow = (overrides: Record<string, unknown> = {}) => ({
   user_id: "u-1",
   username: "alice",
   password: REAL_HASH,
@@ -28,36 +40,11 @@ const realUserRow = {
   token: null,
   updated: "2026-05-19T00:00:00.000Z",
   is_deleted: false,
-};
-
-// Fake model object: queryOne callers invoke `.toUser()` (per searchUser) so
-// we just need that one method to return the User record.
-const makeFakeModel = (row: typeof realUserRow) => ({
-  ...row,
-  toUser() {
-    return { user_id: row.user_id, username: row.username, password: row.password };
-  },
-  toMaskedUser() {
-    return { user_id: row.user_id, username: row.username };
-  },
-  toJSON() {
-    return { user_id: row.user_id, username: row.username };
-  },
-});
-
-const originalQueryOne = usersTable.queryOne.bind(usersTable);
-
-const mockQueryOne = mock(async (_filters: Record<string, unknown>): Promise<unknown> => null);
-
-(usersTable as unknown as { queryOne: typeof mockQueryOne }).queryOne = mockQueryOne;
-
-afterAll(() => {
-  (usersTable as unknown as { queryOne: typeof originalQueryOne }).queryOne = originalQueryOne;
+  ...overrides,
 });
 
 beforeEach(() => {
-  mockQueryOne.mockReset();
-  mockQueryOne.mockResolvedValue(null);
+  mockQuery.mockReset();
 });
 
 interface SessionStub {
@@ -112,27 +99,21 @@ describe("post-login validation", () => {
     const result = await postLoginRoute.execute(makeReq(null), fakeRes());
     expect(result?.status).toBe("failed");
     expect(result?.message).toMatch(/body/i);
-    expect(mockQueryOne).not.toHaveBeenCalled();
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
   test("missing username → validationError", async () => {
-    const result = await postLoginRoute.execute(
-      makeReq({ password: "x" }),
-      fakeRes(),
-    );
+    const result = await postLoginRoute.execute(makeReq({ password: "x" }), fakeRes());
     expect(result?.status).toBe("failed");
     expect(result?.message).toMatch(/username/);
-    expect(mockQueryOne).not.toHaveBeenCalled();
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
   test("missing password → validationError", async () => {
-    const result = await postLoginRoute.execute(
-      makeReq({ username: "alice" }),
-      fakeRes(),
-    );
+    const result = await postLoginRoute.execute(makeReq({ username: "alice" }), fakeRes());
     expect(result?.status).toBe("failed");
     expect(result?.message).toMatch(/password/);
-    expect(mockQueryOne).not.toHaveBeenCalled();
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 
   test("empty-string username → validationError", async () => {
@@ -147,20 +128,20 @@ describe("post-login validation", () => {
 
 describe("post-login auth outcomes", () => {
   test("unknown user → generic failure (no enumeration leak)", async () => {
-    mockQueryOne.mockResolvedValueOnce(null);
+    // searchUser → usersTable.queryOne → pool.query → empty rows
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
     const result = await postLoginRoute.execute(
       makeReq({ username: "ghost", password: REAL_PASSWORD }),
       fakeRes(),
     );
     expect(result?.status).toBe("failed");
     expect(result?.message).toBe("Invalid username or password.");
-    // Verify the search was actually attempted (DUMMY_HASH timing path runs
-    // for unknown users — assertion: queryOne was called once).
-    expect(mockQueryOne).toHaveBeenCalledTimes(1);
+    // searchUser was attempted (DUMMY_HASH timing path still issues one SELECT)
+    expect(mockQuery).toHaveBeenCalledTimes(1);
   });
 
   test("known user + wrong password → same generic failure (no enumeration leak)", async () => {
-    mockQueryOne.mockResolvedValueOnce(makeFakeModel(realUserRow));
+    mockQuery.mockResolvedValueOnce({ rows: [userRow()], rowCount: 1 });
     const result = await postLoginRoute.execute(
       makeReq({ username: "alice", password: "WRONG" }),
       fakeRes(),
@@ -170,7 +151,7 @@ describe("post-login auth outcomes", () => {
   });
 
   test("known user + correct password → success, session.regenerate called, user set", async () => {
-    mockQueryOne.mockResolvedValueOnce(makeFakeModel(realUserRow));
+    mockQuery.mockResolvedValueOnce({ rows: [userRow()], rowCount: 1 });
 
     let regenerateCalled = false;
     const session: SessionStub = {
@@ -204,10 +185,7 @@ describe("post-login auth outcomes", () => {
   });
 
   test("session.regenerate callback error → Route layer surfaces error envelope", async () => {
-    // The Route base class catches throws and returns
-    // { status: "error", message: "Internal server error" } with HTTP 500.
-    // Pin: a regenerate failure must NOT be silently turned into success.
-    mockQueryOne.mockResolvedValueOnce(makeFakeModel(realUserRow));
+    mockQuery.mockResolvedValueOnce({ rows: [userRow()], rowCount: 1 });
     const req = makeReq(
       { username: "alice", password: REAL_PASSWORD },
       { regenerateErr: new Error("boom") },

--- a/src/server/routes/users/post-public-token.test.bundle.ts
+++ b/src/server/routes/users/post-public-token.test.bundle.ts
@@ -1,39 +1,28 @@
-/**
- * Tests for POST /api/public-token (#393 — partial: post-public-token.ts
- * validation and dispatch coverage).
- *
- * Scope: auth gate, provider-routing validation, and the wrong-type
- * branches. The success branches for SIMPLE_FIN / PLAID / MANUAL all
- * call into `plaid.*` / `simpleFin.*` (namespace re-exports) and
- * `upsertItems` / `searchItems` / `sync*` (top-level consts in
- * server/lib). Mocking either layer cleanly requires either DI on the
- * route or a process-wide `mock.module`, which the test-pattern note
- * explicitly avoids (cross-file leak). The MANUAL "already exists"
- * branch is covered because it only requires `itemsTable.query` to
- * return a matching row, which is monkey-patchable in-place.
- *
- * Remaining branches (SIMPLE_FIN success, PLAID success, MANUAL fresh)
- * are tracked as a follow-up to #393.
- */
+// Per-test-bundle isolation — see scripts/test-bundled/.
+// @bundles src/server/routes/users/post-public-token.ts
+import { describe, test, expect, mock, beforeEach } from "bun:test";
 
-import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+const mockQuery = mock(async (_sql: string, _values?: unknown[]) => ({
+  rows: [] as unknown[],
+  rowCount: 0 as number | null,
+}));
 
-import { itemsTable } from "server/lib/postgres/models";
-import { postPublicTokenRoute } from "./post-public-token";
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+}
 
-const originalQuery = itemsTable.query.bind(itemsTable);
+mock.module("pg", () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {} },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+}));
 
-const mockQuery = mock(async (_filters: Record<string, unknown>): Promise<unknown[]> => []);
-
-(itemsTable as unknown as { query: typeof mockQuery }).query = mockQuery;
-
-afterAll(() => {
-  (itemsTable as unknown as { query: typeof originalQuery }).query = originalQuery;
-});
+const { postPublicTokenRoute } = await import("./post-public-token");
 
 beforeEach(() => {
   mockQuery.mockReset();
-  mockQuery.mockResolvedValue([]);
 });
 
 function makeReq(
@@ -41,8 +30,7 @@ function makeReq(
   body: unknown,
   opts: { user?: { user_id: string; username: string } | null } = {},
 ): Parameters<typeof postPublicTokenRoute.execute>[0] {
-  const user =
-    opts.user === undefined ? { user_id: "u-1", username: "test" } : opts.user;
+  const user = opts.user === undefined ? { user_id: "u-1", username: "test" } : opts.user;
   return {
     method: "POST",
     path: "/public-token",
@@ -72,6 +60,25 @@ const fakeRes = () =>
     },
     end() {},
   }) as unknown as Parameters<typeof postPublicTokenRoute.execute>[1];
+
+/** Raw items-table row matching ItemModel's full schema. */
+const itemRow = (overrides: Record<string, unknown> = {}) => ({
+  item_id: "i-existing",
+  user_id: "u-1",
+  access_token: "no_access_token",
+  institution_id: null,
+  available_products: null,
+  cursor: null,
+  status: null,
+  provider: "manual",
+  last_sync_status: null,
+  last_sync_at: null,
+  last_sync_error: null,
+  raw: null,
+  updated: null,
+  is_deleted: false,
+  ...overrides,
+});
 
 describe("post-public-token", () => {
   test("rejects unauthenticated requests", async () => {
@@ -121,17 +128,13 @@ describe("post-public-token", () => {
   });
 
   test("provider=manual with existing MANUAL item → 'Manual item already exists' failure", async () => {
-    // `searchItems` is the only call before the existing-item check; it walks
-    // `itemsTable.query` and filters by user. Returning a MANUAL row makes the
-    // .find() succeed → route hits the failure branch without touching plaid.
-    const manualRow = {
-      toJSON: () => ({
-        item_id: "i-existing",
-        provider: "manual", // ItemProvider.MANUAL = "manual"
-        access_token: "no_access_token",
-      }),
-    };
-    mockQuery.mockResolvedValueOnce([manualRow]);
+    // searchItems calls pool.query (via itemsTable.query). Returning a row
+    // shaped like a MANUAL item makes the route's .find() succeed and
+    // surface the "already exists" failure without ever touching plaid.
+    mockQuery.mockResolvedValueOnce({
+      rows: [itemRow({ item_id: "i-existing", provider: "manual" })],
+      rowCount: 1,
+    });
 
     const result = await postPublicTokenRoute.execute(
       makeReq({ provider: "manual" }, {}),


### PR DESCRIPTION
Per Hoie's adoption push (continuation of #448's batch A) — convert the 3 remaining model-monkey-patch tests to the bundled framework.

## Tests migrated

- \`routes/users/post-public-token\` — was patching \`itemsTable.query\`
- \`routes/users/post-login\` — was patching \`usersTable.queryOne\`
- \`routes/api-keys/post-api-keys\` — was patching \`apiKeysTable.insert\`

Pattern is identical to batch A: leaf-mock \`pg\` with FakePool, dynamic-import the source, walk \`mockQuery.mock.calls\` for the SQL that was previously asserted at the model-method layer.

## Notes per test

- **post-login** re-uses the real \`bcrypt\` via the framework's \`DEFAULT_NODE_EXTERNALS\` list — the bundle keeps \`import bcrypt from "bcrypt"\` external, so \`bcrypt.hash\` at test-module load and \`bcrypt.compare\` inside the route both run unmocked. Same shape as the original.
- **post-public-token** originally returned a pre-built fake model with \`toJSON()\`; the bundled version returns a raw items-table row that \`ItemModel\`'s mapper consumes. The "Manual item already exists" branch is the only one that touches the DB in the original test scope; SIMPLE_FIN / PLAID / MANUAL success branches are still out of scope (tracked separately under #393).
- **post-api-keys** shifts assertions from \`mockInsert.mock.calls[0]\` (the model row) to \`findInsertCall().values\` (the parameterized INSERT). The plaintext-never-persisted contract is now pinned by \`expect(values).not.toContain(plaintext)\` + \`expect(values).toContain(plaintext.slice(0, 11))\` — same invariant, lower-layer evidence.

## Verified locally

- \`bun run test:bundled\` → 14 files / 151 tests / ~1.0s
- \`bun run test:non-bundled\` → 34 files / 500 tests / ~3.6s
- \`bun run test\` → both, **651 / 48 green**
- typecheck + lint clean

## After this lands

The monkey-patch sweep is **complete** — no more \`(table as unknown as { method }).method = mock\` + \`afterAll\` restore patterns remain in the codebase. Next batch: **path 3** — retire DI plumbing from compute-tools sources (\`cash-holding\`, \`backfill-snapshots\`, \`auto-suggest\`), one source per PR.

## Test plan

- [ ] \`bun run test:bundled\` — confirm 14 / 151 green
- [ ] \`bun run test\` — confirm 651 / 48 green
- [ ] \`bun run test:coverage\` — confirm thresholds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)