### PR TITLE
docs(testing): document per-test-bundle runner; drop removed test:client/test:server

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,3 @@
-# Test preload is configured via npm scripts in package.json
-# Use `bun run test:client` or `bun run test:server` for isolated test runs
+# Test preload is configured via npm scripts in package.json.
+# Use `bun run test` (runs test:bundled then test:non-bundled). For a single
+# non-bundled file, pass the preload: `bun test --preload ./src/client/test-setup.ts <file>`.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,21 +4,27 @@
 
 ```bash
 bun run test               # All tests — always use this, not bare bun test
-bun run test:client        # Client-only (React components, hooks, common)
-bun run test:server        # Server-only (routes, repositories, utilities)
-bun test --watch           # Watch mode
-bun run test:coverage      # With coverage report
+bun run test:bundled       # Per-test-bundle suite only (isolated module mocks)
+bun run test:non-bundled   # Everything else (client + server, shared registry)
+bun run test:coverage      # Bundled suite + non-bundled coverage report
 ```
 
-> **Always use `bun run test`, not bare `bun test`.** Client tests require a preload file (`src/client/test-setup.ts`) to initialize browser globals. Bare `bun test` mixes client and server contexts and causes `Dictionary.set() is disabled in server` failures for holdings calculation tests.
+`bun run test` runs `test:bundled` followed by `test:non-bundled`.
 
-To run a single server-side test file:
+> **Always use `bun run test`, not bare `bun test`.** Bare `bun test` skips the
+> bundled suite entirely and runs without the `src/client/test-setup.ts`
+> preload, so client tests fail with `Dictionary.set() is disabled in server`
+> for holdings-calculation tests. `test:non-bundled` supplies that preload.
+
+To run a single non-bundled test file, pass the same preload:
 
 ```bash
-bun test src/path/file.test.ts
+bun test --preload ./src/client/test-setup.ts src/path/file.test.ts
 ```
 
-Client tests need the preload flag, so use `bun run test:client` for those.
+Bundled tests can't be run with bare `bun test` — they are discovered, built,
+and run by the orchestrator. Run the whole bundled suite with `bun run
+test:bundled` (it builds in parallel, ~1.5s).
 
 ## Writing Tests
 
@@ -31,6 +37,60 @@ describe("featureName", () => {
   });
 });
 ```
+
+### Bundled tests (`*.test.bundle.ts`)
+
+`bun test` shares one module registry per process, so `mock.module()` calls leak
+across files. The per-test-bundle runner (`scripts/test-bundled/`) works around
+this: it bundles each source-under-test into a unique file with leaf deps (`pg`,
+`bcrypt`, …) kept external, so each test captures **its own** mocks at first load
+and never collides with sibling tests in the same `bun test` process. This
+replaces the old practice of plumbing dependency-injection seams through server
+functions purely for mockability.
+
+Use a bundled test when the unit mocks a leaf dependency (typically `pg`). Name
+it `*.test.bundle.ts`, co-located with the source, and annotate it:
+
+```typescript
+// @bundles src/server/lib/postgres/repositories/users.ts
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+const mockQuery = mock(async () => ({ rows: [], rowCount: 0 }));
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+}
+mock.module("pg", () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {} },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+}));
+
+// Natural sibling import — the runner's preload redirects it to the bundle.
+const { writeUser } = await import("./users");
+```
+
+The `// @bundles` source is imported by its **natural sibling path**
+(`await import("./users")`); the runner's preload registers a redirect from that
+source path to the built bundle, so the leaf-dep mocks above are captured at
+first load.
+
+To also mock a **sibling source module** (not a leaf dep), keep it external with
+`// @external <relPath>` and mock it at the same relative path:
+
+```typescript
+// @bundles src/server/lib/postgres/repositories/snapshots.ts
+// @external ./securities
+mock.module("./securities", () => ({ searchSecuritiesById: mockSearchSecuritiesById }));
+```
+
+> `// @external` works for a sibling that isn't itself another test's
+> `// @bundles` target. The runner reserves each `@bundles` source path for that
+> one bundle's redirect, so two bundled tests can't both mock the same source
+> module (see issue #451).
+
+See the existing `*.test.bundle.ts` files for full examples.
 
 ## Test Requirements
 
@@ -48,5 +108,6 @@ Tests are co-located with source files:
 
 ```
 src/server/lib/validation.ts
-src/server/lib/validation.test.ts
+src/server/lib/validation.test.ts          # standard, shared-registry test
+src/server/lib/postgres/repositories/users.test.bundle.ts   # isolated bundle test
 ```


### PR DESCRIPTION
## What

`docs/TESTING.md` was last updated in the doc-restructure commit (`878ab21`), **before** the per-test-bundle framework landed (#440, merged via #443–#450). It had drifted out of sync with `package.json`:

- Documented `bun run test:client` and `bun run test:server` as commands — **neither script exists anymore**.
- Omitted `test:bundled` (now the first half of `bun run test`) and `test:non-bundled` entirely.
- The single-file instruction `bun test src/path/file.test.ts` and the "use `bun run test:client`" line referenced the removed scripts / missing preload.

## Changes (docs-only)

- Replace the dead command list with the actual scripts: `test`, `test:bundled`, `test:non-bundled`, `test:coverage` (verified against `package.json`).
- Update the "always use `bun run test`" callout — bare `bun test` now *also* skips the bundled suite, not just the client preload.
- Fix the single-file command to pass the `src/client/test-setup.ts` preload that `test:non-bundled` uses.
- Add a **Bundled tests (`*.test.bundle.ts`)** section documenting the convention, the `// @bundles` / `// @external` annotations, the leaf-dep (`pg`) mock pattern, and the natural-sibling-import + preload-redirect mechanism — grounded in the merged converted tests and `scripts/test-bundled/`.
- Note the `@external`-vs-`@bundles`-target constraint (links #451).

## Verification

- Every command and script name cross-checked against current `package.json` scripts.
- Bundled-test snippets mirror the merged `*.test.bundle.ts` files (`users`, `snapshots`, `cash-holding`) and `scripts/test-bundled/index.ts` preload behavior.
- No source files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)