### PR TITLE
test(database): cover SQL query-builder core directly (#460)

### DIFF
--- a/src/server/lib/postgres/database.test.ts
+++ b/src/server/lib/postgres/database.test.ts
@@ -8,6 +8,7 @@ import {
   buildUpdate,
   buildUpsert,
   buildSoftDelete,
+  buildSelect,
   buildSelectWithFilters,
   buildCreateTable,
   buildCreateIndex,
@@ -262,6 +263,30 @@ describe("buildSoftDelete", () => {
       "UPDATE transactions SET is_deleted = TRUE, updated = CURRENT_TIMESTAMP WHERE id = $1 AND user_id = $2 RETURNING id",
     );
     expect(values).toEqual(["t1", "u1"]);
+  });
+});
+
+describe("buildSelect", () => {
+  it("selects * and threads a where clause's values", () => {
+    const where = prepareQuery({ a: 1 }, { excludeDeleted: false });
+    const { sql, values } = buildSelect("widgets", "*", where);
+    expect(sql).toBe("SELECT * FROM widgets WHERE a = $1");
+    expect(values).toEqual([1]);
+  });
+
+  it("continues placeholder numbering for LIMIT and OFFSET after where values", () => {
+    const where = prepareQuery({ a: 1 }, { excludeDeleted: false });
+    const { sql, values } = buildSelect("widgets", ["id", "name"], where, "name ASC", 10, 20);
+    expect(sql).toBe(
+      "SELECT id, name FROM widgets WHERE a = $1 ORDER BY name ASC LIMIT $2 OFFSET $3",
+    );
+    expect(values).toEqual([1, 10, 20]);
+  });
+
+  it("works with no where clause", () => {
+    const { sql, values } = buildSelect("widgets", "*");
+    expect(sql).toBe("SELECT * FROM widgets");
+    expect(values).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## What

Adds `src/server/lib/postgres/database.test.ts` — 38 direct unit tests for the SQL query-builder core that every repository funnels through. Closes #460.

Before this, only `buildUpdate` had any coverage, and only incidentally — `compute-tools/auto-suggest.test.bundle.ts` exercises two of its `additionalWhere` branches. The other 12 exported builders were unverified, despite all hand-rolling their own `$N` parameter indexing (the classic silent off-by-one surface).

## Coverage added

- `prepareQuery` — eq numbering, `IS NULL` / `IS NOT NULL` not consuming a placeholder, undefined skip, `startIndex`, extra conditions, `excludeDeleted` toggle, Date→ISO.
- `buildInsert` / `buildUpdate` / `buildUpsert` — `updated=CURRENT_TIMESTAMP` injection, SET numbering with pk in the final slot, `null` return when nothing to set, reserved `raw` key skip, single + array `additionalWhere`, `DO UPDATE SET` vs `DO NOTHING`, `RETURNING`.
- `buildSelect` — LIMIT/OFFSET placeholder continuation after where values.
- `buildSoftDelete` / `buildBulkSoftDelete` — empty-list short-circuit, IN-list numbering, and the `$1`-reserved-for-`additionalWhere` ordering (most error-prone path).
- `buildSelectWithFilters` — the full user_id → primaryKey → filters → inFilters → dateRange → soft-delete → LIMIT/OFFSET sequence numbered in order; empty/undefined skips.
- `buildCreateTable` / `buildCreateIndex` and the `successResult` (200/404) / `errorResult` (500) / `noChangeResult` (304) helpers.

## Scope

Test-only, non-functional. No source files touched. Pure functions — pool import is lazy, so no DB connection; runs in the non-bundled suite alongside `migration.test.ts`.

## Verification

```
$ bun test --preload ./src/client/test-setup.ts src/server/lib/postgres/database.test.ts
 38 pass / 0 fail / 70 expect() calls
```

`bunx tsc --noEmit` and `bunx eslint` both clean on the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
