### PR TITLE
cleanup(database): remove dead prepareValue export (#462)

### DIFF
--- a/src/server/lib/postgres/database.ts
+++ b/src/server/lib/postgres/database.ts
@@ -3,8 +3,7 @@
  */
 
 import { Pool, QueryResult, QueryResultRow } from "pg";
-import { isNull, isUndefined, isDate, isNumber, isString } from "common";
-import { NULL } from "./models/common";
+import { isNull, isUndefined, isDate } from "common";
 import { Schema, Constraints } from "./models/base";
 
 export const SOFT_DELETE_CONDITION = "(is_deleted IS NULL OR is_deleted = FALSE)";
@@ -72,14 +71,6 @@ export function buildCreateTable(
 export function buildCreateIndex(tableName: string, column: string, indexName?: string): string {
   const name = indexName || `idx_${tableName}_${column}`;
   return `CREATE INDEX IF NOT EXISTS ${name} ON ${tableName}(${column})`;
-}
-
-export function prepareValue(value: unknown): string | number | undefined {
-  if (isString(value)) return `'${value.replace(/'/g, "''")}'`;
-  if (isNumber(value)) return value;
-  if (isDate(value)) return `'${value.toISOString()}'`;
-  if (isNull(value)) return NULL;
-  return undefined;
 }
 
 export function prepareParamValue(value: ParamValue): ParamValue {


### PR DESCRIPTION
## What

Removes the dead `prepareValue` export from `src/server/lib/postgres/database.ts`. Closes #462.

`prepareValue` had **zero callers repo-wide** (verified by grep — only the definition matched). It was the only *inline-escaping* value preparer in the module — it embedded `'…'`-quoted string literals directly into SQL rather than returning a bound parameter — sitting right next to the parameterized `prepareParamValue` that every live caller actually uses. Leaving it there invited a future reader to reach for it and reintroduce a non-parameterized query path.

## Diff

- Deletes the 6-line `prepareValue` function.
- Drops the now-unused `isString` / `isNumber` imports from `common` and the `NULL` import from `./models/common` (each was used only inside `prepareValue`).
- No behavior change; no other source touched.

## Verification

```
$ bunx tsc --noEmit          # clean
$ bunx eslint database.ts    # clean (no-unused-vars confirms no dangling refs)
$ bun test … migration.test.ts   # 74 pass / 0 fail
```

Sandbox skipped: dead-code removal with no browser surface, and budget sandbox spins are blocked by #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
