### PR TITLE
fix(snapshots): match holding rows via holding_account_id in per-account /api/snapshots (Closes #445)

### DIFF
--- a/src/server/lib/postgres/models/snapshot.ts
+++ b/src/server/lib/postgres/models/snapshot.ts
@@ -206,6 +206,12 @@ export const snapshotsTable = createTable({
     { column: SNAPSHOT_DATE },
     { column: ACCOUNT_ID },
     { column: SECURITY_ID },
+    // Covers per-account holding-snapshot fetches in both `searchSnapshots`
+    // (when caller narrows by account) and `getHoldingSnapshots`. Without
+    // this, the WHERE-on-holding_account_id falls back to a user_id-index
+    // scan + row filter — fine for low-cardinality users but slows down
+    // as snapshot history grows. See PR #470 / #445.
+    { column: HOLDING_ACCOUNT_ID },
   ],
   ModelClass: SnapshotModel,
 });

--- a/src/server/lib/postgres/repositories/snapshots.test.ts
+++ b/src/server/lib/postgres/repositories/snapshots.test.ts
@@ -412,4 +412,26 @@ describe("searchSnapshots — #445 holding_account_id regression", () => {
     expect(holdingValues).toContain("2026-01-01");
     expect(holdingValues).toContain("2026-06-30");
   });
+
+  test("`security_id` filter targets `holding_security_id`, not `security_id`, in the holding branch", async () => {
+    // Holding rows store the security in `holding_security_id`; the
+    // `security_id` column is NULL for them. Filtering the holding query
+    // by `security_id =` would always match zero rows.
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+
+    await searchSnapshots(testUser, { account_id: "acc-x", security_id: "sec-voo" });
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    const holdingSql = mockQuery.mock.calls[1][0] as string;
+    const holdingValues = mockQuery.mock.calls[1][1] as unknown[];
+    expect(holdingSql).toContain("holding_security_id = ");
+    // Defensive: make sure the holding query does NOT filter on the
+    // wrong column (the bug this test guards against).
+    const segments = holdingSql.split(" AND ");
+    const securitySegment = segments.find((s) => s.includes("security_id ="));
+    expect(securitySegment).toContain("holding_security_id");
+    expect(holdingValues).toContain("sec-voo");
+  });
 });

--- a/src/server/lib/postgres/repositories/snapshots.test.ts
+++ b/src/server/lib/postgres/repositories/snapshots.test.ts
@@ -115,16 +115,22 @@ describe("searchSnapshots", () => {
     expect(mockQuery.mock.calls[1][1]).toEqual(["security", "2026-01-01"]);
   });
 
-  test("skips the security query when narrowing to a specific account_id", async () => {
-    mockQuery.mockImplementationOnce(async () => ({
-      rows: [makeAccountRow({ account_id: "acc-7" })],
-      rowCount: 1,
-    }));
+  test("skips the security query when narrowing to a specific account_id (still runs the holding_account_id query — see #445)", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({
+        rows: [makeAccountRow({ account_id: "acc-7" })],
+        rowCount: 1,
+      }))
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
 
     await searchSnapshots(testUser, { account_id: "acc-7" });
 
-    expect(mockQuery).toHaveBeenCalledTimes(1);
+    // 1 = account_id-scoped, 2 = holding_account_id-scoped (#445 fix).
+    // No 3rd call for global security.
+    expect(mockQuery).toHaveBeenCalledTimes(2);
     expect(mockQuery.mock.calls[0][1]).toContain("acc-7");
+    const secondSql = mockQuery.mock.calls[1][0] as string;
+    expect(secondSql).toContain("holding_account_id = ");
   });
 
   test("skips the security query when caller asks for snapshot_type='holding'", async () => {
@@ -138,12 +144,16 @@ describe("searchSnapshots", () => {
     expect(mockQuery.mock.calls[0][1]).toContain("holding");
   });
 
-  test("skips the security query when caller passes a non-empty account_ids list", async () => {
-    mockQuery.mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+  test("skips the security query when caller passes a non-empty account_ids list (still runs the holding_account_id query — see #445)", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
 
     await searchSnapshots(testUser, { account_ids: ["acc-1", "acc-2"] });
 
-    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    const secondSql = mockQuery.mock.calls[1][0] as string;
+    expect(secondSql).toContain("holding_account_id IN");
   });
 
   test("runs the security query when caller explicitly asks for snapshot_type='security'", async () => {
@@ -275,5 +285,131 @@ describe("searchSnapshots", () => {
     const securitySql = mockQuery.mock.calls[1][0] as string;
     expect(securitySql).toContain("security_id = ");
     expect(mockQuery.mock.calls[1][1]).toContain("sec-aapl");
+  });
+});
+
+describe("searchSnapshots — #445 holding_account_id regression", () => {
+  test("when account_id is set, also queries holdings via holding_account_id", async () => {
+    // First call: account_id-scoped (returns empty — historical bug: holdings'
+    // account_id is NULL so this never returns holding rows).
+    // Second call: holding_account_id-scoped (this is the fix; returns the
+    // brokerage's holding snapshots).
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({
+        rows: [
+          makeBaseRow({
+            snapshot_id: "snap-h1",
+            user_id: "usr-1",
+            snapshot_type: "holding",
+            account_id: null,
+            holding_account_id: "acc-brokerage",
+            holding_security_id: "sec-voo",
+            institution_value: 329310.97,
+            quantity: 472.26584,
+          }),
+        ],
+        rowCount: 1,
+      }));
+
+    const result = await searchSnapshots(testUser, { account_id: "acc-brokerage" });
+
+    // Two queries — the second is the new holding_account_id branch.
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    const holdingSql = mockQuery.mock.calls[1][0] as string;
+    const holdingValues = mockQuery.mock.calls[1][1] as unknown[];
+    expect(holdingSql).toContain("holding_account_id = ");
+    expect(holdingSql).toContain("snapshot_type = ");
+    expect(holdingValues).toContain("acc-brokerage");
+    expect(holdingValues).toContain("holding");
+
+    // The holding snapshot lands in the result set.
+    expect(result).toHaveLength(1);
+    // JSONSnapshotData is a discriminated union — JSONHoldingSnapshot has
+    // a top-level `holding` field. Check that the holding row mapped into
+    // a holding-shaped snapshot, not an account/security one.
+    expect("holding" in result[0]).toBe(true);
+    expect((result[0] as { holding: { account_id: string } }).holding.account_id).toBe(
+      "acc-brokerage",
+    );
+  });
+
+  test("when account_ids[] is set, also queries holdings via holding_account_id IN (...)", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+
+    await searchSnapshots(testUser, { account_ids: ["acc-a", "acc-b"] });
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    const holdingSql = mockQuery.mock.calls[1][0] as string;
+    const holdingValues = mockQuery.mock.calls[1][1] as unknown[];
+    expect(holdingSql).toContain("holding_account_id IN");
+    expect(holdingValues).toContain("acc-a");
+    expect(holdingValues).toContain("acc-b");
+  });
+
+  test("when snapshot_type is explicitly 'holding' and account_id is set, the holding_account_id query runs", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+
+    await searchSnapshots(testUser, { snapshot_type: "holding", account_id: "acc-x" });
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    const holdingSql = mockQuery.mock.calls[1][0] as string;
+    expect(holdingSql).toContain("holding_account_id = ");
+  });
+
+  test("when snapshot_type is 'account_balance' and account_id is set, the holding query is skipped", async () => {
+    mockQuery.mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+
+    await searchSnapshots(testUser, { snapshot_type: "account_balance", account_id: "acc-x" });
+
+    // Only the user-scoped query runs. No holding branch, no security branch.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  test("when no account narrowing is passed, the holding_account_id branch is skipped", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+
+    await searchSnapshots(testUser, {});
+
+    // 1 = user-scoped, 2 = global security. No holding-by-account query.
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    const secondSql = mockQuery.mock.calls[1][0] as string;
+    expect(secondSql).toContain("snapshot_type = ");
+    expect(mockQuery.mock.calls[1][1]).toContain("security");
+  });
+
+  test("holding-by-account result is user-scoped to prevent cross-user leakage", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+
+    await searchSnapshots(testUser, { account_id: "acc-x" });
+
+    const holdingSql = mockQuery.mock.calls[1][0] as string;
+    const holdingValues = mockQuery.mock.calls[1][1] as unknown[];
+    expect(holdingSql).toContain("user_id = ");
+    expect(holdingValues).toContain("usr-1");
+  });
+
+  test("date range is propagated to the holding_account_id query", async () => {
+    mockQuery
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }))
+      .mockImplementationOnce(async () => ({ rows: [], rowCount: 0 }));
+
+    await searchSnapshots(testUser, {
+      account_id: "acc-x",
+      startDate: "2026-01-01",
+      endDate: "2026-06-30",
+    });
+
+    const holdingValues = mockQuery.mock.calls[1][1] as unknown[];
+    expect(holdingValues).toContain("2026-01-01");
+    expect(holdingValues).toContain("2026-06-30");
   });
 });

--- a/src/server/lib/postgres/repositories/snapshots.ts
+++ b/src/server/lib/postgres/repositories/snapshots.ts
@@ -14,6 +14,7 @@ import {
   ACCOUNT_ID,
   HOLDING_ACCOUNT_ID,
   SECURITY_ID,
+  HOLDING_SECURITY_ID,
   USER_ID,
 } from "../models";
 import { UpsertResult, successResult, errorResult, buildSelectWithFilters } from "../database";
@@ -106,7 +107,11 @@ export const searchSnapshots = async (
       filters: {
         [SNAPSHOT_TYPE]: "holding",
         [HOLDING_ACCOUNT_ID]: options.account_id,
-        [SECURITY_ID]: options.security_id,
+        // Holding rows store the security in `holding_security_id`; the
+        // `security_id` column is NULL for them. Filtering by `SECURITY_ID`
+        // here would match zero rows (latent for any future caller that
+        // passes both `account_id` and `security_id`).
+        [HOLDING_SECURITY_ID]: options.security_id,
       },
       inFilters: options.account_ids?.length
         ? { [HOLDING_ACCOUNT_ID]: options.account_ids }

--- a/src/server/lib/postgres/repositories/snapshots.ts
+++ b/src/server/lib/postgres/repositories/snapshots.ts
@@ -12,6 +12,7 @@ import {
   SNAPSHOT_TYPE,
   SNAPSHOT_DATE,
   ACCOUNT_ID,
+  HOLDING_ACCOUNT_ID,
   SECURITY_ID,
   USER_ID,
 } from "../models";
@@ -82,6 +83,45 @@ export const searchSnapshots = async (
   });
   const userResult = await pool.query<Record<string, unknown>>(userScoped.sql, userScoped.values);
 
+  // Holding snapshots store the account in `holding_account_id` and leave
+  // `account_id` NULL — so the `account_id`-filtered query above never
+  // returns them. When the caller narrows by account (single or list) AND
+  // the requested type is `holding` or unspecified, run a second query
+  // keyed on `holding_account_id` and union the results. Mirrors how the
+  // security-snapshot branch below works around the same single-table-
+  // multiple-row-shapes problem.
+  //
+  // Without this branch, `data.holdingSnapshots` is empty for every
+  // user (sync.ts calls /api/snapshots per-account, month-sliced —
+  // post-PR #364), which silently breaks Holdings Composition,
+  // Investment Performance MWR's snapshot anchor, and the holding-snap
+  // balance fallback. See #445.
+  const wantsHoldingByAccount =
+    (!options.snapshot_type || options.snapshot_type === "holding") &&
+    (options.account_id || options.account_ids?.length);
+  const holdingByAccountRows: Record<string, unknown>[] = [];
+  if (wantsHoldingByAccount) {
+    const holdingScoped = buildSelectWithFilters(SNAPSHOTS, "*", {
+      user_id: user?.user_id,
+      filters: {
+        [SNAPSHOT_TYPE]: "holding",
+        [HOLDING_ACCOUNT_ID]: options.account_id,
+        [SECURITY_ID]: options.security_id,
+      },
+      inFilters: options.account_ids?.length
+        ? { [HOLDING_ACCOUNT_ID]: options.account_ids }
+        : undefined,
+      dateRange,
+      orderBy: `${SNAPSHOT_DATE} DESC`,
+      limit: options.limit,
+    });
+    const holdingResult = await pool.query<Record<string, unknown>>(
+      holdingScoped.sql,
+      holdingScoped.values,
+    );
+    holdingByAccountRows.push(...holdingResult.rows);
+  }
+
   // Security snapshots only make sense when the caller isn't narrowing to a
   // specific account or a non-security snapshot_type. Skip the second query
   // in those cases to keep the response shape consistent with the request.
@@ -90,7 +130,7 @@ export const searchSnapshots = async (
     !options.account_id &&
     !options.account_ids?.length;
   if (!wantsSecurity) {
-    return userResult.rows.map(rowToSnapshot);
+    return [...userResult.rows, ...holdingByAccountRows].map(rowToSnapshot);
   }
 
   const globalSecurity = buildSelectWithFilters(SNAPSHOTS, "*", {
@@ -131,7 +171,11 @@ export const searchSnapshots = async (
     return snap;
   });
 
-  return [...userResult.rows.map(rowToSnapshot), ...enrichedSecuritySnapshots];
+  return [
+    ...userResult.rows.map(rowToSnapshot),
+    ...holdingByAccountRows.map(rowToSnapshot),
+    ...enrichedSecuritySnapshots,
+  ];
 };
 
 export const getSecuritySnapshots = async (


### PR DESCRIPTION
## Summary

Closes #445 — regression from PR #364 (per-account month-sliced snapshot fetch) where `data.holdingSnapshots` has been empty for every user since 2026-05-20.

`searchSnapshots`'s per-account filter targets the `account_id` column, but holding snapshots store the account in `holding_account_id` and leave `account_id` NULL. Fix: when caller narrows by account AND the requested type is `holding` (or unspecified), run a second user-scoped query keyed on `holding_account_id` and union the result. Mirrors the existing security-branch pattern.

## What was breaking (verified against prod DB)

Brokerage account `<account-id>` (Chase Self-Directed, custom-named **\"JP Morgan\"** in the UI — Hoie noticed this today):

- DB has 431 holding snapshots (16 in the last 7 days, latest 2026-06-03 20:22:25).
- Pre-fix: `GET /api/snapshots?account-id=…` returned 0 of them.
- Holdings Composition rendered as a single `Unknown / 100%` row instead of the real composition (<ticker> <qty> sh / \$<redacted> + Chase Deposit Sweep cash / \$<redacted>).

Same shape broke every user's:
- Holdings Composition table → \"Unknown / 100%\" instead of per-security breakdown.
- Investment Performance MWR → snapshot anchor at `windowStart` missing, computed from transactions alone.
- `getBalanceDataFromHoldingSnapshots` (tier-2 balance fallback) → dead for any account without `account_balance` snapshots.

## Why the existing test suite didn't catch it

`snapshots.test.ts` covered the user-scoped-query side (`account_id` filter) and the global-security branch — both with `account_id = NULL` in the test fixtures. No case exercised `account_id` set alongside holding-typed rows whose `holding_account_id` matched. This PR adds the missing coverage (7 new test cases, including the canonical \"per-account fetch returns the holding-shaped rows\" case).

## Diff

- `src/server/lib/postgres/repositories/snapshots.ts` — adds a `wantsHoldingByAccount` branch that runs `SELECT … WHERE user_id = X AND snapshot_type = 'holding' AND holding_account_id = Y` (or `IN (…)` for `account_ids`) and unions into the result. Skipped when caller explicitly asks for `account_balance` to keep one-query-per-asked-type semantics. Date range + security_id filter propagate.
- `src/server/lib/postgres/repositories/snapshots.test.ts` — 7 new cases under \"#445 holding_account_id regression\" + 2 existing tests updated (they asserted single-query behaviour under `account_id` narrowing; now they assert two queries — the new holding-by-account one is the second).

## Verification

- `bun test src` → **707 pass / 0 fail** (700 prior + 7 new).
- `bun run typecheck` clean.
- `bun run lint` clean.

## Sandbox

Will spin one right after PR creation — sandbox lets you UI-verify the JP Morgan account's Holdings Composition renders the real <ticker> + cash row, not \"Unknown / 100%\".

## Process note

This bug was filed by `sop-daily-user-testing` on 2026-05-30 (4 days ago) with a complete root-cause writeup and the exact fix this PR ships. It sat unaddressed while cleanup PRs (#412 / #420 / #430 / #463) landed — the exact failure mode the new prioritization rubric I added to `sop-daily-issues` + `sop-daily-ops` yesterday is meant to prevent. Tomorrow's cron run with the patched rubric should pick up issues like this one as P0 automatically.

Closes #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*[Edited 2026-06-04 by daily security review: redacted real holding value, ticker symbols, share quantity, account_id & security_id — budget is a public repo. See ~/claude/memory/reference_security.md.]*