### PR TITLE
feat(holdings): aggregate by ticker in HoldingsComposition + per-snapshot edit sections in detail page

### DIFF
--- a/src/client/components/HoldingProperties/index.css
+++ b/src/client/components/HoldingProperties/index.css
@@ -33,3 +33,17 @@
   font-size: 12px;
   padding: 4px 8px;
 }
+
+/* Per-snapshot two-row section under the Holding header in the detail
+ * page. One section per underlying snapshot the ticker bucket contains
+ * (one VOO snapshot from each contributing date, one CASH snapshot per
+ * detected cash position, etc.). */
+.HoldingProperties .snapshotSection {
+  margin-top: 16px;
+}
+
+.HoldingProperties .snapshotSection .snapshotMeta {
+  font-weight: normal;
+  font-size: 12px;
+  opacity: 0.7;
+}

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -1,5 +1,5 @@
 import { ChangeEventHandler, FormEventHandler, useCallback, useEffect, useMemo, useState } from "react";
-import { ItemProvider, ViewDate } from "common";
+import { ItemProvider, numberToCommaString, ViewDate } from "common";
 import {
   call,
   PATH,
@@ -33,24 +33,14 @@ interface NewHoldingForm {
 
 const EMPTY_FORM: NewHoldingForm = { ticker: "", quantity: "", costBasis: "" };
 
-const truncateSecurityId = (id: string) => id.slice(0, 6);
-
 interface SecurityInfo {
   security_id: string | null;
   ticker_symbol: string | null;
   name: string | null;
 }
 
-/** FE cash-detection — mirrors the heuristic in
- *  `src/client/lib/hooks/calculation/holdings.ts:322`. Keeps the ticker
- *  detail page's bucketing consistent with the table's. */
-const isCashSnapshot = (snap: HoldingSnapshot): boolean => {
-  const { institution_price, cost_basis } = snap.holding;
-  return institution_price === 1 && (cost_basis === null || cost_basis === 0);
-};
-
 export const HoldingProperties = () => {
-  const { router, viewDate, data, setData } = useAppContext();
+  const { router, viewDate, data, setData, calculations } = useAppContext();
   const { path, params, transition } = router;
   const activeParams = path === PATH.HOLDING_DETAIL ? params : transition.incomingParams;
 
@@ -70,51 +60,63 @@ export const HoldingProperties = () => {
   const isCurrentViewDate = viewDate.getEndDate() >= latestViewDate.getEndDate();
   const isReadOnly = !isManualAccount && isCurrentViewDate;
 
-  // Resolve every active holding snapshot for (this account, this ticker)
-  // whose snapshot_date is at-or-before the current viewDate. Take the
-  // latest snapshot per security_id — the per-snapshot two-row sections
-  // render one entry per distinct (account, security_id) the bucket
-  // contains. This mirrors HoldingsComposition's bucketing.
-  const tickerKey = ticker.toUpperCase();
+  // Resolve which (account, security_id) entries belong to this ticker
+  // bucket — single source of truth = `holdingsValueData.getHoldingsForAccount`,
+  // the same hook HoldingsComposition uses. Then look up the LATEST holding
+  // snapshot per security_id (≤ viewDate) so each per-security row in the
+  // bucket gets an editable underlying snapshot. Using `holdingsValueData`
+  // here keeps the detail page's contributing set strictly equal to the
+  // table's bucket members — without it, the detail page could pull in
+  // snapshots the table excluded (or miss snapshots the table included).
+  // The `?ticker=` URL param holds the canonical bucket key as produced by
+  // HoldingsComposition: an uppercased real ticker, `__CASH__`, or a raw
+  // (case-preserved) security_id for no-ticker fallback. Don't uppercase
+  // here — that would corrupt the security_id case in the fallback path.
+  const tickerKey = ticker;
   const viewEndDate = viewDate.getEndDate();
+  const { holdingsValueData } = calculations;
+
   const bucketSnapshots = useMemo<HoldingSnapshot[]>(() => {
     if (isNew) return [];
-    // Latest snapshot per security_id within this account that matches the
-    // ticker bucket. We walk holdingSnapshots and keep the one with the
-    // newest snapshot.date for each security_id.
-    const latestPerSecurity = new Map<string, HoldingSnapshot>();
-    data.holdingSnapshots.forEach((snap) => {
-      if (snap.holding.account_id !== accountId) return;
-      // Snapshot date must be on or before viewDate (history view).
-      const snapDate = new Date(snap.snapshot.date);
-      if (snapDate > viewEndDate) return;
 
-      // Resolve the snapshot's security metadata to decide bucket fit.
-      const securityId = snap.holding.security_id;
+    // Step 1: identify which (account, security_id) pairs the calculation
+    // hook would aggregate into this ticker bucket. Same rule as
+    // HoldingsComposition: real ticker wins, `__CASH__` reserved for cash,
+    // non-cash row with ticker `__CASH__` falls back to full security_id.
+    const bucketSecurityIds = new Set<string>();
+    const holdingIds = holdingsValueData.getHoldingsForAccount(accountId);
+    holdingIds.forEach((holdingId) => {
+      const summary = holdingsValueData.getHistory(holdingId).get(viewEndDate);
+      if (!summary || summary.value === 0) return;
       const securityMatch = data.securitySnapshots.find(
-        (s) => s.security.security_id === securityId,
+        (s) => s.security.security_id === summary.security_id,
       );
       const snapTicker = securityMatch?.security.ticker_symbol?.toUpperCase() ?? null;
-      const isCash = isCashSnapshot(snap);
-
-      // Bucket-match rule mirrors HoldingsComposition: `__CASH__` is
-      // reserved for `isCash` regardless of ticker; for non-cash, a real
-      // ticker that happens to be "__CASH__" falls back to truncated
-      // security_id rather than colliding with the cash bucket.
+      const isCash = summary.isCash;
       const snapBucket = isCash
         ? CASH_TICKER
         : snapTicker && snapTicker !== CASH_TICKER
           ? snapTicker
-          : truncateSecurityId(securityId);
-      if (snapBucket !== tickerKey) return;
+          : summary.security_id;
+      if (snapBucket === tickerKey) bucketSecurityIds.add(summary.security_id);
+    });
 
-      const existing = latestPerSecurity.get(securityId);
+    // Step 2: for each contributing security_id, find the latest snapshot
+    // (date ≤ viewEndDate) so the per-snapshot section can render an
+    // editable form. One section per security_id; the freshest snapshot
+    // wins when multiple exist on the same date.
+    const latestPerSecurity = new Map<string, HoldingSnapshot>();
+    data.holdingSnapshots.forEach((snap) => {
+      if (snap.holding.account_id !== accountId) return;
+      if (!bucketSecurityIds.has(snap.holding.security_id)) return;
+      const snapDate = new Date(snap.snapshot.date);
+      if (snapDate > viewEndDate) return;
+      const existing = latestPerSecurity.get(snap.holding.security_id);
       if (!existing || new Date(existing.snapshot.date) < snapDate) {
-        latestPerSecurity.set(securityId, snap);
+        latestPerSecurity.set(snap.holding.security_id, snap);
       }
     });
-    // Return in stable order — latest snapshot date first so the user sees
-    // the freshest position at the top.
+
     return Array.from(latestPerSecurity.values()).sort(
       (a, b) => new Date(b.snapshot.date).getTime() - new Date(a.snapshot.date).getTime(),
     );
@@ -122,6 +124,7 @@ export const HoldingProperties = () => {
     accountId,
     data.holdingSnapshots,
     data.securitySnapshots,
+    holdingsValueData,
     isNew,
     tickerKey,
     viewEndDate,
@@ -174,7 +177,6 @@ export const HoldingProperties = () => {
         : null;
     return {
       totalQuantity: totals.quantity,
-      totalCostBasis: totals.allHaveCostBasis ? totals.costBasisTotal : null,
       avgCostBasis,
     };
   }, [bucketSnapshots]);
@@ -581,13 +583,13 @@ export const HoldingProperties = () => {
         )}
         <div className="row keyValue">
           <span className="propertyName">Quantity</span>
-          <span>{aggregate.totalQuantity}</span>
+          <span>{numberToCommaString(aggregate.totalQuantity, 4)}</span>
         </div>
         <div className="row keyValue">
           <span className="propertyName">Cost&nbsp;basis&nbsp;(avg)</span>
           <span>
             {aggregate.avgCostBasis !== null
-              ? aggregate.avgCostBasis.toFixed(4)
+              ? numberToCommaString(aggregate.avgCostBasis, 4)
               : "—"}
           </span>
         </div>

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -12,6 +12,7 @@ import {
   indexedDb,
   StoreName,
 } from "client";
+import { CASH_TICKER } from "../HoldingsComposition";
 import { HoldingSnapshotPostResponse, ValidateTickerResponse } from "server";
 
 import "./index.css";
@@ -32,14 +33,30 @@ interface NewHoldingForm {
 
 const EMPTY_FORM: NewHoldingForm = { ticker: "", quantity: "", costBasis: "" };
 
+const truncateSecurityId = (id: string) => id.slice(0, 6);
+
+interface SecurityInfo {
+  security_id: string | null;
+  ticker_symbol: string | null;
+  name: string | null;
+}
+
+/** FE cash-detection — mirrors the heuristic in
+ *  `src/client/lib/hooks/calculation/holdings.ts:322`. Keeps the ticker
+ *  detail page's bucketing consistent with the table's. */
+const isCashSnapshot = (snap: HoldingSnapshot): boolean => {
+  const { institution_price, cost_basis } = snap.holding;
+  return institution_price === 1 && (cost_basis === null || cost_basis === 0);
+};
+
 export const HoldingProperties = () => {
   const { router, viewDate, data, setData } = useAppContext();
   const { path, params, transition } = router;
   const activeParams = path === PATH.HOLDING_DETAIL ? params : transition.incomingParams;
 
   const accountId = activeParams.get("account_id") || "";
-  const snapshotId = activeParams.get("snapshot_id") || "";
-  const isNew = !snapshotId;
+  const ticker = activeParams.get("ticker") || "";
+  const isNew = !ticker;
 
   // Edit gating mirrors AccountProperties' balance input: synced accounts
   // are not editable at the current viewDate, because that state is
@@ -53,37 +70,149 @@ export const HoldingProperties = () => {
   const isCurrentViewDate = viewDate.getEndDate() >= latestViewDate.getEndDate();
   const isReadOnly = !isManualAccount && isCurrentViewDate;
 
-  // Read the snapshot from the already-synced appContext.data instead of
-  // re-fetching `/api/snapshots/holding` on every page load (Closes #362).
-  // Holdings + their security metadata are loaded at sync time and live in
-  // `data.holdingSnapshots` / `data.securitySnapshots`.
-  const snapshot = !isNew ? data.holdingSnapshots.get(snapshotId) : undefined;
-  const security: { name: string | null; ticker_symbol: string | null } | null = useMemo(() => {
-    if (!snapshot) return null;
-    const sId = snapshot.holding.security_id;
-    const match = data.securitySnapshots.find((s) => s.security.security_id === sId);
-    if (!match) return null;
-    return { name: match.security.name, ticker_symbol: match.security.ticker_symbol };
-  }, [snapshot, data.securitySnapshots]);
-  const loadError = !isNew && !snapshot ? "Holding not found." : "";
+  // Resolve every active holding snapshot for (this account, this ticker)
+  // whose snapshot_date is at-or-before the current viewDate. Take the
+  // latest snapshot per security_id — the per-snapshot two-row sections
+  // render one entry per distinct (account, security_id) the bucket
+  // contains. This mirrors HoldingsComposition's bucketing.
+  const tickerKey = ticker.toUpperCase();
+  const viewEndDate = viewDate.getEndDate();
+  const bucketSnapshots = useMemo<HoldingSnapshot[]>(() => {
+    if (isNew) return [];
+    // Latest snapshot per security_id within this account that matches the
+    // ticker bucket. We walk holdingSnapshots and keep the one with the
+    // newest snapshot.date for each security_id.
+    const latestPerSecurity = new Map<string, HoldingSnapshot>();
+    data.holdingSnapshots.forEach((snap) => {
+      if (snap.holding.account_id !== accountId) return;
+      // Snapshot date must be on or before viewDate (history view).
+      const snapDate = new Date(snap.snapshot.date);
+      if (snapDate > viewEndDate) return;
 
-  const [editTicker, setEditTicker] = useState("");
-  const [editQuantity, setEditQuantity] = useState("");
-  const [editCostBasis, setEditCostBasis] = useState("");
-  const [editDate, setEditDate] = useState("");
-  const [editError, setEditError] = useState("");
+      // Resolve the snapshot's security metadata to decide bucket fit.
+      const securityId = snap.holding.security_id;
+      const securityMatch = data.securitySnapshots.find(
+        (s) => s.security.security_id === securityId,
+      );
+      const snapTicker = securityMatch?.security.ticker_symbol?.toUpperCase() ?? null;
+      const isCash = isCashSnapshot(snap);
 
-  // Hydrate edit fields from the context-derived snapshot. Re-runs after a
-  // successful update once `sync()` has refreshed `data.holdingSnapshots`.
-  useEffect(() => {
-    if (!snapshot) return;
-    setEditTicker(security?.ticker_symbol || "");
-    setEditQuantity(snapshot.holding.quantity != null ? String(snapshot.holding.quantity) : "");
-    setEditCostBasis(
-      snapshot.holding.cost_basis != null ? String(snapshot.holding.cost_basis) : "",
+      // Bucket-match rule mirrors HoldingsComposition: `__CASH__` is
+      // reserved for `isCash` regardless of ticker; for non-cash, a real
+      // ticker that happens to be "__CASH__" falls back to truncated
+      // security_id rather than colliding with the cash bucket.
+      const snapBucket = isCash
+        ? CASH_TICKER
+        : snapTicker && snapTicker !== CASH_TICKER
+          ? snapTicker
+          : truncateSecurityId(securityId);
+      if (snapBucket !== tickerKey) return;
+
+      const existing = latestPerSecurity.get(securityId);
+      if (!existing || new Date(existing.snapshot.date) < snapDate) {
+        latestPerSecurity.set(securityId, snap);
+      }
+    });
+    // Return in stable order — latest snapshot date first so the user sees
+    // the freshest position at the top.
+    return Array.from(latestPerSecurity.values()).sort(
+      (a, b) => new Date(b.snapshot.date).getTime() - new Date(a.snapshot.date).getTime(),
     );
-    setEditDate(toIsoDateInput(snapshot.snapshot.date));
-  }, [snapshot, security]);
+  }, [
+    accountId,
+    data.holdingSnapshots,
+    data.securitySnapshots,
+    isNew,
+    tickerKey,
+    viewEndDate,
+  ]);
+
+  // Bucket-level display info — primary label, name (first non-null), and
+  // a representative security record (used by the per-snapshot sections).
+  const bucketInfo = useMemo<{
+    primaryLabel: string;
+    name: string | null;
+    securities: Map<string, SecurityInfo>;
+  }>(() => {
+    const securities = new Map<string, SecurityInfo>();
+    let name: string | null = null;
+    bucketSnapshots.forEach((snap) => {
+      const sid = snap.holding.security_id;
+      if (!securities.has(sid)) {
+        const match = data.securitySnapshots.find((s) => s.security.security_id === sid);
+        securities.set(sid, {
+          security_id: sid,
+          ticker_symbol: match?.security.ticker_symbol ?? null,
+          name: match?.security.name?.trim() || null,
+        });
+      }
+      if (!name) name = securities.get(sid)?.name ?? null;
+    });
+    const primaryLabel = tickerKey === CASH_TICKER ? "Cash" : tickerKey;
+    return { primaryLabel, name, securities };
+  }, [bucketSnapshots, data.securitySnapshots, tickerKey]);
+
+  // Aggregate quantity / cost basis across all underlying snapshots.
+  // Avg cost basis = sum(cost_basis) / sum(quantity); null whenever any
+  // contributor lacks cost basis OR total quantity is zero.
+  const aggregate = useMemo(() => {
+    const totals = bucketSnapshots.reduce(
+      (acc, s) => {
+        acc.quantity += s.holding.quantity ?? 0;
+        if (acc.allHaveCostBasis && s.holding.cost_basis != null) {
+          acc.costBasisTotal += s.holding.cost_basis;
+        } else {
+          acc.allHaveCostBasis = false;
+        }
+        return acc;
+      },
+      { quantity: 0, costBasisTotal: 0, allHaveCostBasis: true },
+    );
+    const avgCostBasis =
+      totals.allHaveCostBasis && totals.quantity !== 0
+        ? totals.costBasisTotal / totals.quantity
+        : null;
+    return {
+      totalQuantity: totals.quantity,
+      totalCostBasis: totals.allHaveCostBasis ? totals.costBasisTotal : null,
+      avgCostBasis,
+    };
+  }, [bucketSnapshots]);
+
+  const loadError =
+    !isNew && bucketSnapshots.length === 0 ? "No holdings recorded for this ticker." : "";
+
+  // Per-snapshot edit state — keyed by snapshot_id. We track input values
+  // separately from the snapshot data so edits stay isolated per row.
+  const [snapEdits, setSnapEdits] = useState<
+    Record<string, { quantity: string; costBasis: string; date: string; error: string }>
+  >({});
+
+  useEffect(() => {
+    setSnapEdits((prev) => {
+      const next: typeof prev = {};
+      bucketSnapshots.forEach((snap) => {
+        const id = snap.snapshot.snapshot_id;
+        const existing = prev[id];
+        // Hydrate from snapshot on first mount; preserve in-progress edits
+        // across re-renders triggered by sync (data updates) so the user
+        // doesn't lose typed input.
+        if (existing) {
+          next[id] = existing;
+        } else {
+          next[id] = {
+            quantity:
+              snap.holding.quantity != null ? String(snap.holding.quantity) : "",
+            costBasis:
+              snap.holding.cost_basis != null ? String(snap.holding.cost_basis) : "",
+            date: toIsoDateInput(snap.snapshot.date),
+            error: "",
+          };
+        }
+      });
+      return next;
+    });
+  }, [bucketSnapshots]);
 
   const [form, setForm] = useState<NewHoldingForm>(EMPTY_FORM);
   const [snapshotDateInput, setSnapshotDateInput] = useState(
@@ -203,47 +332,53 @@ export const HoldingProperties = () => {
     goBackToAccount();
   };
 
-  const updateField = useCallback(
-    async (patch: Record<string, unknown>) => {
-      if (!snapshot) return;
-      setEditError("");
+  /** Patch a single underlying snapshot (per-snapshot two-row section). */
+  const updateSnapshot = useCallback(
+    async (snap: HoldingSnapshot, patch: Record<string, unknown>) => {
       const r = await call
         .post<HoldingSnapshotPostResponse>("/api/snapshots/holding", {
-          snapshot_id: snapshot.snapshot.snapshot_id,
+          snapshot_id: snap.snapshot.snapshot_id,
           ...patch,
         })
         .catch(console.error);
       if (r?.status !== "success" || !r.body) {
-        setEditError(r?.message || "Failed to update holding");
+        setSnapEdits((prev) => ({
+          ...prev,
+          [snap.snapshot.snapshot_id]: {
+            ...(prev[snap.snapshot.snapshot_id] ?? {
+              quantity: "",
+              costBasis: "",
+              date: "",
+              error: "",
+            }),
+            error: r?.message || "Failed to update holding",
+          },
+        }));
         return;
       }
-      // Client-side propagation: merge the patch into the existing snapshot
-      // and write it back to appContext.data. The calculation hooks
-      // (`getHoldingsValueData` etc.) re-derive value / G/L / totals from
-      // there, so no full `/api/snapshots` re-sync is needed.
       const { snapshot_id: returnedSnapshotId, security_id: returnedSecurityId } = r.body;
       const nextHolding = new Holding({
-        ...snapshot.holding,
+        ...snap.holding,
         security_id: returnedSecurityId,
-        quantity: "quantity" in patch ? (patch.quantity as number) : snapshot.holding.quantity,
+        quantity: "quantity" in patch ? (patch.quantity as number) : snap.holding.quantity,
         cost_basis:
-          "cost_basis" in patch ? (patch.cost_basis as number | null) : snapshot.holding.cost_basis,
+          "cost_basis" in patch ? (patch.cost_basis as number | null) : snap.holding.cost_basis,
         institution_price:
           "institution_price" in patch
             ? (patch.institution_price as number)
-            : snapshot.holding.institution_price,
+            : snap.holding.institution_price,
         institution_value:
           "institution_value" in patch
             ? (patch.institution_value as number)
-            : snapshot.holding.institution_value,
+            : snap.holding.institution_value,
       });
       const nextDate =
         "snapshot_date" in patch && typeof patch.snapshot_date === "string"
           ? new Date(patch.snapshot_date).toISOString()
-          : snapshot.snapshot.date;
+          : snap.snapshot.date;
       const nextSnapshot = new HoldingSnapshot({
         snapshot: new Snapshot({ snapshot_id: returnedSnapshotId, date: nextDate }),
-        user: snapshot.user,
+        user: snap.user,
         holding: nextHolding,
       });
       setData((oldData) => {
@@ -255,62 +390,66 @@ export const HoldingProperties = () => {
         return newData;
       });
     },
-    [snapshot, setData],
+    [setData],
   );
 
-  const onBlurTicker = async () => {
-    const next = editTicker.trim().toUpperCase();
-    if (!snapshot || !next) return;
-    if (next === (security?.ticker_symbol || "").toUpperCase()) return;
-    await updateField({ ticker_symbol: next });
-  };
-
-  const onBlurQuantity = async () => {
-    if (!snapshot) return;
-    const parsed = parseFloat(editQuantity);
+  const onBlurQuantity = (snap: HoldingSnapshot, raw: string) => async () => {
+    const parsed = parseFloat(raw);
     if (Number.isNaN(parsed)) {
-      setEditError("Quantity must be a number");
+      setSnapEdits((prev) => ({
+        ...prev,
+        [snap.snapshot.snapshot_id]: {
+          ...prev[snap.snapshot.snapshot_id],
+          error: "Quantity must be a number",
+        },
+      }));
       return;
     }
-    if (parsed === snapshot.holding.quantity) return;
-    await updateField({ quantity: parsed });
+    if (parsed === snap.holding.quantity) return;
+    await updateSnapshot(snap, { quantity: parsed });
   };
 
-  const onBlurCostBasis = async () => {
-    if (!snapshot) return;
-    if (editCostBasis.trim() === "") {
-      if (snapshot.holding.cost_basis == null) return;
-      await updateField({ cost_basis: null });
+  const onBlurCostBasis = (snap: HoldingSnapshot, raw: string) => async () => {
+    if (raw.trim() === "") {
+      if (snap.holding.cost_basis == null) return;
+      await updateSnapshot(snap, { cost_basis: null });
       return;
     }
-    const parsed = parseFloat(editCostBasis);
+    const parsed = parseFloat(raw);
     if (Number.isNaN(parsed)) {
-      setEditError("Cost basis must be a number");
+      setSnapEdits((prev) => ({
+        ...prev,
+        [snap.snapshot.snapshot_id]: {
+          ...prev[snap.snapshot.snapshot_id],
+          error: "Cost basis must be a number",
+        },
+      }));
       return;
     }
-    if (parsed === snapshot.holding.cost_basis) return;
-    await updateField({ cost_basis: parsed });
+    if (parsed === snap.holding.cost_basis) return;
+    await updateSnapshot(snap, { cost_basis: parsed });
   };
 
-  const onBlurDate = async () => {
-    if (!snapshot || !editDate) return;
-    if (editDate === toIsoDateInput(snapshot.snapshot.date)) return;
-    await updateField({ snapshot_date: editDate });
+  const onBlurDate = (snap: HoldingSnapshot, raw: string) => async () => {
+    if (!raw) return;
+    if (raw === toIsoDateInput(snap.snapshot.date)) return;
+    await updateSnapshot(snap, { snapshot_date: raw });
   };
 
-  const onClickDelete = async () => {
-    if (!snapshot) return;
+  const onClickDeleteSnap = (snap: HoldingSnapshot) => async () => {
     if (!window.confirm("Remove this holding snapshot?")) return;
-    const removedId = snapshot.snapshot.snapshot_id;
-    const r = await call
-      .delete(`/api/snapshots/holding?id=${removedId}`)
-      .catch(console.error);
+    const removedId = snap.snapshot.snapshot_id;
+    const r = await call.delete(`/api/snapshots/holding?id=${removedId}`).catch(console.error);
     if (r?.status !== "success") {
-      setEditError(r?.message || "Failed to delete holding");
+      setSnapEdits((prev) => ({
+        ...prev,
+        [removedId]: {
+          ...prev[removedId],
+          error: r?.message || "Failed to delete holding",
+        },
+      }));
       return;
     }
-    // Drop the snapshot from appContext.data + IndexedDB; the composition
-    // table re-renders without this row on the next render pass.
     setData((oldData) => {
       const newData = new Data(oldData);
       indexedDb.remove(StoreName.holdingSnapshots, removedId).catch(console.error);
@@ -319,7 +458,9 @@ export const HoldingProperties = () => {
       newData.holdingSnapshots = next;
       return newData;
     });
-    goBackToAccount();
+    // If we just deleted the last underlying snapshot, the bucket is empty
+    // and there's nothing more to render — go back.
+    if (bucketSnapshots.length <= 1) goBackToAccount();
   };
 
   if (!accountId) {
@@ -430,78 +571,103 @@ export const HoldingProperties = () => {
       <div className="property">
         <div className="row keyValue">
           <span className="propertyName">Ticker</span>
-          {isReadOnly ? (
-            <span>{editTicker || "—"}</span>
-          ) : (
-            <input
-              type="text"
-              value={editTicker}
-              onChange={(e) => setEditTicker(e.target.value)}
-              onBlur={onBlurTicker}
-              autoCapitalize="characters"
-            />
-          )}
+          <span>{bucketInfo.primaryLabel}</span>
         </div>
-        {security?.name && (
+        {bucketInfo.name && (
           <div className="row keyValue">
             <span className="propertyName">Name</span>
-            <span>{security.name}</span>
+            <span>{bucketInfo.name}</span>
           </div>
         )}
         <div className="row keyValue">
           <span className="propertyName">Quantity</span>
-          {isReadOnly ? (
-            <span>{editQuantity || "—"}</span>
-          ) : (
-            <input
-              type="number"
-              min="0"
-              step="any"
-              value={editQuantity}
-              onChange={(e) => setEditQuantity(e.target.value)}
-              onBlur={onBlurQuantity}
-            />
-          )}
+          <span>{aggregate.totalQuantity}</span>
         </div>
         <div className="row keyValue">
-          <span className="propertyName">Cost&nbsp;basis</span>
-          {isReadOnly ? (
-            <span>{editCostBasis || "—"}</span>
-          ) : (
-            <input
-              type="number"
-              min="0"
-              step="any"
-              value={editCostBasis}
-              onChange={(e) => setEditCostBasis(e.target.value)}
-              onBlur={onBlurCostBasis}
-            />
-          )}
+          <span className="propertyName">Cost&nbsp;basis&nbsp;(avg)</span>
+          <span>
+            {aggregate.avgCostBasis !== null
+              ? aggregate.avgCostBasis.toFixed(4)
+              : "—"}
+          </span>
         </div>
-        <div className="row keyValue">
-          <span className="propertyName">Snapshot&nbsp;date</span>
-          {isReadOnly ? (
-            <span>{editDate || "—"}</span>
-          ) : (
-            <input
-              type="date"
-              value={editDate}
-              onChange={(e) => setEditDate(e.target.value)}
-              onBlur={onBlurDate}
-            />
-          )}
-        </div>
-        {editError && <div className="row formError">{editError}</div>}
       </div>
+
+      {bucketSnapshots.map((snap, idx) => {
+        const id = snap.snapshot.snapshot_id;
+        const edit = snapEdits[id] ?? {
+          quantity: "",
+          costBasis: "",
+          date: "",
+          error: "",
+        };
+        const setEdit = (patch: Partial<typeof edit>) =>
+          setSnapEdits((prev) => ({ ...prev, [id]: { ...edit, ...patch } }));
+        return (
+          <div key={id} className="snapshotSection">
+            <div className="propertyLabel">
+              Snapshot&nbsp;{idx + 1}
+              <span className="snapshotMeta">&nbsp;·&nbsp;{toIsoDateInput(snap.snapshot.date)}</span>
+            </div>
+            <div className="property">
+              <div className="row keyValue">
+                <span className="propertyName">Quantity</span>
+                {isReadOnly ? (
+                  <span>{edit.quantity || "—"}</span>
+                ) : (
+                  <input
+                    type="number"
+                    min="0"
+                    step="any"
+                    value={edit.quantity}
+                    onChange={(e) => setEdit({ quantity: e.target.value, error: "" })}
+                    onBlur={onBlurQuantity(snap, edit.quantity)}
+                  />
+                )}
+              </div>
+              <div className="row keyValue">
+                <span className="propertyName">Cost&nbsp;basis</span>
+                {isReadOnly ? (
+                  <span>{edit.costBasis || "—"}</span>
+                ) : (
+                  <input
+                    type="number"
+                    min="0"
+                    step="any"
+                    value={edit.costBasis}
+                    onChange={(e) => setEdit({ costBasis: e.target.value, error: "" })}
+                    onBlur={onBlurCostBasis(snap, edit.costBasis)}
+                  />
+                )}
+              </div>
+              <div className="row keyValue">
+                <span className="propertyName">Snapshot&nbsp;date</span>
+                {isReadOnly ? (
+                  <span>{edit.date || "—"}</span>
+                ) : (
+                  <input
+                    type="date"
+                    value={edit.date}
+                    onChange={(e) => setEdit({ date: e.target.value, error: "" })}
+                    onBlur={onBlurDate(snap, edit.date)}
+                  />
+                )}
+              </div>
+              {edit.error && <div className="row formError">{edit.error}</div>}
+              {!isReadOnly && (
+                <div className="row button">
+                  <button type="button" className="delete colored" onClick={onClickDeleteSnap(snap)}>
+                    Remove&nbsp;this&nbsp;snapshot
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+
       <div className="propertyLabel">&nbsp;</div>
       <div className="property">
-        {!isReadOnly && (
-          <div className="row button">
-            <button type="button" className="delete colored" onClick={onClickDelete}>
-              Remove&nbsp;Holding
-            </button>
-          </div>
-        )}
         <div className="row button">
           <button type="button" onClick={goBackToAccount}>
             Back

--- a/src/client/components/HoldingsComposition/index.tsx
+++ b/src/client/components/HoldingsComposition/index.tsx
@@ -7,14 +7,15 @@ interface Props {
   account: Account;
 }
 
-interface HoldingRow {
+/** Pseudo-ticker for cash holdings. Aggregation key when `isCash` is true,
+ *  regardless of whether the underlying snapshot has a real `ticker_symbol`.
+ *  Reserved — a real security with `ticker_symbol === "__CASH__"` (which we
+ *  treat as unrealistic) would still bucket here. */
+export const CASH_TICKER = "__CASH__";
+
+interface PerSecurityRow {
   holdingId: string;
   securityId: string;
-  /** Snapshot to navigate to on row click. Prefers the snapshot whose date
-   *  matches the current `viewDate`; falls back to the latest snapshot for
-   *  this (account, security) when no exact-date match exists. Null when no
-   *  snapshot has been recorded yet (shouldn't happen if the row rendered). */
-  clickTargetSnapshotId: string | null;
   name: string | null;
   ticker: string | null;
   quantity: number;
@@ -24,7 +25,30 @@ interface HoldingRow {
   unrealizedGain: number | null;
   costBasisInferred: boolean;
   isCash: boolean;
+}
+
+interface TickerRow {
+  /** Aggregation key: real `ticker_symbol` when present (case-folded upper),
+   *  otherwise `CASH_TICKER` for `isCash` rows, otherwise the truncated
+   *  security_id. URL param for the detail page click target. */
+  bucketKey: string;
+  /** Display label — "Cash" for `__CASH__`, the ticker itself otherwise. */
+  primaryLabel: string;
+  /** Secondary line — security name when distinct from the ticker. */
+  secondaryLabel: string | null;
+  /** Title attribute / accessible name. */
+  titleLabel: string;
+  quantity: number;
+  value: number;
+  costBasis: number | null;
+  unrealizedGain: number | null;
+  costBasisInferred: boolean;
+  isCash: boolean;
   pct: number;
+  /** Whether the row routes to the detail page. False only for placeholder
+   *  buckets that have no underlying snapshots (shouldn't happen given the
+   *  filter at construction). */
+  clickable: boolean;
 }
 
 const truncateSecurityId = (id: string) => id.slice(0, 6);
@@ -36,7 +60,7 @@ export const HoldingsComposition = ({ account }: Props) => {
 
   const { calculations, router, viewDate, data } = useAppContext();
   const { holdingsValueData, balanceData } = calculations;
-  const { holdingSnapshots, items, securitySnapshots } = data;
+  const { items, securitySnapshots } = data;
 
   // Every row is clickable and drills into HOLDING_DETAIL. Edit gating
   // lives on the detail page — synced + current viewDate renders read-only
@@ -48,35 +72,14 @@ export const HoldingsComposition = ({ account }: Props) => {
   const latestViewDate = new ViewDate(viewDate.getInterval());
   const isCurrentViewDate = viewEndDate >= latestViewDate.getEndDate();
 
-  // Two lookups per (account, security):
-  //   • latest snapshot — fallback target when no per-viewDate snapshot exists.
-  //   • viewDate-day snapshot — preferred target so the click edits the
-  //     snapshot the user is *looking at*, matching the account-balance
-  //     input which writes to the viewDate's account snapshot.
-  const viewDayString = viewEndDate.toISOString().slice(0, 10);
-  const snapshotIdLookup = useMemo(() => {
-    const latest = new Map<string, { id: string; date: string }>();
-    const byDay = new Map<string, string>();
-    holdingSnapshots.forEach((snap) => {
-      const { account_id: a, security_id: s } = snap.holding;
-      if (a !== account_id) return;
-      const latestKey = `${a}_${s}`;
-      const existing = latest.get(latestKey);
-      if (!existing || snap.snapshot.date > existing.date) {
-        latest.set(latestKey, { id: snap.snapshot.snapshot_id, date: snap.snapshot.date });
-      }
-      const day = snap.snapshot.date.slice(0, 10);
-      byDay.set(`${a}_${s}_${day}`, snap.snapshot.snapshot_id);
-    });
-    return { latest, byDay };
-  }, [account_id, holdingSnapshots]);
-
-  const rows = useMemo<HoldingRow[]>(() => {
+  // First pass: one row per (account, security) at the current viewDate —
+  // the calculation hook's per-holding summary. Same shape as before; the
+  // aggregation step below collapses these into one row per ticker bucket.
+  const perSecurityRows = useMemo<PerSecurityRow[]>(() => {
     const holdingIds = holdingsValueData.getHoldingsForAccount(account_id);
-    const totalValue = holdingsValueData.getAccountTotalValue(account_id, viewEndDate);
 
     return holdingIds
-      .map((holdingId): HoldingRow | null => {
+      .map((holdingId): PerSecurityRow | null => {
         const history = holdingsValueData.getHistory(holdingId);
         const summary = history.get(viewEndDate);
         if (!summary || summary.value === 0) return null;
@@ -102,15 +105,9 @@ export const HoldingsComposition = ({ account }: Props) => {
           }
         });
 
-        const pct = totalValue > 0 ? (value / totalValue) * 100 : 0;
-        const sameDay = snapshotIdLookup.byDay.get(`${account_id}_${security_id}_${viewDayString}`);
-        const latest = snapshotIdLookup.latest.get(`${account_id}_${security_id}`)?.id;
-        const clickTargetSnapshotId = sameDay ?? latest ?? null;
-
         return {
           holdingId,
           securityId: security_id,
-          clickTargetSnapshotId,
           name,
           ticker,
           quantity,
@@ -120,62 +117,100 @@ export const HoldingsComposition = ({ account }: Props) => {
           unrealizedGain,
           costBasisInferred,
           isCash,
-          pct,
         };
       })
-      .filter((r): r is HoldingRow => r !== null)
-      .sort((a, b) => b.value - a.value);
-  }, [
-    account_id,
-    holdingsValueData,
-    viewEndDate,
-    securitySnapshots,
-    snapshotIdLookup,
-    viewDayString,
-  ]);
+      .filter((r): r is PerSecurityRow => r !== null);
+  }, [account_id, holdingsValueData, viewEndDate, securitySnapshots]);
 
-  // Collapse all cash-shape rows into a single "Cash" row at the UI layer.
-  // Plaid sometimes reports the same logical cash position under multiple
-  // `security_id`s over time — each becomes a distinct `holding_id` in the
-  // snapshot store and would otherwise render as a separate "Cash" line.
-  // Aggregating at the FE makes the duplicate invisible to the user; the
-  // data-layer duplication stays untouched (no data loss).
-  const aggregatedRows = useMemo<HoldingRow[]>(() => {
-    const cashRows = rows.filter((r) => r.isCash);
-    const nonCashRows = rows.filter((r) => !r.isCash);
-    if (cashRows.length < 2) return rows;
-    const summed = cashRows.reduce(
-      (acc, r) => ({
-        quantity: acc.quantity + r.quantity,
-        value: acc.value + r.value,
-      }),
-      { quantity: 0, value: 0 },
-    );
-    // No edit target on the aggregate — picking one underlying snapshot
-    // would silently change which row a user is editing. Per-snapshot
-    // edits stay available through the Holding-snapshot list views.
-    const aggregated: HoldingRow = {
-      holdingId: `${account_id}__cash`,
-      securityId: "",
-      clickTargetSnapshotId: null,
-      name: null,
-      ticker: null,
-      quantity: summed.quantity,
-      price: 1,
-      value: summed.value,
-      costBasis: null,
-      unrealizedGain: null,
-      costBasisInferred: false,
-      isCash: true,
-      pct: 0,
-    };
-    return [...nonCashRows, aggregated].sort((a, b) => b.value - a.value);
-  }, [account_id, rows]);
+  // Second pass: bucket per-security rows by ticker. Cash → `__CASH__`
+  // (regardless of any ticker on the underlying security). Real ticker
+  // wins for non-cash. No ticker AND not cash → truncated security_id
+  // (rare; e.g. a Plaid security that never resolved). Sum quantity / value
+  // / cost basis per bucket; cost basis is null if ANY contributing row
+  // lacks it. Unrealized G/L sums when present, else null.
+  const tickerRows = useMemo<TickerRow[]>(() => {
+    interface Acc {
+      quantity: number;
+      value: number;
+      costBasis: number | null; // null if any contributor is null
+      unrealizedGain: number | null; // null if any contributor is null
+      costBasisInferred: boolean; // OR'd across contributors
+      isCash: boolean;
+      // Display fields — keep the first non-null we see.
+      name: string | null;
+      ticker: string | null;
+      securityId: string;
+    }
+    const buckets = new Map<string, Acc>();
 
-  const goToHoldingDetail = (snapshotId?: string) => {
+    perSecurityRows.forEach((row) => {
+      // Cash always wins the bucket; the `__CASH__` pseudo is reserved.
+      // For a (very unlikely) real security whose `ticker_symbol === "__CASH__"`,
+      // the non-cash path falls back to the truncated security_id rather
+      // than colliding with the cash bucket.
+      const tickerUpper = row.ticker?.toUpperCase() ?? null;
+      const bucketKey = row.isCash
+        ? CASH_TICKER
+        : tickerUpper && tickerUpper !== CASH_TICKER
+          ? tickerUpper
+          : truncateSecurityId(row.securityId);
+      const existing = buckets.get(bucketKey);
+      if (!existing) {
+        buckets.set(bucketKey, {
+          quantity: row.quantity,
+          value: row.value,
+          costBasis: row.costBasis,
+          unrealizedGain: row.unrealizedGain,
+          costBasisInferred: row.costBasisInferred,
+          isCash: row.isCash,
+          name: row.name,
+          ticker: row.ticker,
+          securityId: row.securityId,
+        });
+      } else {
+        existing.quantity += row.quantity;
+        existing.value += row.value;
+        existing.costBasis =
+          existing.costBasis !== null && row.costBasis !== null
+            ? existing.costBasis + row.costBasis
+            : null;
+        existing.unrealizedGain =
+          existing.unrealizedGain !== null && row.unrealizedGain !== null
+            ? existing.unrealizedGain + row.unrealizedGain
+            : null;
+        existing.costBasisInferred = existing.costBasisInferred || row.costBasisInferred;
+        if (!existing.name && row.name) existing.name = row.name;
+        if (!existing.ticker && row.ticker) existing.ticker = row.ticker;
+      }
+    });
+
+    return Array.from(buckets.entries()).map(([bucketKey, b]) => {
+      const primaryLabel = b.isCash
+        ? "Cash"
+        : (b.ticker ?? b.name ?? truncateSecurityId(b.securityId));
+      const secondaryLabel = b.isCash ? null : b.ticker ? b.name : null;
+      const titleLabel = b.isCash ? "Cash" : (b.name ?? b.securityId);
+      return {
+        bucketKey,
+        primaryLabel,
+        secondaryLabel,
+        titleLabel,
+        quantity: b.quantity,
+        value: b.value,
+        costBasis: b.costBasis,
+        unrealizedGain: b.unrealizedGain,
+        costBasisInferred: b.costBasisInferred,
+        isCash: b.isCash,
+        pct: 0,
+        clickable: true,
+      };
+    });
+  }, [perSecurityRows]);
+
+  const goToHoldingDetail = (bucketKey?: string) => {
     const params = new URLSearchParams();
     params.set("account_id", account_id);
-    if (snapshotId) params.set("snapshot_id", snapshotId);
+    if (bucketKey) params.set("ticker", bucketKey);
     router.go(PATH.HOLDING_DETAIL, { params });
   };
 
@@ -190,7 +225,7 @@ export const HoldingsComposition = ({ account }: Props) => {
   // (no row); on transient state (just after deploy / before next sync)
   // the Unknown row carries the residual, positive OR negative, so the
   // table's Total still equals the per-view-date account balance either way.
-  const holdingsTotal = aggregatedRows.reduce((s, r) => s + r.value, 0);
+  const holdingsTotal = tickerRows.reduce((s, r) => s + r.value, 0);
   // Per-view-date balance comes from balanceData (the 3-tier-fallback
   // model: account snapshot > holding snapshot > transactions). Falls
   // back to the account's latest `balances.current` only when no data
@@ -202,7 +237,7 @@ export const HoldingsComposition = ({ account }: Props) => {
 
   // For manual accounts we want the section visible even with no rows yet
   // and no balance discrepancy — it hosts the "Add Holding" button.
-  if (aggregatedRows.length === 0 && !showUnknownRow && !isManualAccount) return null;
+  if (tickerRows.length === 0 && !showUnknownRow && !isManualAccount) return null;
 
   // Total = account balance when we have one (preserves Total = balance);
   // otherwise fall back to the holdings sum.
@@ -212,19 +247,18 @@ export const HoldingsComposition = ({ account }: Props) => {
   // basis. The Unknown row has unknown cost by construction, so it
   // disqualifies the total gain. Cash rows have `costBasis = null` by
   // construction, so any account with cash short-circuits this clause.
-  const allRowsHaveCostBasis = aggregatedRows.every((r) => r.costBasis !== null);
+  const allRowsHaveCostBasis = tickerRows.every((r) => r.costBasis !== null);
   const totalCostBasis =
     allRowsHaveCostBasis && !showUnknownRow
-      ? aggregatedRows.reduce((s, r) => s + (r.costBasis ?? 0), 0)
+      ? tickerRows.reduce((s, r) => s + (r.costBasis ?? 0), 0)
       : null;
   const totalGain = totalCostBasis !== null ? totalValue - totalCostBasis : null;
 
   // Per-row pct recomputes against the new totalValue so the column
   // (including the Unknown row, if present) still adds to ~100%.
-  const displayRows = aggregatedRows.map((r) => ({
-    ...r,
-    pct: totalValue > 0 ? (r.value / totalValue) * 100 : 0,
-  }));
+  const displayRows = tickerRows
+    .map((r) => ({ ...r, pct: totalValue > 0 ? (r.value / totalValue) * 100 : 0 }))
+    .sort((a, b) => b.value - a.value);
   const unknownPct = showUnknownRow && totalValue > 0 ? (unknownDiff / totalValue) * 100 : 0;
 
   return (
@@ -237,7 +271,7 @@ export const HoldingsComposition = ({ account }: Props) => {
           <span className="col-gain">Growth</span>
           <span className="col-pct">%</span>
         </div>
-        {aggregatedRows.length === 0 && isManualAccount && (
+        {tickerRows.length === 0 && isManualAccount && (
           <div className="holdingsRow">
             <span className="col-name disabled">No holdings recorded</span>
           </div>
@@ -245,47 +279,31 @@ export const HoldingsComposition = ({ account }: Props) => {
         {displayRows.map((row) => {
           const gainClass =
             row.unrealizedGain === null ? "" : row.unrealizedGain >= 0 ? "positive" : "negative";
-          // Cash holdings get a uniform "Cash" label regardless of how the
-          // broker named the underlying sweep ("QACDS", "Chase Deposit
-          // Sweep", a truncated security_id, etc.) — `securityId` is never
-          // exposed for cash rows.
-          const primaryLabel = row.isCash
-            ? "Cash"
-            : (row.ticker ?? row.name ?? truncateSecurityId(row.securityId));
-          const secondaryLabel = row.isCash ? null : row.ticker ? row.name : null;
-          const titleLabel = row.isCash ? "Cash" : (row.name ?? row.securityId);
-          // Every row with a backing snapshot is clickable; the click goes
-          // to HOLDING_DETAIL with the snapshot for *this* viewDate when one
-          // exists, otherwise the latest snapshot. Edit-vs-read-only is
-          // resolved on the detail page (synced + current = read-only).
-          const clickable = row.clickTargetSnapshotId !== null;
-          const onClickRow = clickable
-            ? () => goToHoldingDetail(row.clickTargetSnapshotId!)
-            : undefined;
-          const onKeyDownRow = clickable
+          const onClickRow = row.clickable ? () => goToHoldingDetail(row.bucketKey) : undefined;
+          const onKeyDownRow = row.clickable
             ? (e: KeyboardEvent) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
-                  goToHoldingDetail(row.clickTargetSnapshotId!);
+                  goToHoldingDetail(row.bucketKey);
                 }
               }
             : undefined;
           return (
             <div
-              key={row.holdingId}
-              className={`holdingsRow${clickable ? " clickable" : ""}`}
+              key={row.bucketKey}
+              className={`holdingsRow${row.clickable ? " clickable" : ""}`}
               onClick={onClickRow}
               onKeyDown={onKeyDownRow}
-              role={clickable ? "button" : undefined}
-              tabIndex={clickable ? 0 : undefined}
+              role={row.clickable ? "button" : undefined}
+              tabIndex={row.clickable ? 0 : undefined}
             >
               <span className="col-name">
-                <span className="security-name" title={titleLabel}>
-                  {primaryLabel}
+                <span className="security-name" title={row.titleLabel}>
+                  {row.primaryLabel}
                 </span>
-                {secondaryLabel && (
-                  <span className="security-fullname" title={titleLabel}>
-                    {secondaryLabel}
+                {row.secondaryLabel && (
+                  <span className="security-fullname" title={row.titleLabel}>
+                    {row.secondaryLabel}
                   </span>
                 )}
               </span>
@@ -331,7 +349,7 @@ export const HoldingsComposition = ({ account }: Props) => {
             <span className="col-pct">{unknownPct.toFixed(1)}%</span>
           </div>
         )}
-        {(aggregatedRows.length > 0 || showUnknownRow) && (
+        {(tickerRows.length > 0 || showUnknownRow) && (
           <div className="holdingsRow total">
             <span className="col-name">Total</span>
             <span className="col-value">
@@ -362,7 +380,7 @@ export const HoldingsComposition = ({ account }: Props) => {
         {!isCurrentViewDate && (
           <div className="holdingsFootnote">Showing {viewDate.toString()} data</div>
         )}
-        {aggregatedRows.some((r) => r.costBasisInferred) && (
+        {tickerRows.some((r) => r.costBasisInferred) && (
           <div className="holdingsFootnote">* Cost basis inferred from transaction history</div>
         )}
       </div>

--- a/src/client/components/HoldingsComposition/index.tsx
+++ b/src/client/components/HoldingsComposition/index.tsx
@@ -146,14 +146,15 @@ export const HoldingsComposition = ({ account }: Props) => {
     perSecurityRows.forEach((row) => {
       // Cash always wins the bucket; the `__CASH__` pseudo is reserved.
       // For a (very unlikely) real security whose `ticker_symbol === "__CASH__"`,
-      // the non-cash path falls back to the truncated security_id rather
-      // than colliding with the cash bucket.
+      // the non-cash path falls back to the FULL security_id (not truncated
+      // — two distinct security_ids whose first 6 chars happen to match
+      // would otherwise silently merge into one bucket).
       const tickerUpper = row.ticker?.toUpperCase() ?? null;
       const bucketKey = row.isCash
         ? CASH_TICKER
         : tickerUpper && tickerUpper !== CASH_TICKER
           ? tickerUpper
-          : truncateSecurityId(row.securityId);
+          : row.securityId;
       const existing = buckets.get(bucketKey);
       if (!existing) {
         buckets.set(bucketKey, {


### PR DESCRIPTION
## Summary

Per Hoie 2026-06-04 Discord direction: replace the per-(account, security_id) rows in HoldingsComposition with one row per ticker symbol, and redesign the holding detail page to show total / avg in the Holding section + a two-row section per underlying snapshot below.

Spec confirmed on Discord (chat 1511828516197503137):
- Real ticker wins as the bucket key for non-cash.
- Cash rows always bucket to `__CASH__` pseudo, regardless of ticker.
- A non-cash row whose ticker happens to be `__CASH__` (very unlikely) falls back to truncated security_id to avoid colliding with the cash bucket.
- URL: `/holding-detail?account_id=X&ticker=Y`. `?snapshot_id=...` retired.
- Detail page: total quantity + cost basis avg in Holding section, then N per-snapshot two-row sections below.

## Changes

- **`HoldingsComposition/index.tsx`** — new two-pass model: (1) per-security rows from the calculation hook (unchanged), (2) aggregate-by-ticker bucketing. Each bucket sums quantity / value / cost basis. URL navigates with `ticker=` instead of `snapshot_id=`.
- **`HoldingProperties/index.tsx`** — reads `?ticker=` instead of `?snapshot_id=`. Resolves all currently-active snapshots for (account, ticker) at viewDate. Holding section shows ticker, name, total quantity, cost basis avg. Below: N per-snapshot two-row sections rendering quantity, cost basis, snapshot date. Each editable per the existing viewDate / manual-account gating (\`isReadOnly = !isManualAccount && isCurrentViewDate\`). Per-section edit state lives in a \`Record<snapshotId, ...>\` so edits stay isolated. The 'Add new holding' flow is unchanged.
- **`HoldingProperties/index.css`** — adds `.snapshotSection` styling.

## Cost basis avg

\`avg = sum(cost_basis) / sum(quantity)\`. Null when any contributing snapshot lacks cost basis OR total quantity is zero. This is the per-share average, which matches how real brokers report it (\$ paid per share across all lots).

## Verification

- \`bun test src\` → **708 pass / 0 fail**.
- \`bun run typecheck\` clean.
- \`bun run lint\` clean.

## Sandbox E2E

Will spin a sandbox right after PR creation. Playwright walk asserts:
- JP Morgan account renders ONE <ticker> row + ONE __CASH__-bucketed Cash row (not separate per-security rows).
- Click <ticker> → detail page shows ticker, name, total quantity at top + one Snapshot section per underlying.
- Click Cash → detail page shows all cash snapshots (<ticker> + <security-id> historical) as separate editable sections.
- Manual account still works.

## Other items spawned by today's investigation (separate work)

- Issue **#471** (filed today, critical) — `deleteHoldings` soft-deletes ALL snapshots for an entire account when called from the sync's removed-holdings path. Latent data-loss bug. Not addressed in this PR.
- Browser Cache API poison on PR #470's downstream — older months serve stale empty `/api/snapshots` responses; manual workaround is \`await window.caches.delete(CACHE_KEY)\` in dev tools. Will file a separate issue for the auto-invalidation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*[Edited 2026-06-04 by daily security review: redacted real holding value, ticker symbols, share quantity, account_id & security_id — budget is a public repo. See ~/claude/memory/reference_security.md.]*