### PR TITLE
fix(accounts): soft-delete orphaned holding snapshots on account delete (#474)

### DIFF
--- a/src/server/lib/postgres/repositories/accounts.test.ts
+++ b/src/server/lib/postgres/repositories/accounts.test.ts
@@ -19,8 +19,14 @@ mock.module("pg", () => ({
   default: { Pool: FakePool, types: { setTypeParser: () => {} } },
 }));
 
-const { getAccounts, getAccount, searchAccounts, searchAccountsById, upsertAccounts } =
-  await import("./accounts");
+const {
+  getAccounts,
+  getAccount,
+  searchAccounts,
+  searchAccountsById,
+  upsertAccounts,
+  deleteAccounts,
+} = await import("./accounts");
 
 afterAll(restoreLeaves);
 
@@ -237,5 +243,31 @@ describe("upsertAccounts", () => {
     const result = await upsertAccounts(testUser, accounts);
     expect(result).toHaveLength(3);
     expect(result.every((r: { status: number }) => r.status === 200)).toBe(true);
+  });
+});
+
+describe("deleteAccounts", () => {
+  test("returns deleted: 0 without querying for empty input", async () => {
+    const result = await deleteAccounts(testUser, []);
+    expect(result).toEqual({ deleted: 0 });
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("soft-deletes snapshots by BOTH account_id and holding_account_id (#474)", async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    await deleteAccounts(testUser, ["acc-del"]);
+
+    // Account-balance snapshots live under `account_id`; holding snapshots
+    // live under `holding_account_id` (their `account_id` is NULL). Both
+    // passes must fire or the holding-snapshot history is orphaned.
+    const snapshotDeletes = mockQuery.mock.calls
+      .map(([sql]) => sql)
+      .filter(
+        (sql): sql is string =>
+          typeof sql === "string" && /UPDATE\s+snapshots\b/i.test(sql) && /is_deleted/i.test(sql),
+      );
+
+    expect(snapshotDeletes.some((sql) => /WHERE\s+account_id\s*=/i.test(sql))).toBe(true);
+    expect(snapshotDeletes.some((sql) => /WHERE\s+holding_account_id\s*=/i.test(sql))).toBe(true);
   });
 });

--- a/src/server/lib/postgres/repositories/accounts.ts
+++ b/src/server/lib/postgres/repositories/accounts.ts
@@ -9,6 +9,7 @@ import {
   snapshotsTable,
   holdingsTable,
   ACCOUNT_ID,
+  HOLDING_ACCOUNT_ID,
   USER_ID,
   ITEM_ID,
   INSTITUTION_ID,
@@ -131,7 +132,11 @@ export const deleteAccounts = async (
         client,
       );
       await splitTransactionsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id, client);
+      // Account-balance snapshots store the account in `account_id`; holding
+      // snapshots store it in `holding_account_id` (their `account_id` is NULL).
+      // Soft-delete both so deleting an account leaves no orphaned holding history.
       await snapshotsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id, client);
+      await snapshotsTable.bulkSoftDeleteByColumn(HOLDING_ACCOUNT_ID, account_id, user_id, client);
       await holdingsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id, client);
     }
 


### PR DESCRIPTION
Closes #474

## Problem
`deleteAccounts` soft-deletes related rows per account, but the snapshots pass only filters on `account_id`:

```ts
await snapshotsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id, client);
```

Holding snapshots store the account in **`holding_account_id`** (their `account_id` column is NULL — same column divergence that broke per-account `/api/snapshots` in #445). So deleting an account leaves every holding snapshot behind:
- `account_id IS NULL` → the cleanup query never matches them
- `holding_account_id = <deleted-account-id>`, `is_deleted = false` → still active

Those orphans are discoverable via `searchSnapshots` after #470, and can leak the deleted account's holdings history into a newly created manual account that collides on the short (5-char hex) manual-provider `account_id`.

## Fix
Add a second `bulkSoftDeleteByColumn` pass keyed on `holding_account_id`, so the cascade covers both snapshot shapes (account-balance + holding):

```ts
await snapshotsTable.bulkSoftDeleteByColumn(ACCOUNT_ID, account_id, user_id, client);
await snapshotsTable.bulkSoftDeleteByColumn(HOLDING_ACCOUNT_ID, account_id, user_id, client);
```

`HOLDING_ACCOUNT_ID` already exists as a constant and is imported the same way by `snapshots.ts`. Sibling of #471 (the *opposite* failure shape — over-deletion in `deleteHoldings`); that one carries an open design question and is intentionally not touched here.

## Testing
- New regression tests in `accounts.test.ts` pin the SQL contract: deleting an account issues a snapshots soft-delete keyed on `account_id` **and** one keyed on `holding_account_id`; empty input short-circuits with no query.
- `bun test accounts.test.ts` → 20 pass / 0 fail.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)