### PR TITLE
fix(holdings): use magnitude of sell quantity in inferCostBasis (#459)

### DIFF
--- a/src/client/lib/hooks/calculation/holdings.test.ts
+++ b/src/client/lib/hooks/calculation/holdings.test.ts
@@ -326,10 +326,11 @@ describe("inferCostBasis", () => {
       "tx1",
       createInvestmentTransaction("acc1", "sec1", InvestmentTransactionType.Buy, 100, 10, "2026-01-10")
     );
-    // Sell 4 @ avg cost $100 = $400 removed
+    // Sell 4 @ avg cost $100 = $400 removed.
+    // Plaid encodes sell quantities as NEGATIVE — use the real shape (-4).
     transactions.set(
       "tx2",
-      createInvestmentTransaction("acc1", "sec1", InvestmentTransactionType.Sell, 120, 4, "2026-01-15")
+      createInvestmentTransaction("acc1", "sec1", InvestmentTransactionType.Sell, 120, -4, "2026-01-15")
     );
 
     const result = inferCostBasis({
@@ -341,6 +342,32 @@ describe("inferCostBasis", () => {
 
     expect(result!.totalQuantity).toBe(6);
     expect(result!.costBasis).toBe(600); // $1000 - $400 = $600
+  });
+
+  test("should reduce (not inflate) basis when a sell uses Plaid's negative quantity", () => {
+    // Regression for #459: a negative sell quantity must remove shares + basis,
+    // not add them. Pre-fix this returned { totalQuantity: 14, costBasis: 1400 }.
+    const transactions = new InvestmentTransactionDictionary();
+    // Buy 10 @ $100 = $1000
+    transactions.set(
+      "tx1",
+      createInvestmentTransaction("acc1", "sec1", InvestmentTransactionType.Buy, 100, 10, "2026-01-10")
+    );
+    // Sell 4 shares — Plaid encodes quantity = -4
+    transactions.set(
+      "tx2",
+      createInvestmentTransaction("acc1", "sec1", InvestmentTransactionType.Sell, 130, -4, "2026-01-15")
+    );
+
+    const result = inferCostBasis({
+      accountId: "acc1",
+      securityId: "sec1",
+      investmentTransactions: transactions,
+      asOfDate: new Date("2026-01-20"),
+    });
+
+    expect(result!.totalQuantity).toBe(6);
+    expect(result!.costBasis).toBe(600);
   });
 
   test("should filter by date", () => {

--- a/src/client/lib/hooks/calculation/holdings.ts
+++ b/src/client/lib/hooks/calculation/holdings.ts
@@ -217,13 +217,16 @@ export const inferCostBasis = ({
       totalCost += cost;
       totalQuantity += quantity;
     } else if (type === InvestmentTransactionType.Sell) {
-      // SELL: reduce quantity using average cost
-      // Average cost per share = totalCost / totalQuantity
+      // SELL: reduce quantity using average cost.
+      // Plaid encodes sell quantities as NEGATIVE, so take the magnitude —
+      // otherwise `-= quantity` would ADD shares and basis back instead of
+      // removing them (cf. benchmark.ts, which already uses -Math.abs for sells).
       if (totalQuantity > 0) {
+        const soldQuantity = Math.abs(quantity);
         const avgCost = totalCost / totalQuantity;
-        const soldCost = avgCost * quantity;
+        const soldCost = avgCost * soldQuantity;
         totalCost -= soldCost;
-        totalQuantity -= quantity;
+        totalQuantity -= soldQuantity;
 
         // Prevent negative from rounding errors
         if (totalQuantity < 0) totalQuantity = 0;


### PR DESCRIPTION
Closes #459

## Problem
`inferCostBasis` (`src/client/lib/hooks/calculation/holdings.ts`) does average-cost inference, but its SELL branch assumed `quantity` is **positive**. Plaid (and our `investment_transactions` table) encode sells with **negative** `quantity`:

```
 type | count |      min      | max
------+-------+---------------+-----
 buy  |    97 |      0.010000 | 30371   (all positive)
 sell |    38 | -26109.010000 | 0       (all negative)
```

With the raw negative quantity, `totalCost -= avgCost * quantity` and `totalQuantity -= quantity` become `-= negative` → they **add** shares and basis instead of removing them. Running the exported function directly:

- Buy 10 @ $100, then sell 4 (Plaid `quantity = -4`)
- Expected: qty 6, basis $600
- **Pre-fix actual: qty 14, basis $[redacted]** — the sell *added* 4 shares and $400.

This feeds the **Unrealized G/L** column in Holdings Composition for any non-cash holding whose broker `cost_basis` is null/0 and that has sell history, inflating the basis and understating/flipping the gain. (Latent on the current snapshot — the only holdings with sells are cash sweeps excluded by the `isCash` gate — but it fires on a normal partial sell of a position the broker didn't report basis for.)

## Fix
Take `Math.abs(quantity)` in the SELL branch — the same convention `benchmark.ts` already uses (`-Math.abs(t.quantity)` for sells). Only `inferCostBasis` had the sign wrong.

## Testing
- Updated the existing "should handle sells using average cost method" test to use the real negative Plaid shape (`-4`); its positive `4` was exactly what masked the bug.
- Added a regression test pinning qty 6 / basis $600 for a `-4` sell (pre-fix this asserted-against value was 14 / 1400).
- `bun test holdings.test.ts` → **34 pass / 0 fail**; `tsc --noEmit` clean; `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

*[Edited 2026-06-28: redacted dollar figures via a retroactive sweep after the daily-security-review's body-scan + shorthand-currency regex gap (found via issue #381 — see channel 1520705621228388514). Original detail removed.]*
