### PR TITLE
fix(holdings): per-snapshot sections lose Properties shell styling — drop the wrapper div

### DIFF
--- a/src/client/components/HoldingProperties/index.css
+++ b/src/client/components/HoldingProperties/index.css
@@ -34,15 +34,11 @@
   padding: 4px 8px;
 }
 
-/* Per-snapshot two-row section under the Holding header in the detail
- * page. One section per underlying snapshot the ticker bucket contains
- * (one VOO snapshot from each contributing date, one CASH snapshot per
- * detected cash position, etc.). */
-.HoldingProperties .snapshotSection {
-  margin-top: 16px;
-}
-
-.HoldingProperties .snapshotSection .snapshotMeta {
+/* Date suffix inside a per-snapshot `.propertyLabel`. The label itself
+ * picks up the canonical `div.Properties > .propertyLabel` styling because
+ * the snapshot's label + property are rendered as direct children of the
+ * `.HoldingProperties Properties` root (no wrapper). */
+.HoldingProperties .propertyLabel .snapshotMeta {
   font-weight: normal;
   font-size: 12px;
   opacity: 0.7;

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, FormEventHandler, useCallback, useEffect, useMemo, useState } from "react";
+import { ChangeEventHandler, Fragment, FormEventHandler, useCallback, useEffect, useMemo, useState } from "react";
 import { ItemProvider, numberToCommaString, ViewDate } from "common";
 import {
   call,
@@ -605,8 +605,16 @@ export const HoldingProperties = () => {
         };
         const setEdit = (patch: Partial<typeof edit>) =>
           setSnapEdits((prev) => ({ ...prev, [id]: { ...edit, ...patch } }));
+        // Render the propertyLabel + property as DIRECT children of the
+        // `.HoldingProperties Properties` root — the canonical Properties
+        // shell rules use `div.Properties > .propertyLabel` and
+        // `div.Properties > .property` (direct-child selectors), so wrapping
+        // them in another <div> strips the background, border-radius,
+        // bottom-margin, label font-sizing, and first/last row padding.
+        // Use `<Fragment>` to give the map element a key without adding
+        // a DOM wrapper.
         return (
-          <div key={id} className="snapshotSection">
+          <Fragment key={id}>
             <div className="propertyLabel">
               Snapshot&nbsp;{idx + 1}
               <span className="snapshotMeta">&nbsp;·&nbsp;{toIsoDateInput(snap.snapshot.date)}</span>
@@ -664,7 +672,7 @@ export const HoldingProperties = () => {
                 </div>
               )}
             </div>
-          </div>
+          </Fragment>
         );
       })}
 


### PR DESCRIPTION
## Summary

Hoie reported via Discord 2026-06-04 15:02 that the merged PR #472 has broken styling on the FE. Diagnosed by reading the CSS:

PR #472 wrapped each per-snapshot section in:

\`\`\`tsx
<div key={id} className=\"snapshotSection\">
  <div className=\"propertyLabel\">Snapshot N · date</div>
  <div className=\"property\">…</div>
</div>
\`\`\`

The canonical Properties shell (`src/client/components/App/index.css:381+`) uses **direct-child selectors**:

\`\`\`css
div.Properties > .propertyLabel { font-size: 14px; padding: 5px; }
div.Properties > .property { background-color: #292929; border-radius: 5px; overflow: hidden; }
div.Properties > .property:not(:last-child) { margin-bottom: 20px; }
\`\`\`

With the wrapper present, the per-snapshot `.propertyLabel` and `.property` are no longer direct children of `.HoldingProperties Properties`. They lose:
- background-color #292929
- border-radius 5px
- 20px bottom-margin between adjacent sections
- 14px font-size on the label
- The `.row:first-child` 16px top-padding / `.row:last-child` 18px bottom-padding cascades still apply (descendant selectors), but the section frame itself is missing — looks like raw rows floating on the page background.

(The top-level `<div className=\"property\">` for the Holding header and the bottom Back-button block were rendered correctly because they're already direct children of the root.)

## Fix

Render each per-snapshot pair as a `<Fragment key={id}>` so the label + property become direct children of the Properties root. No DOM wrapper.

CSS: drop the `.snapshotSection` rule (no longer present in the tree) and re-scope the `.snapshotMeta` selector to `.HoldingProperties .propertyLabel .snapshotMeta` so the date suffix inside the label still gets the lighter font-weight / smaller font-size / 0.7 opacity.

## Why the reviewer pass on #472 missed this

The PR added the wrapper element + matching CSS rules in the same commit. The reviewer agent checked the rules in isolation (`.snapshotSection { margin-top: 16px }` exists, `.snapshotMeta` is reachable) and that the test suite passed — but the **shell parent rules dropped silently** because the new wrapper interrupted the `>` chain. This is the canonical \"wrapper component breaking `>` direct-child CSS selector silently\" Principle-1 trap recorded in `feedback_hoie_review_patterns.md`. The lesson: when adding a wrapping `<div>` inside a Properties shell, always verify the diff doesn't break any `div.Properties > .X` rule. I'll save it to memory after merge.

## Diff

- `src/client/components/HoldingProperties/index.tsx` — import `Fragment` from React; replace the `<div className=\"snapshotSection\">` with `<Fragment key={id}>`. Comment block explaining the direct-child rule + why no wrapper.
- `src/client/components/HoldingProperties/index.css` — remove `.snapshotSection { margin-top: 16px }`; rewrite `.snapshotMeta` rule to scope under `.HoldingProperties .propertyLabel` (since `.snapshotSection` no longer exists in the DOM).

## Verification

- `bun test src` → **708 pass / 0 fail** (no test-suite delta).
- `bun run typecheck` clean.
- `bun run lint` clean.
- Sandbox spin will land alongside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)