### PR TITLE
feat(client): add Properties shell components + migrate ConnectionProperties + HoldingProperties (#326 Phase 2)

### DIFF
--- a/src/client/components/App/index.css
+++ b/src/client/components/App/index.css
@@ -378,90 +378,11 @@ div.Router:not(.transitioning.backward) > div.currentPage {
   transform: rotate(270deg);
 }
 
-div.Properties {
-  margin-top: 20px;
-}
-
-div.Properties button:disabled {
-  background-color: inherit;
-  color: #474747;
-  border: none;
-}
-
-div.Properties > .propertyLabel {
-  font-size: 14px;
-  padding: 5px;
-}
-
-div.Properties > .property {
-  background-color: #292929;
-  border-radius: 5px;
-  overflow: hidden;
-}
-
-div.Properties > .property:not(:last-child) {
-  margin-bottom: 20px;
-}
-
-div.Properties > .property .disabled.lineThrough {
-  color: #858585;
-  text-decoration: line-through;
-}
-
-div.Properties .row {
-  padding: 14px 10px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-div.Properties .row button.delete {
-  font-weight: 500;
-  color: var(--darkRed);
-}
-
-div.Properties .row:not(:last-child) {
-  border-bottom: 1px solid #474747;
-}
-
-div.Properties .row:first-child {
-  padding-top: 16px;
-}
-
-div.Properties .row:last-child {
-  padding-bottom: 18px;
-}
-
-div.Properties .row span.small {
-  color: #858585;
-  font-size: 12px;
-}
-
-div.Properties .row select {
-  font-size: 14px;
-}
-
-div.Properties .row input {
-  font-size: 16px;
-  height: 18px;
-  text-align: right;
-}
-
-div.Properties .row.keyValue span.propertyName {
-  color: #858585;
-}
-
-div.Properties .row > button {
-  width: 100%;
-  text-align: left;
-  font-size: 16px;
-  margin-left: -4px;
-  background-color: transparent;
-}
-
-div.Properties .row.button:hover {
-  background-color: #383838;
-}
+/* Properties shell rules moved to src/client/components/Properties/index.css
+ * 2026-06-04 (#326 componentization). The styling now ships with the
+ * <Properties> component import — every `div.Properties …` rule is co-
+ * located with the shell. Consumers go through <Properties> / <Property>
+ * / <PropertyLabel> / <Row> instead of hand-classed divs. */
 
 .sidePadding {
   padding-right: 10px;

--- a/src/client/components/ConnectionProperties/ConnectedAccountRow.tsx
+++ b/src/client/components/ConnectionProperties/ConnectedAccountRow.tsx
@@ -1,6 +1,6 @@
 import { MouseEventHandler } from "react";
 import { ItemProvider, toTitleCase } from "common";
-import { Account, Item, PATH, useAppContext } from "client";
+import { Account, Item, PATH, Property, Row, useAppContext } from "client";
 
 interface Props {
   item: Item;
@@ -20,24 +20,24 @@ export const ConnectedAccountRow = ({ item, account }: Props) => {
   };
 
   return (
-    <div className="property">
-      <div className="row keyValue">
+    <Property>
+      <Row className="keyValue">
         <span className="propertyName">Name</span>
         <span>{custom_name || name}</span>
-      </div>
-      <div className="row keyValue">
+      </Row>
+      <Row className="keyValue">
         <span className="propertyName">Type</span>
         <span>{toTitleCase(type)}</span>
-      </div>
+      </Row>
       {!isManualItem && !!subtype && (
-        <div className="row keyValue">
+        <Row className="keyValue">
           <span className="propertyName">Subtype</span>
           <span>{toTitleCase(subtype)}</span>
-        </div>
+        </Row>
       )}
-      <div className="row button">
+      <Row className="button">
         <button onClick={onClickDetails}>See&nbsp;Details</button>
-      </div>
-    </div>
+      </Row>
+    </Property>
   );
 };

--- a/src/client/components/ConnectionProperties/index.tsx
+++ b/src/client/components/ConnectionProperties/index.tsx
@@ -11,6 +11,10 @@ import {
   call,
   InstitutionSpan,
   PlaidLinkButton,
+  Properties,
+  PropertyLabel,
+  Property,
+  Row,
   useAppContext,
   indexedDb,
   StoreName,
@@ -35,9 +39,7 @@ export const ConnectionProperties = ({ item }: Props) => {
       let propertyLabel = isManualItem ? "Manual Account" : "Connected Account";
       if (length > 1) propertyLabel += ` ${i + 1}`;
       return [
-        <div className="propertyLabel" key={`${id}_label`}>
-          {propertyLabel}
-        </div>,
+        <PropertyLabel key={`${id}_label`}>{propertyLabel}</PropertyLabel>,
         <ConnectedAccountRow key={id} item={item} account={account} />,
       ];
     });
@@ -126,48 +128,48 @@ export const ConnectionProperties = ({ item }: Props) => {
   };
 
   return (
-    <div className="ConnectionProperties Properties">
-      <div className="propertyLabel">Connection&nbsp;Detail</div>
-      <div className="property">
+    <Properties className="ConnectionProperties">
+      <PropertyLabel>Connection&nbsp;Detail</PropertyLabel>
+      <Property>
         {!!institution_id && (
-          <div className="row keyValue">
+          <Row className="keyValue">
             <span className="propertyName">Institution</span>
             <InstitutionSpan institution_id={institution_id} />
-          </div>
+          </Row>
         )}
-        <div className="row keyValue">
+        <Row className="keyValue">
           <span className="propertyName">Last&nbsp;Updated</span>
           <span>{updated || "Unknown"}</span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Status</span>
           <span>{status ? toTitleCase(status) : "Unknown"}</span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Connection&nbsp;Provider</span>
           <span>{toUpperCamelCase(provider)}</span>
-        </div>
-      </div>
+        </Row>
+      </Property>
       {accountRows}
-      <div className="propertyLabel">&nbsp;</div>
-      <div className="property">
+      <PropertyLabel>&nbsp;</PropertyLabel>
+      <Property>
         {provider === ItemProvider.PLAID && (
-          <div className="row button">
+          <Row className="button">
             <PlaidLinkButton item={item}>Update</PlaidLinkButton>
-          </div>
+          </Row>
         )}
         {provider === ItemProvider.MANUAL ? (
-          <div className="row button">
+          <Row className="button">
             <button onClick={onClickAddManualAccount}>Add&nbsp;Account</button>
-          </div>
+          </Row>
         ) : (
-          <div className="row button">
+          <Row className="button">
             <button className="delete colored" onClick={onClickRemove}>
               Delete
             </button>
-          </div>
+          </Row>
         )}
-      </div>
-    </div>
+      </Property>
+    </Properties>
   );
 };

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -9,6 +9,10 @@ import {
   Holding,
   HoldingSnapshot,
   HoldingSnapshotDictionary,
+  Properties,
+  PropertyLabel,
+  Property,
+  Row,
   indexedDb,
   StoreName,
 } from "client";
@@ -467,133 +471,139 @@ export const HoldingProperties = () => {
 
   if (!accountId) {
     return (
-      <div className="HoldingProperties Properties">
-        <div className="propertyLabel">Holding</div>
-        <div className="property">
-          <div className="row keyValue">
+      <Properties className="HoldingProperties">
+        <PropertyLabel>Holding</PropertyLabel>
+        <Property>
+          <Row className="keyValue">
             <span className="propertyName">Missing&nbsp;account&nbsp;context</span>
             <span></span>
-          </div>
-        </div>
-      </div>
+          </Row>
+        </Property>
+      </Properties>
     );
   }
 
   if (isNew) {
     return (
-      <div className="HoldingProperties Properties">
-        <div className="propertyLabel">New&nbsp;Holding</div>
-        <form className="property" onSubmit={onSubmitNew}>
-          <div className="row keyValue">
-            <span className="propertyName">Ticker</span>
-            <div className="tickerField">
+      <Properties className="HoldingProperties">
+        <PropertyLabel>New&nbsp;Holding</PropertyLabel>
+        {/* The `<Property>` wrapper keeps the `.property` styling on a
+            direct child of `<Properties>`. The inner `<form>` carries the
+            submit handler but doesn't need any class — `<Row>` rules
+            cascade via descendant selectors. */}
+        <Property>
+          <form onSubmit={onSubmitNew}>
+            <Row className="keyValue">
+              <span className="propertyName">Ticker</span>
+              <div className="tickerField">
+                <input
+                  type="text"
+                  placeholder="e.g. AAPL"
+                  value={form.ticker}
+                  onChange={onChangeField("ticker")}
+                  autoCapitalize="characters"
+                />
+                <button type="button" className="validateBtn" onClick={onValidateTicker}>
+                  {tickerStatus === "validating" ? "…" : "Check"}
+                </button>
+              </div>
+            </Row>
+            {tickerMessage && (
+              <Row className={`tickerFeedback ${tickerStatus}`}>{tickerMessage}</Row>
+            )}
+            <Row className="keyValue">
+              <span className="propertyName">Quantity</span>
               <input
-                type="text"
-                placeholder="e.g. AAPL"
-                value={form.ticker}
-                onChange={onChangeField("ticker")}
-                autoCapitalize="characters"
+                type="number"
+                placeholder="0"
+                min="0"
+                step="any"
+                value={form.quantity}
+                onChange={onChangeField("quantity")}
               />
-              <button type="button" className="validateBtn" onClick={onValidateTicker}>
-                {tickerStatus === "validating" ? "…" : "Check"}
+            </Row>
+            <Row className="keyValue">
+              <span className="propertyName">Cost&nbsp;basis&nbsp;(opt)</span>
+              <input
+                type="number"
+                placeholder="Total $ paid (all shares)"
+                min="0"
+                step="any"
+                value={form.costBasis}
+                onChange={onChangeField("costBasis")}
+              />
+            </Row>
+            <Row className="keyValue">
+              <span className="propertyName">Snapshot&nbsp;date</span>
+              <input
+                type="date"
+                value={snapshotDateInput}
+                onChange={(e) => setSnapshotDateInput(e.target.value)}
+              />
+            </Row>
+            {submitError && <Row className="formError">{submitError}</Row>}
+            <Row className="button">
+              <button type="submit" className="colored">
+                Add
               </button>
-            </div>
-          </div>
-          {tickerMessage && (
-            <div className={`row tickerFeedback ${tickerStatus}`}>{tickerMessage}</div>
-          )}
-          <div className="row keyValue">
-            <span className="propertyName">Quantity</span>
-            <input
-              type="number"
-              placeholder="0"
-              min="0"
-              step="any"
-              value={form.quantity}
-              onChange={onChangeField("quantity")}
-            />
-          </div>
-          <div className="row keyValue">
-            <span className="propertyName">Cost&nbsp;basis&nbsp;(opt)</span>
-            <input
-              type="number"
-              placeholder="Total $ paid (all shares)"
-              min="0"
-              step="any"
-              value={form.costBasis}
-              onChange={onChangeField("costBasis")}
-            />
-          </div>
-          <div className="row keyValue">
-            <span className="propertyName">Snapshot&nbsp;date</span>
-            <input
-              type="date"
-              value={snapshotDateInput}
-              onChange={(e) => setSnapshotDateInput(e.target.value)}
-            />
-          </div>
-          {submitError && <div className="row formError">{submitError}</div>}
-          <div className="row button">
-            <button type="submit" className="colored">
-              Add
-            </button>
-          </div>
-          <div className="row button">
-            <button type="button" onClick={goBackToAccount}>
-              Cancel
-            </button>
-          </div>
-        </form>
-      </div>
+            </Row>
+            <Row className="button">
+              <button type="button" onClick={goBackToAccount}>
+                Cancel
+              </button>
+            </Row>
+          </form>
+        </Property>
+      </Properties>
     );
   }
 
   if (loadError) {
     return (
-      <div className="HoldingProperties Properties">
-        <div className="propertyLabel">Holding</div>
-        <div className="property">
-          <div className="row formError">{loadError}</div>
-        </div>
-        <div className="propertyLabel">&nbsp;</div>
-        <div className="property">
-          <div className="row button">
+      <Properties className="HoldingProperties">
+        <PropertyLabel>Holding</PropertyLabel>
+        <Property>
+          <Row className="formError">{loadError}</Row>
+        </Property>
+        <PropertyLabel>&nbsp;</PropertyLabel>
+        <Property>
+          <Row className="button">
             <button type="button" onClick={goBackToAccount}>
               Back
             </button>
-          </div>
-        </div>
-      </div>
+          </Row>
+        </Property>
+      </Properties>
     );
   }
 
   return (
-    <div className="HoldingProperties Properties">
-      <div className="propertyLabel">Holding</div>
-      <div className="property">
-        <div className="row keyValue">
+    <Properties className="HoldingProperties">
+      <PropertyLabel>Holding</PropertyLabel>
+      <Property>
+        <Row className="keyValue">
           <span className="propertyName">Ticker</span>
           <span>{bucketInfo.primaryLabel}</span>
-        </div>
+        </Row>
         {bucketInfo.name && (
-          <div className="row keyValue">
+          <Row className="keyValue">
             <span className="propertyName">Name</span>
             <span>{bucketInfo.name}</span>
-          </div>
+          </Row>
         )}
-        <div className="row keyValue">
+        <Row className="keyValue">
           <span className="propertyName">Quantity</span>
           <span>{numberToCommaString(aggregate.totalQuantity, 4)}</span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Cost&nbsp;basis&nbsp;(avg)</span>
           <span>
             {aggregate.avgCostBasis !== null
               ? numberToCommaString(aggregate.avgCostBasis, 4)
               : "—"}
           </span>
-        </div>
-      </div>
+        </Row>
+      </Property>
 
       {bucketSnapshots.map((snap, idx) => {
         const id = snap.snapshot.snapshot_id;
@@ -605,22 +615,17 @@ export const HoldingProperties = () => {
         };
         const setEdit = (patch: Partial<typeof edit>) =>
           setSnapEdits((prev) => ({ ...prev, [id]: { ...edit, ...patch } }));
-        // Render the propertyLabel + property as DIRECT children of the
-        // `.HoldingProperties Properties` root — the canonical Properties
-        // shell rules use `div.Properties > .propertyLabel` and
-        // `div.Properties > .property` (direct-child selectors), so wrapping
-        // them in another <div> strips the background, border-radius,
-        // bottom-margin, label font-sizing, and first/last row padding.
-        // Use `<Fragment>` to give the map element a key without adding
-        // a DOM wrapper.
+        // <Fragment> keeps the per-snapshot <PropertyLabel> + <Property>
+        // pair as DIRECT children of <Properties> — no wrapper div. See
+        // PR #478 for the regression this guards against.
         return (
           <Fragment key={id}>
-            <div className="propertyLabel">
+            <PropertyLabel>
               Snapshot&nbsp;{idx + 1}
               <span className="snapshotMeta">&nbsp;·&nbsp;{toIsoDateInput(snap.snapshot.date)}</span>
-            </div>
-            <div className="property">
-              <div className="row keyValue">
+            </PropertyLabel>
+            <Property>
+              <Row className="keyValue">
                 <span className="propertyName">Quantity</span>
                 {isReadOnly ? (
                   <span>{edit.quantity || "—"}</span>
@@ -634,8 +639,8 @@ export const HoldingProperties = () => {
                     onBlur={onBlurQuantity(snap, edit.quantity)}
                   />
                 )}
-              </div>
-              <div className="row keyValue">
+              </Row>
+              <Row className="keyValue">
                 <span className="propertyName">Cost&nbsp;basis</span>
                 {isReadOnly ? (
                   <span>{edit.costBasis || "—"}</span>
@@ -649,8 +654,8 @@ export const HoldingProperties = () => {
                     onBlur={onBlurCostBasis(snap, edit.costBasis)}
                   />
                 )}
-              </div>
-              <div className="row keyValue">
+              </Row>
+              <Row className="keyValue">
                 <span className="propertyName">Snapshot&nbsp;date</span>
                 {isReadOnly ? (
                   <span>{edit.date || "—"}</span>
@@ -662,28 +667,28 @@ export const HoldingProperties = () => {
                     onBlur={onBlurDate(snap, edit.date)}
                   />
                 )}
-              </div>
-              {edit.error && <div className="row formError">{edit.error}</div>}
+              </Row>
+              {edit.error && <Row className="formError">{edit.error}</Row>}
               {!isReadOnly && (
-                <div className="row button">
+                <Row className="button">
                   <button type="button" className="delete colored" onClick={onClickDeleteSnap(snap)}>
                     Remove&nbsp;this&nbsp;snapshot
                   </button>
-                </div>
+                </Row>
               )}
-            </div>
+            </Property>
           </Fragment>
         );
       })}
 
-      <div className="propertyLabel">&nbsp;</div>
-      <div className="property">
-        <div className="row button">
+      <PropertyLabel>&nbsp;</PropertyLabel>
+      <Property>
+        <Row className="button">
           <button type="button" onClick={goBackToAccount}>
             Back
           </button>
-        </div>
-      </div>
-    </div>
+        </Row>
+      </Property>
+    </Properties>
   );
 };

--- a/src/client/components/Properties/index.css
+++ b/src/client/components/Properties/index.css
@@ -1,0 +1,93 @@
+/* Canonical Properties shell. Moved from App/index.css 2026-06-04 to
+ * co-locate with the <Properties> / <PropertyLabel> / <Property> / <Row>
+ * components in this directory.
+ *
+ * 🔴 The `> .propertyLabel` / `> .property` selectors are DIRECT-CHILD —
+ * any wrapper between <Properties> and its label/property children strips
+ * the section frame. That's the failure mode #326 / #472 / PR #478 surfaced
+ * and the reason every Properties use must go through the typed component. */
+
+div.Properties {
+  margin-top: 20px;
+}
+
+div.Properties button:disabled {
+  background-color: inherit;
+  color: #474747;
+  border: none;
+}
+
+div.Properties > .propertyLabel {
+  font-size: 14px;
+  padding: 5px;
+}
+
+div.Properties > .property {
+  background-color: #292929;
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+div.Properties > .property:not(:last-child) {
+  margin-bottom: 20px;
+}
+
+div.Properties > .property .disabled.lineThrough {
+  color: #858585;
+  text-decoration: line-through;
+}
+
+div.Properties .row {
+  padding: 14px 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+div.Properties .row button.delete {
+  font-weight: 500;
+  color: var(--darkRed);
+}
+
+div.Properties .row:not(:last-child) {
+  border-bottom: 1px solid #474747;
+}
+
+div.Properties .row:first-child {
+  padding-top: 16px;
+}
+
+div.Properties .row:last-child {
+  padding-bottom: 18px;
+}
+
+div.Properties .row span.small {
+  color: #858585;
+  font-size: 12px;
+}
+
+div.Properties .row select {
+  font-size: 14px;
+}
+
+div.Properties .row input {
+  font-size: 16px;
+  height: 18px;
+  text-align: right;
+}
+
+div.Properties .row.keyValue span.propertyName {
+  color: #858585;
+}
+
+div.Properties .row > button {
+  width: 100%;
+  text-align: left;
+  font-size: 16px;
+  margin-left: -4px;
+  background-color: transparent;
+}
+
+div.Properties .row.button:hover {
+  background-color: #383838;
+}

--- a/src/client/components/Properties/index.tsx
+++ b/src/client/components/Properties/index.tsx
@@ -1,0 +1,69 @@
+import { ComponentPropsWithoutRef } from "react";
+import "./index.css";
+
+type PropertiesProps = ComponentPropsWithoutRef<"div">;
+
+/**
+ * Properties shell. Wrap a screen's property list in `<Properties>` and the
+ * children render against the canonical shell styling (#292929 box,
+ * 5px radius, label font-sizing, row spacing, etc.).
+ *
+ * `className` is merged in front of the reserved `"Properties"` token to
+ * preserve the existing convention: `<div class="<Foo>Properties Properties">`.
+ * Drop in as `<Properties className="HoldingProperties">…</Properties>`.
+ *
+ * 🔴 Children MUST be direct `<PropertyLabel>` / `<Property>` pairs. Do NOT
+ * wrap groups of children in an extra `<div>` — the shell CSS uses
+ * `div.Properties > .propertyLabel` and `div.Properties > .property`
+ * direct-child selectors, so any intermediate wrapper strips the section
+ * frame (PR #472 regression caught 2026-06-04). Use `<React.Fragment>` if
+ * you need to render an array of label/property pairs from a `.map`.
+ */
+export const Properties = ({ className, children, ...rest }: PropertiesProps) => {
+  const merged = className ? `${className} Properties` : "Properties";
+  return (
+    <div className={merged} {...rest}>
+      {children}
+    </div>
+  );
+};
+
+type PropertyLabelProps = ComponentPropsWithoutRef<"div">;
+
+/** A `.propertyLabel` direct child of `<Properties>`. Renders the section
+ *  title above its sibling `<Property>` box. */
+export const PropertyLabel = ({ className, children, ...rest }: PropertyLabelProps) => {
+  const merged = className ? `propertyLabel ${className}` : "propertyLabel";
+  return (
+    <div className={merged} {...rest}>
+      {children}
+    </div>
+  );
+};
+
+type PropertyProps = ComponentPropsWithoutRef<"div">;
+
+/** A `.property` direct child of `<Properties>`. Renders the boxed section
+ *  containing rows. Children should be `<Row>` (or any `.row`-classed div). */
+export const Property = ({ className, children, ...rest }: PropertyProps) => {
+  const merged = className ? `property ${className}` : "property";
+  return (
+    <div className={merged} {...rest}>
+      {children}
+    </div>
+  );
+};
+
+type RowProps = ComponentPropsWithoutRef<"div">;
+
+/** A `.row` inside `<Property>`. `className` is merged AFTER `row` so
+ *  variant tokens like `"keyValue"` / `"button"` / `"formError"` compose
+ *  naturally: `<Row className="keyValue">` → `<div class="row keyValue">`. */
+export const Row = ({ className, children, ...rest }: RowProps) => {
+  const merged = className ? `row ${className}` : "row";
+  return (
+    <div className={merged} {...rest}>
+      {children}
+    </div>
+  );
+};

--- a/src/client/components/index.ts
+++ b/src/client/components/index.ts
@@ -1,5 +1,6 @@
 export * from "./App";
 export * from "./Page";
+export * from "./Properties";
 export * from "./HoldingProperties";
 export * from "./ErrorBoundary";
 export * from "./PlaidLinkContext";


### PR DESCRIPTION
## Summary

Hoie 2026-06-04 Discord: *\"this issue can be prevented by componentizing — open an equivalent PR for properties.\"* The equivalent of #473's `<Page>` componentization, for the Properties shell.

The motivating bug is the one PR #478 just fixed: wrapping a section in `<div className=\"snapshotSection\">` broke the canonical Properties shell's `div.Properties > .property` direct-child selectors, silently stripping the dark-gray box / radius / margin frame. Routing every Properties use through typed components — where the component bodies render the relevant class directly on a single div with no intermediate wrapper — makes that failure mode unreachable by construction.

## API

```tsx
import { Properties, PropertyLabel, Property, Row } from \"client\";

<Properties className=\"HoldingProperties\">
  <PropertyLabel>Holding</PropertyLabel>
  <Property>
    <Row className=\"keyValue\">
      <span className=\"propertyName\">Ticker</span>
      <span>{ticker}</span>
    </Row>
    <Row className=\"button\">
      <button onClick={onClick}>Save</button>
    </Row>
  </Property>
</Properties>
```

- `<Properties className=\"X\">` → `<div class=\"X Properties\">` (specific-class first, mirroring the existing `<Foo>Properties Properties` convention so existing call sites don't need to flip).
- `<PropertyLabel>` → `<div class=\"propertyLabel\">`.
- `<Property>` → `<div class=\"property\">`.
- `<Row className=\"X\">` → `<div class=\"row X\">` — variant tokens (`keyValue` / `button` / `formError` / `tickerFeedback`) compose as className suffixes.

Each component renders **exactly one div** with the relevant class and the children inside. **No wrapper.** That's the whole point.

## CSS

The 80-line `div.Properties …` block moves from `App/index.css` to `Properties/index.css` (co-located with the components, mirroring what #473 did for the Page padding rule). No selector or rule changes — pure relocation. App/index.css gets a 3-line breadcrumb comment.

## Phase 2 migrations (in this PR)

- **ConnectionProperties** + **ConnectedAccountRow** — small, single-render-branch consumer. Validates the basic `<Properties>` / `<Property>` / `<Row>` shape.
- **HoldingProperties** — 4 render branches including the per-snapshot `.map` block from #472 (kept the `<Fragment>` shape from #478, just routed through `<PropertyLabel>` + `<Property>` typed components). The `isNew` form-element branch keeps its `<form onSubmit>` as a child of `<Property>` — the form's submit semantics are preserved; the `.property` styling sits on the wrapping div.

## Phase 3 (NOT in this PR; #326 stays open)

Per Hoie's direction *\"don't close the issue until componentize all common components\"*, four more consumers remain:

- **AccountProperties** — has additional `.property > .row > .amount` rules in own css.
- **BudgetProperties** — has additional `.RadioInputs` rules + sub-components.
- **ApiKeyProperties** — has additional `.apiKeyError` styling + 5 render branches.
- **TransactionProperties** — has additional `.row > .splitItem` rules + sub-component.

Each migration needs verification that the per-component className is preserved alongside `Properties` (analogous to the #473 reviewer note about BudgetConfigPage's `.title` rules). Splitting them out keeps Phase 2 reviewable in isolation.

The other componentization candidate the #473 PR body flagged — the list-page sticky `<h2>` block on Accounts/Budgets/Dashboard — is also still open under #326.

## Verification

- `bun test src` → **708 pass / 0 fail**.
- `bun run typecheck` clean.
- `bun run lint` clean.
- Sandbox spin lands alongside this PR (visual diff vs. main on the JP Morgan detail page + connection detail).

Part 2 of #326. Issue stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)