### PR TITLE
fix(holdings): label suffix shows security_id + propagate snapshot deletes across cache layers

### DIFF
--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -620,9 +620,14 @@ export const HoldingProperties = () => {
         // PR #478 for the regression this guards against.
         return (
           <Fragment key={id}>
+            {/* Suffix is `security_id` — sections are grouped by security
+                so this is the distinguishing identity. NOT the snapshot
+                date (misread as "same holding, different dates" and made
+                summing look wrong) and NOT the holding_id (a composite
+                that repeats the account_id across every section). */}
             <PropertyLabel>
               Snapshot&nbsp;{idx + 1}
-              <span className="snapshotMeta">&nbsp;·&nbsp;{toIsoDateInput(snap.snapshot.date)}</span>
+              <span className="snapshotMeta">&nbsp;·&nbsp;{snap.holding.security_id}</span>
             </PropertyLabel>
             <Property>
               <Row className="keyValue">

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -52,6 +52,7 @@ import {
   Institution,
   useDebounce,
   indexedDb,
+  StoreName,
   HoldingDictionary,
   Holding,
   SecurityDictionary,
@@ -311,6 +312,23 @@ const fetchSnapshots = async (
   };
 
   const ingestSnapshot = (snapshot: JSONSnapshotData) => {
+    // Tombstone — the server marked this row `is_deleted=true`. Skip
+    // the dict insert AND evict the id from IDB so the persistent store
+    // converges with the server. Without this, additive `saveAllData`
+    // can leave a stale row behind whenever the deletion was made on a
+    // different device (or the local delete handler's `indexedDb.remove`
+    // call lost the race against an in-flight sync).
+    if (snapshot.snapshot.is_deleted) {
+      const id = snapshot.snapshot.snapshot_id;
+      const store =
+        "account" in snapshot
+          ? StoreName.accountSnapshots
+          : "holding" in snapshot
+            ? StoreName.holdingSnapshots
+            : StoreName.securitySnapshots;
+      indexedDb.remove(store, id).catch(console.error);
+      return;
+    }
     if ("account" in snapshot) {
       const account = accounts.get(snapshot.account.account_id) || {};
       snapshot.account = { ...account, ...snapshot.account };

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -311,22 +311,22 @@ const fetchSnapshots = async (
     networkFailed: false,
   };
 
+  // Tombstones collected from any month's response. Applied at the end
+  // so the eviction wins regardless of which parallel response arrived
+  // last — without this, a tombstone from June's live query loses to a
+  // cached older-month response that still has the row as active.
+  const tombstones = {
+    account: new Set<string>(),
+    holding: new Set<string>(),
+    security: new Set<string>(),
+  };
+
   const ingestSnapshot = (snapshot: JSONSnapshotData) => {
-    // Tombstone — the server marked this row `is_deleted=true`. Skip
-    // the dict insert AND evict the id from IDB so the persistent store
-    // converges with the server. Without this, additive `saveAllData`
-    // can leave a stale row behind whenever the deletion was made on a
-    // different device (or the local delete handler's `indexedDb.remove`
-    // call lost the race against an in-flight sync).
     if (snapshot.snapshot.is_deleted) {
       const id = snapshot.snapshot.snapshot_id;
-      const store =
-        "account" in snapshot
-          ? StoreName.accountSnapshots
-          : "holding" in snapshot
-            ? StoreName.holdingSnapshots
-            : StoreName.securitySnapshots;
-      indexedDb.remove(store, id).catch(console.error);
+      if ("account" in snapshot) tombstones.account.add(id);
+      else if ("holding" in snapshot) tombstones.holding.add(id);
+      else if ("security" in snapshot) tombstones.security.add(id);
       return;
     }
     if ("account" in snapshot) {
@@ -415,6 +415,24 @@ const fetchSnapshots = async (
   }
 
   await Promise.all(promises);
+
+  // Apply tombstones after every parallel ingest has landed: drop the
+  // id from the dict (in case a stale cachedCall response re-added it)
+  // AND evict from IDB. Order matters — the dict-delete must happen
+  // before the consumer hands the dict to `saveAllData`, which would
+  // otherwise persist the stale row right back.
+  tombstones.account.forEach((id) => {
+    result.accountSnapshots.delete(id);
+    indexedDb.remove(StoreName.accountSnapshots, id).catch(console.error);
+  });
+  tombstones.holding.forEach((id) => {
+    result.holdingSnapshots.delete(id);
+    indexedDb.remove(StoreName.holdingSnapshots, id).catch(console.error);
+  });
+  tombstones.security.forEach((id) => {
+    result.securitySnapshots.delete(id);
+    indexedDb.remove(StoreName.securitySnapshots, id).catch(console.error);
+  });
 
   return result;
 };

--- a/src/common/models/Snapshot.ts
+++ b/src/common/models/Snapshot.ts
@@ -4,6 +4,11 @@ import { JSONHolding, JSONSecurity } from "./miscellaneous";
 export interface JSONSnapshot {
   snapshot_id: string;
   date: string;
+  /** Tombstone flag. When true, the row was soft-deleted on the server
+   *  and the client should EVICT this snapshot_id from its local cache
+   *  (in-memory dict + IDB) on receipt. Only ever set when the caller
+   *  asked for `includeDeleted` on `/api/snapshots`. */
+  is_deleted?: boolean;
 }
 
 export interface JSONAccountSnapshot {

--- a/src/server/lib/postgres/models/snapshot.ts
+++ b/src/server/lib/postgres/models/snapshot.ts
@@ -119,7 +119,7 @@ export class SnapshotModel extends Model<JSONSnapshotData, SnapshotSchema> imple
 
   toAccountSnapshot(): JSONAccountSnapshot {
     return {
-      snapshot: { snapshot_id: this.snapshot_id, date: this.snapshot_date },
+      snapshot: { snapshot_id: this.snapshot_id, date: this.snapshot_date, is_deleted: this.is_deleted ?? false },
       user: { user_id: this.user_id ?? "" },
       account: {
         account_id: this.account_id ?? "",
@@ -136,14 +136,14 @@ export class SnapshotModel extends Model<JSONSnapshotData, SnapshotSchema> imple
 
   toSecuritySnapshot(): JSONSecuritySnapshot {
     return {
-      snapshot: { snapshot_id: this.snapshot_id, date: this.snapshot_date },
+      snapshot: { snapshot_id: this.snapshot_id, date: this.snapshot_date, is_deleted: this.is_deleted ?? false },
       security: { security_id: this.security_id ?? "", close_price: this.close_price },
     } as JSONSecuritySnapshot;
   }
 
   toHoldingSnapshot(): JSONHoldingSnapshot {
     return {
-      snapshot: { snapshot_id: this.snapshot_id, date: this.snapshot_date },
+      snapshot: { snapshot_id: this.snapshot_id, date: this.snapshot_date, is_deleted: this.is_deleted ?? false },
       user: { user_id: this.user_id ?? "" },
       holding: {
         account_id: this.holding_account_id ?? "",

--- a/src/server/lib/postgres/repositories/snapshots.ts
+++ b/src/server/lib/postgres/repositories/snapshots.ts
@@ -11,6 +11,7 @@ import {
   SNAPSHOT_ID,
   SNAPSHOT_TYPE,
   SNAPSHOT_DATE,
+  UPDATED,
   ACCOUNT_ID,
   HOLDING_ACCOUNT_ID,
   SECURITY_ID,
@@ -29,6 +30,12 @@ export interface SearchSnapshotsOptions {
   startDate?: string;
   endDate?: string;
   limit?: number;
+  /** When true, soft-deleted (`is_deleted = TRUE`) rows are INCLUDED in
+   *  the response so the client can treat them as tombstones and
+   *  evict them from its local cache (IDB + in-memory dict). Defaults
+   *  to `false` for backward compatibility with consumers that expect
+   *  active-only rows. */
+  includeDeleted?: boolean;
 }
 
 export interface SecuritySnapshot {
@@ -65,9 +72,17 @@ export const searchSnapshots = async (
   user: MaskedUser | null,
   options: SearchSnapshotsOptions = {},
 ): Promise<JSONSnapshotData[]> => {
+  // Filter by `updated`, not `snapshot_date` — matches the transactions
+  // repository (`{ column: UPDATED, ... }`). Soft-deletes and edits bump
+  // the row's `updated` timestamp, so any change surfaces in the latest
+  // month's live query (the FE always live-fetches the current month).
+  // Without this, a snapshot deleted today but originally dated months
+  // ago stays bound to its old month — which is the cachedCall layer's
+  // frozen response — so the deletion never propagates to clients that
+  // already populated IDB from the cold sync.
   const dateRange =
     options.startDate || options.endDate
-      ? { column: SNAPSHOT_DATE, start: options.startDate, end: options.endDate }
+      ? { column: UPDATED, start: options.startDate, end: options.endDate }
       : undefined;
 
   const userScoped = buildSelectWithFilters(SNAPSHOTS, "*", {
@@ -81,6 +96,7 @@ export const searchSnapshots = async (
     dateRange,
     orderBy: `${SNAPSHOT_DATE} DESC`,
     limit: options.limit,
+    excludeDeleted: !options.includeDeleted,
   });
   const userResult = await pool.query<Record<string, unknown>>(userScoped.sql, userScoped.values);
 
@@ -119,6 +135,7 @@ export const searchSnapshots = async (
       dateRange,
       orderBy: `${SNAPSHOT_DATE} DESC`,
       limit: options.limit,
+      excludeDeleted: !options.includeDeleted,
     });
     const holdingResult = await pool.query<Record<string, unknown>>(
       holdingScoped.sql,
@@ -146,6 +163,7 @@ export const searchSnapshots = async (
     dateRange,
     orderBy: `${SNAPSHOT_DATE} DESC`,
     limit: options.limit,
+    excludeDeleted: !options.includeDeleted,
   });
   const securityResult = await pool.query<Record<string, unknown>>(
     globalSecurity.sql,

--- a/src/server/routes/accounts/get-snapshots.ts
+++ b/src/server/routes/accounts/get-snapshots.ts
@@ -38,7 +38,14 @@ export const getSnapshotsRoute = new Route<SnapshotsGetResponse>(
       );
     }
 
-    const options: SearchSnapshotsOptions = {};
+    const options: SearchSnapshotsOptions = {
+      // Include soft-deleted rows as tombstones so the client can evict
+      // them from its local cache (in-memory dict + IDB). Without this
+      // the FE has no signal that a snapshot was deleted on the server,
+      // since the existing IDB persistence layer (`saveAllData`) is
+      // additive — it never DROPS rows not present in a fetch result.
+      includeDeleted: true,
+    };
     if (startResult.data) options.startDate = startResult.data;
     if (endResult.data) options.endDate = endResult.data;
     if (accountResult.data) options.account_id = accountResult.data;


### PR DESCRIPTION
## Summary

Two fixes that surfaced from one bug report ("delete persisted"):

### 1. Label — section suffix shows `security_id`

Per-snapshot edit sections in the holdings detail page had a grey suffix with the snapshot date (`YYYY-MM-DD`). Hoie reported this read as "the same holding at different dates" — making the summed-values UI appear wrong.

Swap to the holding's `security_id` (the actual axis sections are grouped by). NOT `holding_id` — composite `<account_id>-<security_id>`, account_id repeats across sections.

### 2. Delete propagation

The reported "delete persisted" turned out to be the bucket rendering the next-latest snapshot for the same security (UX illusion). Verification surfaced a *real* bug behind it though: older-month snapshot deletions never propagated to the FE.

Two-part root cause:

- **`searchSnapshots` filtered date range on `SNAPSHOT_DATE`, not `UPDATED`** — the transactions repo uses `UPDATED` (`transactions.ts:48,84`). A snapshot dated months ago but soft-deleted today still maps to its old month; the latest-month live query never surfaces it, and the older-month `cachedCall` response is frozen at the pre-delete state.

- **The route filtered `is_deleted=true` rows out at SQL level.** Even with the column fix, the FE would never see the deleted row → IDB persistence layer (`saveDictionary`) is additive, never drops rows missing from a fetch.

Fix (combined):

- `searchSnapshots` filters by `UPDATED` instead of `SNAPSHOT_DATE`. Matches transactions: any recent edit/delete surfaces in the latest live query. Internal helpers (`getSecuritySnapshots`, `getHoldingSnapshots`) keep `SNAPSHOT_DATE` — backfill needs snapshot-date semantics.
- `SearchSnapshotsOptions` gains `includeDeleted?: boolean` (defaults false). All three `buildSelectWithFilters` calls honor it.
- `/api/snapshots` route passes `includeDeleted: true` → latest month's live query returns tombstones.
- `JSONSnapshot` gains `is_deleted?: boolean`; all three `toX` mappers set it.
- FE `fetchSnapshots` collects tombstone IDs across all parallel month-sliced fetches, then **after** `Promise.all` resolves: deletes the IDs from the in-memory dict (so `saveAllData` doesn't persist a stale-cached row that arrived in a different month's response) AND calls `indexedDb.remove`.

The two-phase ingest matters: a tombstone arriving from June's live query can't lose to an older-month `cachedCall` response that still has the row as active, because the dict-cleanup runs at the end.

## Files

- `src/server/lib/postgres/repositories/snapshots.ts` — `UPDATED` filter, `includeDeleted` option, `excludeDeleted: !options.includeDeleted` on all three queries
- `src/server/lib/postgres/models/snapshot.ts` — `is_deleted` field on all three `toX` outputs
- `src/server/routes/accounts/get-snapshots.ts` — pass `includeDeleted: true`
- `src/common/models/Snapshot.ts` — `is_deleted?: boolean` on `JSONSnapshot`
- `src/client/lib/hooks/sync.ts` — tombstone collection + post-`Promise.all` apply
- `src/client/components/HoldingProperties/index.tsx` — label suffix → `security_id`

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 708 pass / 0 fail
- [x] **E2E** (cold sync → API delete → reload → warm sync → IDB check):
  - Recent-month delete: PASS (live API + tombstone-aware ingest)
  - Older-month delete: PASS (UPDATED filter surfaces tombstone in latest month's live query → post-`Promise.all` cleanup wins the race against the stale cached older-month response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)