### PR TITLE
fix(holdings): scope snapshot soft-delete to the holding being deleted (#471)

### DIFF
--- a/src/server/lib/postgres/repositories/holdings.test.ts
+++ b/src/server/lib/postgres/repositories/holdings.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+import { restoreLeaves } from "test-helpers";
+
+const mockQuery = mock(async (_sql: string, _values?: unknown[]) => ({
+  rows: [] as unknown[],
+  rowCount: 0 as number | null,
+}));
+
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+}
+
+mock.module("pg", () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {} },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+}));
+
+const { deleteHoldings } = await import("./holdings");
+
+afterAll(restoreLeaves);
+
+const mockUser = { user_id: "usr-1", username: "tester" } as {
+  user_id: string;
+  username: string;
+};
+
+beforeEach(() => {
+  mockQuery.mockClear();
+  mockQuery.mockImplementation(async () => ({ rows: [], rowCount: 1 }));
+});
+
+describe("deleteHoldings — terminator-only model (#471)", () => {
+  // The sync path writes a `quantity = 0` terminator snapshot for every
+  // removed holding BEFORE calling deleteHoldings (see
+  // compute-tools/create-snapshots.ts). That terminator is the
+  // deletion signal historical readers consume — there's no need (and
+  // it's actively unsafe) for deleteHoldings to soft-delete snapshot
+  // rows on top.
+  //
+  // The previous implementation soft-deleted snapshots filtered on
+  // `holding_account_id` alone, which wiped EVERY holding's snapshot
+  // history for the entire account whenever a single position was
+  // removed (#471). Lock the new contract in: deleteHoldings only
+  // touches the `holdings` table.
+
+  test("only the holdings table is updated — snapshots are untouched", async () => {
+    await deleteHoldings(mockUser, ["acc-1-sec-a", "acc-1-sec-b"]);
+    const updateCalls = mockQuery.mock.calls.filter(([sql]) =>
+      String(sql).toUpperCase().startsWith("UPDATE "),
+    );
+    expect(updateCalls.length).toBeGreaterThan(0);
+    for (const [sql] of updateCalls) {
+      expect(String(sql)).toContain("UPDATE holdings");
+      expect(String(sql)).not.toContain("snapshots");
+    }
+  });
+
+  test("empty input is a no-op (no SQL emitted)", async () => {
+    await deleteHoldings(mockUser, []);
+    expect(mockQuery.mock.calls.length).toBe(0);
+  });
+
+  test("returns the deleted-rowCount from the holdings UPDATE", async () => {
+    mockQuery.mockImplementationOnce(async () => ({ rows: [], rowCount: 3 }));
+    const result = await deleteHoldings(mockUser, ["acc-1-sec-a", "acc-1-sec-b", "acc-1-sec-c"]);
+    expect(result).toEqual({ deleted: 3 });
+  });
+
+  test("user_id is part of the WHERE clause (caller is scoped)", async () => {
+    await deleteHoldings(mockUser, ["acc-1-sec-a"]);
+    const [sql, values] = mockQuery.mock.calls[0];
+    expect(String(sql)).toContain("user_id");
+    expect(values).toContain("usr-1");
+  });
+});

--- a/src/server/lib/postgres/repositories/holdings.ts
+++ b/src/server/lib/postgres/repositories/holdings.ts
@@ -3,7 +3,6 @@ import {
   MaskedUser,
   HoldingModel,
   holdingsTable,
-  snapshotsTable,
   HOLDING_ID,
   USER_ID,
   ACCOUNT_ID,
@@ -104,18 +103,17 @@ export const deleteHoldings = async (
   holding_ids: string[],
 ): Promise<{ deleted: number }> => {
   if (!holding_ids.length) return { deleted: 0 };
-  const { user_id } = user;
-
-  // Soft-delete related snapshots for these holdings
-  for (const holding_id of holding_ids) {
-    await snapshotsTable.bulkSoftDeleteByColumn(
-      "holding_account_id",
-      holding_id.split("-")[0],
-      user_id,
-    );
-  }
-
-  const deleted = await holdingsTable.bulkSoftDelete(holding_ids, { [USER_ID]: user_id });
+  // Snapshots are intentionally NOT soft-deleted. The sync path
+  // (`upsertHoldingsWithSnapshots` in compute-tools/create-snapshots.ts)
+  // writes a fresh `quantity = 0` terminator snapshot for every removed
+  // holding BEFORE calling this — that terminator is the deletion
+  // signal historical readers (charts, performance calcs) consume.
+  // Earlier this function wiped the entire account's snapshot history
+  // (filtering by `holding_account_id` only — see #471) which silently
+  // erased every holding's history when a single position was removed.
+  // The fix is not a tighter filter on the soft-delete; it's removing
+  // the soft-delete entirely.
+  const deleted = await holdingsTable.bulkSoftDelete(holding_ids, { [USER_ID]: user.user_id });
   return { deleted };
 };
 


### PR DESCRIPTION
## Summary

`deleteHoldings` previously soft-deleted snapshots filtered on `holding_account_id` alone — removing one holding wiped EVERY holding's snapshot history for the entire account (#471). Latent / account-wide data loss; would fire on the next Plaid sync that detects a missing position.

This PR took a first pass at tightening the filter to include `holding_security_id` (commit c1420cd). Per Hoie's review feedback ([#481-comment](https://github.com/hoiekim/budget/pull/481#issuecomment-4635636343)), that's the wrong layer to fix — **the snapshot soft-delete shouldn't be tightened, it should be removed**.

The sync path (`upsertHoldingsWithSnapshots` in `src/server/lib/compute-tools/create-snapshots.ts:88-95`) already writes a `quantity = 0` terminator snapshot for every removed holding BEFORE calling `deleteHoldings`. That terminator is the deletion signal historical readers (charts, performance calcs) consume. `deleteHoldings` mutating snapshots on top of that is both redundant and the source of the bug.

## Fix

`deleteHoldings` only touches the `holdings` table now. The `bulkSoftDeleteByColumns` helper introduced in the prior attempt has been dropped — this fix doesn't need it.

```diff
 export const deleteHoldings = async (
   user: MaskedUser,
   holding_ids: string[],
 ): Promise<{ deleted: number }> => {
   if (!holding_ids.length) return { deleted: 0 };
-  const { user_id } = user;
-
-  // Soft-delete related snapshots for these holdings
-  for (const holding_id of holding_ids) {
-    await snapshotsTable.bulkSoftDeleteByColumn(
-      "holding_account_id",
-      holding_id.split("-")[0],
-      user_id,
-    );
-  }
-
-  const deleted = await holdingsTable.bulkSoftDelete(holding_ids, { [USER_ID]: user_id });
+  const deleted = await holdingsTable.bulkSoftDelete(holding_ids, { [USER_ID]: user.user_id });
   return { deleted };
 };
```

## Tests

New `holdings.test.ts` pins the contract:
- only `UPDATE holdings` SQL is emitted; nothing referencing `snapshots`
- empty input is a no-op (no SQL)
- returns the `rowCount` from the holdings UPDATE
- `user_id` is scoped into the WHERE clause

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 712 pass / 0 fail
- [x] Verified the only live caller (`upsertHoldingsWithSnapshots`) writes a `quantity = 0` terminator snapshot before calling `deleteHoldings`, so removed holdings still have a deletion-marker row in history.

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)