### PR TITLE
fix(auto-suggest): record rejected suggestions so the merchant signal can learn (#333)

### DIFF
--- a/src/client/components/TransactionsTable/InvestmentTransactionRow.tsx
+++ b/src/client/components/TransactionsTable/InvestmentTransactionRow.tsx
@@ -33,6 +33,9 @@ const InvestmentTransactionRow = ({ investmentTransaction, isEditable = false }:
     return label.budget_id || account?.label.budget_id || "";
   });
   const [selectedCategoryIdLabel, setSelectedCategoryIdLabel] = useState(() => {
+    // A rejected row keeps its category_id so the merchant signal can learn
+    // the negative (#333), but it must render as uncategorized.
+    if (label.category_confidence === 0) return "";
     return label.category_id || "";
   });
   const [selectedConfidence, setSelectedConfidence] = useState<number | null>(
@@ -138,9 +141,15 @@ const InvestmentTransactionRow = ({ investmentTransaction, isEditable = false }:
     if (value === selectedCategoryIdLabel) return;
 
     setSelectedCategoryIdLabel(value);
+    // On reject (cleared to "Select Category") PERSIST the category being
+    // rejected with confidence=0 instead of nulling it, so getMerchantSignal
+    // can count the negative — otherwise the rejected row falls into the
+    // NULL-category bucket and the engine never learns it (#333). The row
+    // still renders uncategorized.
     const nextConfidence = value ? 1 : 0;
+    const nextCategoryId = value || selectedCategoryIdLabel || label.category_id || null;
     const labelQuery = new TransactionLabel({
-      category_id: value || null,
+      category_id: nextCategoryId,
       category_confidence: nextConfidence,
     });
     if (!label.budget_id) labelQuery.budget_id = account?.label.budget_id;
@@ -158,7 +167,7 @@ const InvestmentTransactionRow = ({ investmentTransaction, isEditable = false }:
         if (!newTransaction.label.budget_id) {
           newTransaction.label.budget_id = account?.label.budget_id;
         }
-        newTransaction.label.category_id = value || null;
+        newTransaction.label.category_id = nextCategoryId;
         newTransaction.label.category_confidence = nextConfidence;
         indexedDb.save(newTransaction).catch(console.error);
         const newTransactions = new InvestmentTransactionDictionary(newData.investmentTransactions);

--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -39,6 +39,9 @@ const TransactionRow = ({ transaction }: Props) => {
     return label.budget_id || account?.label.budget_id || "";
   });
   const [selectedCategoryIdLabel, setSelectedCategoryIdLabel] = useState(() => {
+    // A rejected row keeps its category_id so the merchant signal can learn
+    // the negative (#333), but it must render as uncategorized.
+    if (label.category_confidence === 0) return "";
     return label.category_id || "";
   });
   const categoryConfidence = label.category_confidence ?? null;
@@ -153,9 +156,14 @@ const TransactionRow = ({ transaction }: Props) => {
     // Any user-driven category change resolves the suggestion: 1 = accept
     // (picked a value), 0 = reject (cleared to "Select Category"). Per the
     // JSONTransactionLabel docstring, 1.0 = confirmed and 0.0 = rejected.
+    // On reject we PERSIST the category being rejected (confidence=0) instead
+    // of nulling it, so getMerchantSignal can count the negative — otherwise
+    // the rejected row falls into the NULL-category bucket and the engine
+    // never learns it (#333). The row still renders uncategorized.
     const nextConfidence = value ? 1 : 0;
+    const nextCategoryId = value || selectedCategoryIdLabel || label.category_id || null;
     const labelQuery = new TransactionLabel({
-      category_id: value || null,
+      category_id: nextCategoryId,
       category_confidence: nextConfidence,
     });
     if (!label.budget_id) labelQuery.budget_id = account?.label.budget_id;
@@ -181,7 +189,7 @@ const TransactionRow = ({ transaction }: Props) => {
           if (!newSplitTransaction.label.budget_id) {
             newSplitTransaction.label.budget_id = account?.label.budget_id;
           }
-          newSplitTransaction.label.category_id = value || null;
+          newSplitTransaction.label.category_id = nextCategoryId;
           newSplitTransaction.label.category_confidence = nextConfidence;
           indexedDb.save(newSplitTransaction).catch(console.error);
           const newSplitTransactions = new SplitTransactionDictionary(newData.splitTransactions);
@@ -192,7 +200,7 @@ const TransactionRow = ({ transaction }: Props) => {
           if (!newTransaction.label.budget_id) {
             newTransaction.label.budget_id = account?.label.budget_id;
           }
-          newTransaction.label.category_id = value || null;
+          newTransaction.label.category_id = nextCategoryId;
           newTransaction.label.category_confidence = nextConfidence;
           indexedDb.save(newTransaction).catch(console.error);
           const newTransactions = new TransactionDictionary(newData.transactions);

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -52,7 +52,8 @@ export const getBudgetData = (
     // "Unsorted" for the purposes of budget bar graphs / counts is any
     // transaction the user hasn't confirmed. That bundles three states:
     //   - genuinely unlabeled (category_id null, confidence null)
-    //   - explicitly rejected (category_id null, confidence 0)
+    //   - explicitly rejected (category_id set to the rejected category so the
+    //     merchant signal can learn the negative — #333 — with confidence 0)
     //   - auto-suggested but unreviewed (category_id set, 0 < confidence < 1)
     // The unsorted-count and the unsorted-amount-bar reflect "needs my
     // review", not just "literally lacking a category", so the gate is


### PR DESCRIPTION
## Problem

`getMerchantSignal` returned `rejected: 0` for every (user, merchant, category) tuple, so the `rejectRate > 0.1` skip gate was dead code and the engine could never stop suggesting a category the user repeatedly rejected.

**Root cause:** rejecting a suggestion (clearing the category to "Select Category") wrote `label_category_id = NULL, confidence = 0`. `getMerchantSignal` GROUPs by `label_category_id` and INNER-JOINs `categories ON category_id`, so every rejected row fell into the NULL bucket and was dropped before reaching the per-category `SUM(CASE WHEN confidence = 0 …)` reject counter.

## Fix — Option 2 from the issue (smallest, schema-free)

On reject, **persist the category being rejected with `confidence = 0`** instead of nulling it. The server SQL already counts `confidence = 0` rows that carry a `category_id` as rejected, so **no server change is needed** — the rejected rows now survive the `JOIN categories` and land in the reject SUM.

To keep the UX unchanged, a rejected row still renders uncategorized:
- `selectedCategoryIdLabel` initializes to `""` whenever `confidence === 0`, so the select shows the "Select Category" placeholder + notification styling, and `isSuggested` stays false.
- The budget calculation layer already gates the sorted/category bucket on `confidence === 1 && category_id`, so a rejected row (confidence 0) stays in the **unsorted** bucket and is never attributed to the rejected category. (Comment updated to reflect the new rejected-row shape.)

Applies symmetrically to `TransactionRow` and `InvestmentTransactionRow`. `onChangeBudgetSelect` (which clears the category as a side effect of switching budgets) is intentionally left writing `category_id = null` — switching budgets is not a category rejection, so it should not feed negative merchant signal.

## Why Option 2

The issue flagged a design choice (rejected-category column / keep-on-reject / separate table). Option 2 was the pre-committed default in the grooming comment (smallest reversible change, no migration). Per the standing directive to stop deferring this 24-day-old bug, shipping Option 2; happy to switch to a dedicated column/table if preferred.

## Testing

- `tsc --noEmit`: clean.
- Browser E2E on a sandbox: assign a category to a transaction, clear it (reject), then verify the persisted row keeps `label_category_id` with `label_category_confidence = 0` (and renders as uncategorized). _(results in a follow-up comment)_

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)