### PR TITLE
fix(transactions): split rows update their own cache entry — remove dead early-return + construct from the split (#423, #435)

### DIFF
--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -108,7 +108,6 @@ const TransactionRow = ({ transaction }: Props) => {
         split_transaction_id: id,
         label: { budget_id: value || null, category_id: null, category_confidence: 0 },
       });
-      return;
     } else {
       response = await call.post("/api/transaction", {
         transaction_id: id,
@@ -120,7 +119,7 @@ const TransactionRow = ({ transaction }: Props) => {
       setData((oldData) => {
         const newData = new Data(oldData);
         if (isSplitTransaction) {
-          const newSplitTransaction = new SplitTransaction(parentTransaction);
+          const newSplitTransaction = new SplitTransaction(transaction as SplitTransaction);
           newSplitTransaction.label.budget_id = value || null;
           newSplitTransaction.label.category_id = null;
           newSplitTransaction.label.category_confidence = 0;
@@ -178,7 +177,7 @@ const TransactionRow = ({ transaction }: Props) => {
       setData((oldData) => {
         const newData = new Data(oldData);
         if (isSplitTransaction) {
-          const newSplitTransaction = new SplitTransaction(parentTransaction);
+          const newSplitTransaction = new SplitTransaction(transaction as SplitTransaction);
           if (!newSplitTransaction.label.budget_id) {
             newSplitTransaction.label.budget_id = account?.label.budget_id;
           }
@@ -228,7 +227,7 @@ const TransactionRow = ({ transaction }: Props) => {
     setData((oldData) => {
       const newData = new Data(oldData);
       if (isSplitTransaction) {
-        const newSplitTransaction = new SplitTransaction(parentTransaction);
+        const newSplitTransaction = new SplitTransaction(transaction as SplitTransaction);
         newSplitTransaction.label.category_confidence = 1;
         indexedDb.save(newSplitTransaction).catch(console.error);
         const newSplitTransactions = new SplitTransactionDictionary(newData.splitTransactions);

--- a/src/client/pages/TransactionsPage/index.tsx
+++ b/src/client/pages/TransactionsPage/index.tsx
@@ -311,9 +311,7 @@ export const TransactionsPage = () => {
             indexedDb.save(updated).catch(console.error);
             newInvest.set(id, updated);
           } else if (existing instanceof SplitTransaction) {
-            const parent = newData.transactions.get(existing.transaction_id);
-            if (!parent) return;
-            const updated = new SplitTransaction(parent);
+            const updated = new SplitTransaction(existing);
             updated.label.category_confidence = 1;
             indexedDb.save(updated).catch(console.error);
             newSplits.set(id, updated);


### PR DESCRIPTION
## What

When a user changes the **budget** of a *split* transaction from the transactions list, the server was updated but the client cache (`data.splitTransactions` + IndexedDB) was left stale, and a server rejection was never rolled back. Two coupled bugs:

- **#423** — `TransactionRow.onChangeBudgetSelect` had a stale `return` right after the split POST, short-circuiting the entire success/rollback branch for splits. The branch's split-cache-update code (added later by PR #332) was therefore dead. Result: in-memory dict + IndexedDB never updated; budget-bar/donut/Sankey totals stay wrong until the next full sync; a `status:"failed"` response leaves the optimistic select un-rolled-back.
- **#435** — removing that return alone would expose a second bug: the split branches construct the cached row with `new SplitTransaction(parentTransaction)`, which copies the **parent's** amount/custom_name and mints a fresh **random** `split_transaction_id` — discarding the split's own data and persisting a phantom IDB row under a random key. The same wrong constructor is used in `onChangeCategorySelect`, `onAcceptSuggestion` (TransactionRow) and Accept-All (TransactionsPage). #435 explicitly notes the two must land together.

## Fix

- Delete the dead early `return` in `onChangeBudgetSelect`.
- Construct the new split from the **existing split** — `new SplitTransaction(transaction as SplitTransaction)` (and `new SplitTransaction(existing)` in Accept-All) — matching the canonical pattern already in `SplitTransactionRow.tsx`. This drops the now-dead `parent` lookup in Accept-All.

4 lines changed net (+4/−7), 2 files.

## E2E verification (Playwright, prod-like server on local pg, admin)

Drove the real built bundle: login → `/transactions` → year view → located split `04bf0c11` (amount **500**, parent **1000**, budget *Annie's*) via its React fiber → changed its budget `<select>` to *Shared Budget* → awaited the `POST /api/split-transaction` → read IndexedDB.

**Post-fix — all assertions pass:**
- IDB entry for the split updates: `budget_id → Shared`, `category_id → null`, `category_confidence → 0` (#423)
- cached row keeps the split's **own** id `04bf0c11` and **own** amount **500** (not the parent's 1000) (#435)
- no phantom split row created (IDB split count 57 → 57) (#435)

**Baseline (this branch reverted, rebuilt, same test) — fails exactly as the bugs predict:** server POST succeeds (200) but the IDB cache keeps the **old** budget_id and `confidence=null` — the early return skipped the client cache write. This is the #423 symptom, and it confirms the test actually catches the regression.

typecheck ✓ · lint ✓ · build-client ✓ · build-server ✓

### Note on the other #435 sites
`onChangeCategorySelect` / `onAcceptSuggestion` / Accept-All aren't gated by an early return, so their phantom-row bug fires today only once an auto-suggestion lands on a split (the test data currently has no splits in suggested state, per #435). They are fixed here by the same constructor change but were not individually driven via E2E — the constructor fix is mechanical and shares the canonical `SplitTransactionRow.tsx` pattern.

Closes #423
Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)