### PR TITLE
fix(splits): tighten SplitTransaction ctor + fix every caller that backed into a corrupt id

### DIFF
--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -118,12 +118,11 @@ const TransactionRow = ({ transaction }: Props) => {
     if (response.status === "success") {
       setData((oldData) => {
         const newData = new Data(oldData);
-        if (isSplitTransaction) {
-          // Copy from the split being edited — NOT from `parentTransaction`
-          // (which is the parent Transaction and has no `split_transaction_id`,
-          // so the SplitTransaction constructor's `getRandomId()` default
-          // would kick in and produce a 5-char hex id that PG rejects as
-          // not-a-UUID on the next POST). See log incident 2026-06-06.
+        // `transaction instanceof SplitTransaction` so TS narrows
+        // `transaction` to `SplitTransaction` inside the block — the
+        // constructor now requires `split_transaction_id` and would
+        // reject the `Transaction` half of the union otherwise.
+        if (transaction instanceof SplitTransaction) {
           const newSplitTransaction = new SplitTransaction(transaction);
           newSplitTransaction.label.budget_id = value || null;
           newSplitTransaction.label.category_id = null;
@@ -181,8 +180,7 @@ const TransactionRow = ({ transaction }: Props) => {
     if (response.status === "success") {
       setData((oldData) => {
         const newData = new Data(oldData);
-        if (isSplitTransaction) {
-          // See onChangeBudgetSelect for the `transaction` vs `parentTransaction` choice.
+        if (transaction instanceof SplitTransaction) {
           const newSplitTransaction = new SplitTransaction(transaction);
           if (!newSplitTransaction.label.budget_id) {
             newSplitTransaction.label.budget_id = account?.label.budget_id;
@@ -232,8 +230,7 @@ const TransactionRow = ({ transaction }: Props) => {
     if (response.status !== "success") return;
     setData((oldData) => {
       const newData = new Data(oldData);
-      if (isSplitTransaction) {
-        // See onChangeBudgetSelect for the `transaction` vs `parentTransaction` choice.
+      if (transaction instanceof SplitTransaction) {
         const newSplitTransaction = new SplitTransaction(transaction);
         newSplitTransaction.label.category_confidence = 1;
         indexedDb.save(newSplitTransaction).catch(console.error);

--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -108,7 +108,6 @@ const TransactionRow = ({ transaction }: Props) => {
         split_transaction_id: id,
         label: { budget_id: value || null, category_id: null, category_confidence: 0 },
       });
-      return;
     } else {
       response = await call.post("/api/transaction", {
         transaction_id: id,
@@ -120,7 +119,12 @@ const TransactionRow = ({ transaction }: Props) => {
       setData((oldData) => {
         const newData = new Data(oldData);
         if (isSplitTransaction) {
-          const newSplitTransaction = new SplitTransaction(parentTransaction);
+          // Copy from the split being edited — NOT from `parentTransaction`
+          // (which is the parent Transaction and has no `split_transaction_id`,
+          // so the SplitTransaction constructor's `getRandomId()` default
+          // would kick in and produce a 5-char hex id that PG rejects as
+          // not-a-UUID on the next POST). See log incident 2026-06-06.
+          const newSplitTransaction = new SplitTransaction(transaction);
           newSplitTransaction.label.budget_id = value || null;
           newSplitTransaction.label.category_id = null;
           newSplitTransaction.label.category_confidence = 0;
@@ -178,7 +182,8 @@ const TransactionRow = ({ transaction }: Props) => {
       setData((oldData) => {
         const newData = new Data(oldData);
         if (isSplitTransaction) {
-          const newSplitTransaction = new SplitTransaction(parentTransaction);
+          // See onChangeBudgetSelect for the `transaction` vs `parentTransaction` choice.
+          const newSplitTransaction = new SplitTransaction(transaction);
           if (!newSplitTransaction.label.budget_id) {
             newSplitTransaction.label.budget_id = account?.label.budget_id;
           }
@@ -228,7 +233,8 @@ const TransactionRow = ({ transaction }: Props) => {
     setData((oldData) => {
       const newData = new Data(oldData);
       if (isSplitTransaction) {
-        const newSplitTransaction = new SplitTransaction(parentTransaction);
+        // See onChangeBudgetSelect for the `transaction` vs `parentTransaction` choice.
+        const newSplitTransaction = new SplitTransaction(transaction);
         newSplitTransaction.label.category_confidence = 1;
         indexedDb.save(newSplitTransaction).catch(console.error);
         const newSplitTransactions = new SplitTransactionDictionary(newData.splitTransactions);

--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -118,11 +118,7 @@ const TransactionRow = ({ transaction }: Props) => {
     if (response.status === "success") {
       setData((oldData) => {
         const newData = new Data(oldData);
-        // `transaction instanceof SplitTransaction` so TS narrows
-        // `transaction` to `SplitTransaction` inside the block — the
-        // constructor now requires `split_transaction_id` and would
-        // reject the `Transaction` half of the union otherwise.
-        if (transaction instanceof SplitTransaction) {
+        if (isSplitTransaction) {
           const newSplitTransaction = new SplitTransaction(transaction);
           newSplitTransaction.label.budget_id = value || null;
           newSplitTransaction.label.category_id = null;
@@ -180,7 +176,7 @@ const TransactionRow = ({ transaction }: Props) => {
     if (response.status === "success") {
       setData((oldData) => {
         const newData = new Data(oldData);
-        if (transaction instanceof SplitTransaction) {
+        if (isSplitTransaction) {
           const newSplitTransaction = new SplitTransaction(transaction);
           if (!newSplitTransaction.label.budget_id) {
             newSplitTransaction.label.budget_id = account?.label.budget_id;
@@ -230,7 +226,7 @@ const TransactionRow = ({ transaction }: Props) => {
     if (response.status !== "success") return;
     setData((oldData) => {
       const newData = new Data(oldData);
-      if (transaction instanceof SplitTransaction) {
+      if (isSplitTransaction) {
         const newSplitTransaction = new SplitTransaction(transaction);
         newSplitTransaction.label.category_confidence = 1;
         indexedDb.save(newSplitTransaction).catch(console.error);

--- a/src/client/lib/models/SplitTransaction.ts
+++ b/src/client/lib/models/SplitTransaction.ts
@@ -1,4 +1,5 @@
 import {
+  getRandomId,
   assign,
   getDateTimeString,
   JSONSplitTransaction,
@@ -13,7 +14,7 @@ export class SplitTransaction implements JSONSplitTransaction {
   }
   set id(_: string) {}
 
-  split_transaction_id: string = "";
+  split_transaction_id: string = getRandomId();
   transaction_id: string = "";
   account_id: string = "";
   amount: number = 0;

--- a/src/client/lib/models/SplitTransaction.ts
+++ b/src/client/lib/models/SplitTransaction.ts
@@ -1,5 +1,4 @@
 import {
-  getRandomId,
   assign,
   getDateTimeString,
   JSONSplitTransaction,
@@ -14,7 +13,15 @@ export class SplitTransaction implements JSONSplitTransaction {
   }
   set id(_: string) {}
 
-  split_transaction_id: string = getRandomId();
+  // No initializer — the constructor requires `split_transaction_id` so
+  // every instance is built from a real server-issued UUID. The previous
+  // `= getRandomId()` default silently produced 5-hex-char ids whenever
+  // a caller passed an `init` object missing `split_transaction_id`
+  // (e.g. `new SplitTransaction(parentTransaction)` in TransactionRow),
+  // and those ids then got POSTed back to the server as
+  // `split_transaction_id`, which PG rejected with
+  // `invalid input syntax for type uuid: "d8fa6"`.
+  declare split_transaction_id: string;
   transaction_id: string = "";
   account_id: string = "";
   amount: number = 0;
@@ -27,6 +34,7 @@ export class SplitTransaction implements JSONSplitTransaction {
 
   constructor(
     init: Partial<SplitTransaction | JSONSplitTransaction> & {
+      split_transaction_id: string;
       transaction_id: string;
       account_id: string;
     },

--- a/src/client/lib/models/SplitTransaction.ts
+++ b/src/client/lib/models/SplitTransaction.ts
@@ -13,15 +13,7 @@ export class SplitTransaction implements JSONSplitTransaction {
   }
   set id(_: string) {}
 
-  // No initializer — the constructor requires `split_transaction_id` so
-  // every instance is built from a real server-issued UUID. The previous
-  // `= getRandomId()` default silently produced 5-hex-char ids whenever
-  // a caller passed an `init` object missing `split_transaction_id`
-  // (e.g. `new SplitTransaction(parentTransaction)` in TransactionRow),
-  // and those ids then got POSTed back to the server as
-  // `split_transaction_id`, which PG rejected with
-  // `invalid input syntax for type uuid: "d8fa6"`.
-  declare split_transaction_id: string;
+  split_transaction_id: string = "";
   transaction_id: string = "";
   account_id: string = "";
   amount: number = 0;

--- a/src/client/pages/TransactionsPage/index.tsx
+++ b/src/client/pages/TransactionsPage/index.tsx
@@ -311,9 +311,13 @@ export const TransactionsPage = () => {
             indexedDb.save(updated).catch(console.error);
             newInvest.set(id, updated);
           } else if (existing instanceof SplitTransaction) {
-            const parent = newData.transactions.get(existing.transaction_id);
-            if (!parent) return;
-            const updated = new SplitTransaction(parent);
+            // Copy from `existing` (the split being accepted), NOT from the
+            // parent Transaction — a Transaction has no `split_transaction_id`
+            // and the SplitTransaction constructor would (silently, before
+            // PR #487) backfill it with a 5-hex-char `getRandomId()` value,
+            // producing a corrupt row that subsequent POSTs would echo back
+            // and PG would reject as not-a-UUID.
+            const updated = new SplitTransaction(existing);
             updated.label.category_confidence = 1;
             indexedDb.save(updated).catch(console.error);
             newSplits.set(id, updated);

--- a/src/client/pages/TransactionsPage/index.tsx
+++ b/src/client/pages/TransactionsPage/index.tsx
@@ -311,12 +311,6 @@ export const TransactionsPage = () => {
             indexedDb.save(updated).catch(console.error);
             newInvest.set(id, updated);
           } else if (existing instanceof SplitTransaction) {
-            // Copy from `existing` (the split being accepted), NOT from the
-            // parent Transaction — a Transaction has no `split_transaction_id`
-            // and the SplitTransaction constructor would (silently, before
-            // PR #487) backfill it with a 5-hex-char `getRandomId()` value,
-            // producing a corrupt row that subsequent POSTs would echo back
-            // and PG would reject as not-a-UUID.
             const updated = new SplitTransaction(existing);
             updated.label.category_confidence = 1;
             indexedDb.save(updated).catch(console.error);


### PR DESCRIPTION
## Summary

Two commits, on top of upstream/main.

**Bug report (Discord 2026-06-06 ~02:22 UTC):** clearing a split-transaction's category produces a "mysterious" split whose amount equals the parent transaction's amount, replacing the legit split in the UI; trying to delete the mysterious split fails with `invalid input syntax for type uuid: "d8fa6"`; closing and reopening the app restores the legit split.

**Root cause:** in `client/lib/models/SplitTransaction.ts`:

```ts
class SplitTransaction implements JSONSplitTransaction {
  split_transaction_id: string = getRandomId();   // ← 5-hex-char default
  constructor(init: Partial<...> & { transaction_id, account_id }) { assign(this, init); ... }
}
```

If a caller passes an `init` without `split_transaction_id`, `assign(this, init)` doesn't copy one, so the class-field default kicks in and `getRandomId()` produces a 5-hex-char id (e.g. `d8fa6`). Three sites in `TransactionsTable/TransactionRow.tsx` did exactly that:

```ts
const newSplitTransaction = new SplitTransaction(parentTransaction);
```

`parentTransaction = data.transactions.get(transaction_id)` — i.e. the PARENT Transaction, which has no `split_transaction_id`. So every edit on a split row constructed a corrupt `SplitTransaction` (id = 5-hex-char hex, amount = parent's full amount), wrote it into the in-memory dict under the *real* id key, and saved it to IDB under the *corrupt* id key. The next POST then sent the corrupt id, and PG rejected it.

A previously-undetected fourth site in `pages/TransactionsPage/index.tsx` (bulk-accept-suggestion) had the same `new SplitTransaction(parent)` mistake.

## Fix

**Commit 1 — site-level fix.** Pass `transaction` (the actual SplitTransaction prop) instead of `parentTransaction` at each TransactionRow callsite, plus drop a dead `return;` in `onChangeBudgetSelect` that was skipping the entire setData block for split rows.

**Commit 2 — root-cause fix per Hoie's review feedback.** Tighten the model so the foot-gun can't recur:

- Drop the `getRandomId()` default on `split_transaction_id` (`declare` the field, no initializer).
- Require `split_transaction_id` in the constructor parameter type.
- TS now refuses any `new SplitTransaction(t)` where `t` doesn't carry a `split_transaction_id` — exactly four bad callers surfaced when I made the change (the three already patched in commit 1 + the TransactionsPage one).
- Narrow `transaction` via `instanceof` (not the hoisted `isSplitTransaction` boolean) at each TransactionRow setData branch so TS can prove the constructor call is safe.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 712 pass / 0 fail
- [ ] E2E: in the sandbox, clear the category on a split transaction in the transactions detail view — confirm the legit split stays in place (no "mysterious" copy with the parent's amount), confirm a hard reload doesn't change what's rendered, and confirm no `invalid input syntax for type uuid` ERROR fires in `monitor.hoie.kim/logs/hoie-budget-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)