### PR TITLE
fix(auto-suggest): cap engine confidence at 0.98 so it never collides with the 0.99 /api reservation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,13 +65,14 @@ A transaction carries three correlated fields that together describe its current
 | `label_budget_id` | UUID \| null | The parent budget for `label_category_id` — written alongside it so the UI's category `<select>` (which filters options by budget) can render the value |
 | `label_category_confidence` | number \| null | Confidence in [0, 1]; `null` means unlabeled |
 
-The `label_category_confidence` field encodes four distinct states:
+The `label_category_confidence` field encodes these states. The `0 < c < 1` band is further partitioned so a suggested row's provenance stays recoverable:
 
 | Confidence | Meaning | UI signal |
 |---|---|---|
 | `null` | Unlabeled (`label_category_id IS NULL`) | Red dot in `TransactionRow` |
 | `0` | User rejected a prior suggestion | Counted as a rejection signal for that merchant |
-| `0 < c < 1` | Auto-suggest applied a label — user has not yet confirmed or rejected | Yellow dot in `TransactionRow` |
+| `c < 0.99` (engine cap `0.98`) | Auto-suggest engine applied a label — user has not yet confirmed or rejected | Yellow dot in `TransactionRow` |
+| `0.99` | `/api/suggest-category` write (external Claude instance) | Yellow dot in `TransactionRow` |
 | `1` | User explicitly confirmed | No dot |
 
 A prod backfill on 2026-05-13 set `label_category_confidence = 1` for every labeled row in `transactions`, so the `(category_id IS NOT NULL, confidence IS NULL)` combination is no longer expected in production data.

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -72,13 +72,14 @@ A labeled transaction stores its category across three correlated columns. Both 
 
 **Write both `label_category_id` and `label_budget_id` together.** The UI category `<select>` filters options by the row's budget. Writing only `label_category_id` leaves the dropdown unable to render the value. See `defaultApplyLabel` in `src/server/lib/compute-tools/auto-suggest.ts` for the canonical pattern.
 
-**The four states of `label_category_confidence`:**
+**The states of `label_category_confidence`:** the `0 < c < 1` band is split into two reserved buckets so suggestion provenance is recoverable.
 
 | Value | Meaning |
 |---|---|
 | `NULL` | Row is unlabeled (`label_category_id IS NULL`) |
 | `0` | User rejected an auto-suggestion |
-| `0 < c < 1` | Auto-suggested, not yet confirmed by user |
+| `c < 0.99` (engine cap `0.98`) | Auto-suggest engine applied a label, not yet confirmed by user |
+| `0.99` | `/api/suggest-category` write (external Claude instance) |
 | `1` | User confirmed |
 
 **Prod backfill.** A backfill on 2026-05-13 set `label_category_confidence = 1` for every row with `label_category_id IS NOT NULL`. The application code's confirmation predicate (`category_confidence === 1 && !!category_id` in `src/client/lib/hooks/calculation/budgets.ts`) does not tolerate `NULL`, so this backfill is load-bearing — any new INSERT that sets `label_category_id` without also setting `label_category_confidence` would reintroduce the "labeled but counted as unsorted" miscount.

--- a/docs/DESIGN_PATTERNS.md
+++ b/docs/DESIGN_PATTERNS.md
@@ -154,7 +154,7 @@ Auto-categorization (`src/server/lib/compute-tools/auto-suggest.ts`) writes cate
 | Min total labeled | `accepted + rejected >= 3` | Don't suggest from a single data point             |
 | Max reject rate   | `rejected / total <= 0.10` | Users actively disagree — back off                 |
 | Min confidence    | `accepted / total >= 0.95` | Suggestion has to be near-unanimous in the history |
-| Confidence cap    | `min(confidence, 0.99)`    | `1.0` is reserved for user-confirmed labels        |
+| Confidence cap    | `min(confidence, AUTO_SUGGEST_MAX_CONFIDENCE)` (`0.98`) | Strictly `< 0.99`: `0.99` is reserved for `/api/suggest-category`, `1.0` for user-confirmed labels |
 
 The signal itself comes from a pg_trgm fuzzy match on `merchant_name` (`MERCHANT_SIMILARITY_THRESHOLD = 0.5`), with a `LIMIT 30` over the user's recent labeled transactions for that merchant.
 

--- a/src/server/lib/compute-tools/auto-suggest.test.ts
+++ b/src/server/lib/compute-tools/auto-suggest.test.ts
@@ -183,12 +183,14 @@ describe("runAutoSuggestions", () => {
     expect(updateCalls(/UPDATE\s+transactions\b/i)).toHaveLength(0);
   });
 
-  test("applies suggestion and caps confidence at 0.99", async () => {
+  test("applies suggestion and caps confidence at 0.98 (never 0.99)", async () => {
     userRows = [userRow({ user_id: "user-4" })];
     unlabeledByUser.set("user-4", [
       txRow({ transaction_id: "txn-4", user_id: "user-4", merchant_name: "Grocery Store" }),
     ]);
-    // 10 accepted, 0 rejected → confidence = 1.0 → caps at 0.99.
+    // 10 accepted, 0 rejected → confidence = 1.0 → caps at 0.98. The engine
+    // must NOT write 0.99: that value is reserved for /api/suggest-category,
+    // and 1.0 for user-confirmed labels (#422).
     signalRow = {
       label_category_id: "cat-groceries",
       label_budget_id: "bud-household",
@@ -205,7 +207,8 @@ describe("runAutoSuggestions", () => {
     // Confidence is the 3rd param.
     expect(updates[0].values[0]).toBe("cat-groceries");
     expect(updates[0].values[1]).toBe("bud-household");
-    expect(updates[0].values[2]).toBe(0.99);
+    expect(updates[0].values[2]).toBe(0.98);
+    expect(updates[0].values[2]).not.toBe(0.99);
     expect(updates[0].values[3]).toBe("txn-4");
     expect(updates[0].values[4]).toBe("user-4");
   });
@@ -316,7 +319,8 @@ describe("runAutoSuggestions", () => {
     expect(updates).toHaveLength(1);
     expect(updates[0].values[0]).toBe("cat-groceries");
     expect(updates[0].values[1]).toBe("bud-household");
-    expect(updates[0].values[2]).toBe(0.99);
+    expect(updates[0].values[2]).toBe(0.98);
+    expect(updates[0].values[2]).not.toBe(0.99);
     expect(updates[0].values[3]).toBe("split-1");
     expect(updates[0].values[4]).toBe("user-split-1");
   });

--- a/src/server/lib/compute-tools/auto-suggest.ts
+++ b/src/server/lib/compute-tools/auto-suggest.ts
@@ -21,6 +21,19 @@ export const CAS_NULL_CONFIDENCE: AdditionalWhere = {
   value: null,
 };
 
+// Highest confidence the auto-suggest engine may write. The confidence column
+// has three reserved buckets, kept distinct so a row's suggestion provenance
+// stays recoverable:
+//   - `< 0.99`  → auto-suggest engine (this file)
+//   - `= 0.99`  → /api/suggest-category (external Claude-instance writes)
+//   - `= 1.0`   → user-confirmed labels (UI writes)
+// The engine must cap strictly below 0.99: a merchant with 100% acceptance
+// computes confidence = 1.0, and capping that at 0.99 would collide with the
+// API bucket, making engine and API writes indistinguishable. Lifted to a
+// named exported constant so the reservation map is grep-able and tests can
+// assert the engine never emits 0.99. Closes #422.
+export const AUTO_SUGGEST_MAX_CONFIDENCE = 0.98;
+
 interface MerchantSignal {
   label_category_id: string;
   // The category's parent section's parent budget. Carried alongside the
@@ -206,8 +219,9 @@ const evaluateSignal = (signal: MerchantSignal): number | null => {
   if (rejectRate > 0.1) return null;
   const confidence = signal.accepted / totalLabeled;
   if (confidence < 0.95) return null;
-  // Cap at 0.99 — 1.0 is reserved for user-confirmed labels.
-  return Math.min(confidence, 0.99);
+  // Cap strictly below 0.99: 0.99 is reserved for /api/suggest-category and
+  // 1.0 for user-confirmed labels. See AUTO_SUGGEST_MAX_CONFIDENCE.
+  return Math.min(confidence, AUTO_SUGGEST_MAX_CONFIDENCE);
 };
 
 const processUserSuggestions = async (userId: string): Promise<number> => {


### PR DESCRIPTION
Closes #422

## Problem

`evaluateSignal` in `auto-suggest.ts` capped the suggested confidence with `Math.min(confidence, 0.99)`. A merchant whose history is 100% accepted computes `confidence = accepted / (accepted + rejected) = 1.0`, and `Math.min(1.0, 0.99) === 0.99` — but **0.99 is reserved for `/api/suggest-category`** (the external Claude-instance endpoint), per Hoie's 2026-05-20 directive. So every fully-accepted merchant's auto-suggested rows were written with the exact same confidence value as API-suggested rows, destroying suggestion provenance.

100% acceptance is the common case (especially with the dead-rejection-count of #333), so in practice essentially *every* engine write collided with the API bucket.

## Fix

- Lift the cap to a named exported constant `AUTO_SUGGEST_MAX_CONFIDENCE = 0.98`, strictly below the 0.99 API reservation, and write it via `Math.min(confidence, AUTO_SUGGEST_MAX_CONFIDENCE)`.
- Document the three reserved buckets in the source comment and in `docs/ARCHITECTURE.md`, `docs/DATABASE.md`, `docs/DESIGN_PATTERNS.md`:
  - `< 0.99` → auto-suggest engine
  - `= 0.99` → `/api/suggest-category`
  - `= 1.0` → user-confirmed labels

## Tests

Strengthened the two existing cap tests (`auto-suggest.test.ts`) so they assert the engine writes `0.98` and **never** `0.99` at `confidence = 1.0` (both the top-level transaction pass and the split-transaction pass). These drive `runAutoSuggestions()` end-to-end through the leaf-mocked `pg` SQL router and capture the exact `UPDATE … label_category_confidence = $3` parameter, so they verify the real write path, not just the helper in isolation.

```
18 pass, 0 fail (auto-suggest.test.ts)
```

`bun run typecheck` clean.

## Verification note

This is a backend numeric cap; the behavioral assertion is the exact value the engine UPDATEs, which the unit tests capture end-to-end through the SQL router. A browser E2E can't observe the stored confidence number directly, so the per-test-bundle test driving `runAutoSuggestions()` is the functional verification here. No prod backfill of legacy 0.99 engine rows is included (out of scope; the issue notes it's optional and CAS-guarded).

## Scope

Changes are limited to the engine cap (`auto-suggest.ts`), its tests, and the confidence-bucket documentation that the cap value feeds. The upstream dead-rejection-count (#333) is a separate issue with its own PR; this fix is correct independently of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)