### PR TITLE
fix(holdings): cash UI tweaks — "—" growth, hide cost basis, "Amount" label, currency suffix

### DIFF
--- a/src/client/components/HoldingProperties/index.css
+++ b/src/client/components/HoldingProperties/index.css
@@ -43,3 +43,14 @@
   font-size: 12px;
   opacity: 0.7;
 }
+
+.HoldingProperties .currencyMeta {
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.HoldingProperties .inputWithSuffix {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -1,5 +1,5 @@
 import { ChangeEventHandler, Fragment, FormEventHandler, useCallback, useEffect, useMemo, useState } from "react";
-import { ItemProvider, numberToCommaString, ViewDate } from "common";
+import { ItemProvider, numberToCommaString, ViewDate, currencyCodeToSymbol } from "common";
 import {
   call,
   PATH,
@@ -158,6 +158,11 @@ export const HoldingProperties = () => {
     const primaryLabel = tickerKey === CASH_TICKER ? "Cash" : tickerKey;
     return { primaryLabel, name, securities };
   }, [bucketSnapshots, data.securitySnapshots, tickerKey]);
+
+  const isCash = tickerKey === CASH_TICKER;
+  const currencySymbol = currencyCodeToSymbol(
+    bucketSnapshots[0]?.holding.iso_currency_code || "USD",
+  );
 
   // Aggregate quantity / cost basis across all underlying snapshots.
   // Avg cost basis = sum(cost_basis) / sum(quantity); null whenever any
@@ -592,17 +597,22 @@ export const HoldingProperties = () => {
           </Row>
         )}
         <Row className="keyValue">
-          <span className="propertyName">Quantity</span>
-          <span>{numberToCommaString(aggregate.totalQuantity, 4)}</span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Cost&nbsp;basis&nbsp;(avg)</span>
+          <span className="propertyName">{isCash ? "Amount" : "Quantity"}</span>
           <span>
-            {aggregate.avgCostBasis !== null
-              ? numberToCommaString(aggregate.avgCostBasis, 4)
-              : "—"}
+            {numberToCommaString(aggregate.totalQuantity, isCash ? 2 : 4)}
+            {isCash && <span className="currencyMeta">&nbsp;{currencySymbol}</span>}
           </span>
         </Row>
+        {!isCash && (
+          <Row className="keyValue">
+            <span className="propertyName">Cost&nbsp;basis&nbsp;(avg)</span>
+            <span>
+              {aggregate.avgCostBasis !== null
+                ? numberToCommaString(aggregate.avgCostBasis, 4)
+                : "—"}
+            </span>
+          </Row>
+        )}
       </Property>
 
       {bucketSnapshots.map((snap, idx) => {
@@ -626,35 +636,45 @@ export const HoldingProperties = () => {
             </PropertyLabel>
             <Property>
               <Row className="keyValue">
-                <span className="propertyName">Quantity</span>
+                <span className="propertyName">{isCash ? "Amount" : "Quantity"}</span>
                 {isReadOnly ? (
-                  <span>{edit.quantity || "—"}</span>
+                  <span>
+                    {edit.quantity || "—"}
+                    {isCash && edit.quantity && (
+                      <span className="currencyMeta">&nbsp;{currencySymbol}</span>
+                    )}
+                  </span>
                 ) : (
-                  <input
-                    type="number"
-                    min="0"
-                    step="any"
-                    value={edit.quantity}
-                    onChange={(e) => setEdit({ quantity: e.target.value, error: "" })}
-                    onBlur={onBlurQuantity(snap, edit.quantity)}
-                  />
+                  <span className="inputWithSuffix">
+                    <input
+                      type="number"
+                      min="0"
+                      step="any"
+                      value={edit.quantity}
+                      onChange={(e) => setEdit({ quantity: e.target.value, error: "" })}
+                      onBlur={onBlurQuantity(snap, edit.quantity)}
+                    />
+                    {isCash && <span className="currencyMeta">{currencySymbol}</span>}
+                  </span>
                 )}
               </Row>
-              <Row className="keyValue">
-                <span className="propertyName">Cost&nbsp;basis</span>
-                {isReadOnly ? (
-                  <span>{edit.costBasis || "—"}</span>
-                ) : (
-                  <input
-                    type="number"
-                    min="0"
-                    step="any"
-                    value={edit.costBasis}
-                    onChange={(e) => setEdit({ costBasis: e.target.value, error: "" })}
-                    onBlur={onBlurCostBasis(snap, edit.costBasis)}
-                  />
-                )}
-              </Row>
+              {!isCash && (
+                <Row className="keyValue">
+                  <span className="propertyName">Cost&nbsp;basis</span>
+                  {isReadOnly ? (
+                    <span>{edit.costBasis || "—"}</span>
+                  ) : (
+                    <input
+                      type="number"
+                      min="0"
+                      step="any"
+                      value={edit.costBasis}
+                      onChange={(e) => setEdit({ costBasis: e.target.value, error: "" })}
+                      onBlur={onBlurCostBasis(snap, edit.costBasis)}
+                    />
+                  )}
+                </Row>
+              )}
               <Row className="keyValue">
                 <span className="propertyName">Snapshot&nbsp;date</span>
                 {isReadOnly ? (

--- a/src/client/components/HoldingsComposition/index.tsx
+++ b/src/client/components/HoldingsComposition/index.tsx
@@ -279,7 +279,11 @@ export const HoldingsComposition = ({ account }: Props) => {
         )}
         {displayRows.map((row) => {
           const gainClass =
-            row.unrealizedGain === null ? "" : row.unrealizedGain >= 0 ? "positive" : "negative";
+            row.isCash || row.unrealizedGain === null
+              ? ""
+              : row.unrealizedGain >= 0
+                ? "positive"
+                : "negative";
           const onClickRow = row.clickable ? () => goToHoldingDetail(row.bucketKey) : undefined;
           const onKeyDownRow = row.clickable
             ? (e: KeyboardEvent) => {
@@ -312,7 +316,9 @@ export const HoldingsComposition = ({ account }: Props) => {
                 {currencySymbol}&nbsp;{numberToCommaString(row.value, 0)}
               </span>
               <span className={`col-gain ${gainClass}`}>
-                {row.unrealizedGain !== null ? (
+                {row.isCash || row.unrealizedGain === null ? (
+                  <span className="no-data">—</span>
+                ) : (
                   <>
                     {row.unrealizedGain >= 0 ? "+" : ""}
                     {currencySymbol}&nbsp;{numberToCommaString(row.unrealizedGain, 0)}
@@ -322,8 +328,6 @@ export const HoldingsComposition = ({ account }: Props) => {
                       </span>
                     )}
                   </>
-                ) : (
-                  <span className="no-data">—</span>
                 )}
               </span>
               <span className="col-pct">{row.pct.toFixed(1)}%</span>


### PR DESCRIPTION
## Summary

Three small follow-up tweaks to PR #425's cash-detection behavior:

### `HoldingsComposition` (account detail page)

Cash rows now render the **Growth** column as `—` instead of `+$0`. The numeric `unrealizedGain` is still `0` (`costBasis === value`), but the display matches the "no movement" convention used elsewhere. `gainClass` drops the `positive` modifier too, so the row isn't tinted green.

### `HoldingProperties` (holding detail page)

When the bucket is cash:

- **Cost basis rows hidden**, both on the aggregate Holding panel and on each per-snapshot section. Cash has no meaningful cost basis.
- **"Quantity" → "Amount"** on the same rows. Plaid quotes cash as `quantity == institution_value`, so "Amount" reads more like the dollar value the user actually sees.
- **Currency symbol as small grey suffix** next to the amount value (`.currencyMeta`, 12px / opacity 0.7) — same pattern the existing `.snapshotMeta` date suffix uses.
- Input gains an `.inputWithSuffix` wrapper so the currency badge sits inside the input row in edit mode, not floating outside it.

## Files

- `src/client/components/HoldingsComposition/index.tsx` — growth column override + class fix.
- `src/client/components/HoldingProperties/index.tsx` — detect `isCash` once near `bucketInfo`, gate cost-basis rows behind it, swap the label, render the currency badge.
- `src/client/components/HoldingProperties/index.css` — `.currencyMeta` + `.inputWithSuffix` rules.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 718 pass / 0 fail
- [ ] **UI E2E** — sandbox spinning. Will verify Chase Brokerage detail page (Cash row "—" growth) and the holding detail page (no Cost basis row, "Amount" label, "$" suffix on the amount).

🤖 Generated with [Claude Code](https://claude.com/claude-code)