### PR TITLE
fix(accounts): Changes widget compares against $0 for zero-balance months

### DIFF
--- a/src/client/components/AccountsTable/Balance.tsx
+++ b/src/client/components/AccountsTable/Balance.tsx
@@ -59,7 +59,12 @@ export const Balance = ({ account }: BalanceProps) => {
   // Now the table sums to the same number the donut shows.
   const shouldShowChanges = !!previousAmount || !!dynamicAmount;
   const changesProps = {
-    currentAmount: dynamicAmount || current!,
+    // Use dynamicAmount directly — it is always a number (line 26's `?? fallback`
+    // already resolved it). The old `|| current!` substituted the live balance
+    // whenever dynamicAmount was 0, which is wrong: $0 is the correct balance for
+    // a zero-balance month (closed account, liquidated position), and the row
+    // itself renders $0, so the Changes delta must compare against 0, not current.
+    currentAmount: dynamicAmount,
     previousAmount,
   };
 


### PR DESCRIPTION
## Problem

`Balance.tsx` built the per-row Changes widget's `currentAmount` as:

```ts
currentAmount: dynamicAmount || current!,
```

When `dynamicAmount` is `0` — a genuine zero-balance month (closed account, fully liquidated brokerage position, checking account swept to $0) — `||` treats it as falsy and falls through to `current!`, the **live** Plaid/manual balance. The balance row itself renders `$0` (it uses `dynamicAmount` directly), but the Changes delta then compared the unrelated live balance against the previous month, producing a nonsensical change (e.g. `+$(live − prev)` instead of `−$prev`).

## Fix

`dynamicAmount` is always a `number` at this point — line 26's `?? fallback` already resolves it — so the `|| current!` substitution could only ever fire on the `0` edge case, exactly where it does harm. Use `dynamicAmount` directly so the delta correctly reads `−$previous` when an account goes to zero, matching the `$0` the row displays.

## Testing

- `bun run typecheck` — clean.
- The type system guarantees `dynamicAmount: number`, so dropping `|| current!` changes behavior **only** in the `dynamicAmount === 0` case (the bug), and is a no-op for every non-zero month.

This is a **latent** bug: as the issue notes, no current account has the August-or-earlier snapshot needed to flip `shouldShowChanges` true while `dynamicAmount === 0`, so the wrong delta isn't visible in today's data — it would surface after a snapshot backfill or any account that legitimately drops to $0 between two recorded months. Driving the exact path in a browser E2E would require seeding that snapshot shape into the DB; I verified the change at the type/logic level and confirmed the Accounts page renders without regression on this branch (sandbox).

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)