### PR TITLE
fix(sync): anchor cold/warm history fetch to oldestDate's month start (#434)

### DIFF
--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -667,7 +667,21 @@ export const useSync = () => {
         const oldestDatePromise = getOldestTransactionDate();
         const oldestDate = await oldestDatePromise;
         const defaultFrom = currentViewDate.clone().previous().previous().previous().getStartDate();
-        const fullFrom = oldestDate && oldestDate < defaultFrom ? oldestDate : defaultFrom;
+        // The slice loop fetches a month M only when `from < M.getStartDate()`
+        // (strict). A raw mid-month `oldestDate` (e.g. 2021-07-28) is NOT < its
+        // own month start (2021-07-01), so that month is never requested and
+        // every row whose `updated` falls in it is silently dropped. Anchor to
+        // the start of the month *before* oldestDate's month so the loop's last
+        // iteration covers oldestDate's month, then compare the *anchored* value
+        // against defaultFrom — comparing the raw oldestDate would still drop the
+        // month when oldestDate sits in defaultFrom's own month past the 1st. (#434)
+        const oldestMonthStart = oldestDate
+          ? new ViewDate("month", oldestDate).previous().getStartDate()
+          : null;
+        const fullFrom =
+          oldestMonthStart && oldestMonthStart < defaultFrom
+            ? oldestMonthStart
+            : defaultFrom;
         const fullUntil = currentViewDate.clone().next().getStartDate();
         const fullRange: FetchRange = { from: fullFrom, until: fullUntil };
         // Freshness window: 30 days back from the last sync. Anything
@@ -872,7 +886,18 @@ export const useSync = () => {
       // tile cleanly with no overlap and no gap.
       const oldestDate = await oldestDatePromise;
       const defaultFrom = currentViewDate.clone().previous().previous().previous().getStartDate();
-      const olderFrom = oldestDate && oldestDate < defaultFrom ? oldestDate : defaultFrom;
+      // Anchor to the month before oldestDate's month — see the warm-path note
+      // above: the slice loop's strict `from < M.getStartDate()` drops the
+      // month containing a mid-month oldestDate otherwise. Compare the anchored
+      // value (not raw oldestDate) against defaultFrom so the same-calendar-month
+      // boundary is covered too. (#434)
+      const oldestMonthStart = oldestDate
+        ? new ViewDate("month", oldestDate).previous().getStartDate()
+        : null;
+      const olderFrom =
+        oldestMonthStart && oldestMonthStart < defaultFrom
+          ? oldestMonthStart
+          : defaultFrom;
       const olderUntil = currentViewDate.clone().previous().getStartDate();
 
       const olderRange: FetchRange = { from: olderFrom, until: olderUntil };


### PR DESCRIPTION
Closes #434.

## Problem

On every load (cold + warm), transactions whose `updated` timestamp falls inside the month containing `oldestTransactionDate` were **silently dropped** from the client — the IndexedDB store ended up a strict subset of the server's data, with no UI signal.

Two bugs compound:
1. The history slice loop (`fetchTransactions`/`fetchSnapshots`) walks months back with a strict `while (range.from < viewDate.getStartDate())`. `range.from` was set to the raw `oldestDate` (`MIN(transactions.date)`), which is **not** month-aligned. For `oldestDate = 2021-07-28`, the July slice `[2021-07-01, 2021-08-01)` is never requested because `2021-07-28 < 2021-07-01` is false.
2. The server filters slices by `updated`, not `date` (intentional, commit 3feee63). So any row whose `updated` lands in the never-requested July window is in no slice the client asks for.

## Fix

Anchor `from` to the **start of the month before** `oldestDate`'s month, at both slice sites in `sync.ts` (warm `fullFrom`, cold stage-3 `olderFrom`). Because the loop boundary is a strict `<` against month-starts, anchoring to the *previous* month-start is what makes the loop's final iteration cover `oldestDate`'s own month.

> Note: simply month-aligning `oldestDate` down to its own month-start (`2021-07-01`) does **not** fix it — `2021-07-01 < 2021-07-01` is still false. I simulated the loop against the real `ViewDate` to confirm; only anchoring to the previous month-start includes the oldest month. The server `updated`-vs-`date` filter is left as-is (its purpose — surfacing recently-edited old rows in fresh slices — is independent and still load-bearing).

Client-side only, ~2 lines of logic + comments. No schema/API change.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — **720 pass / 0 fail**
- [x] Loop simulation against the real `common/utils/date` `ViewDate`: buggy + naive-month-align both drop the oldest month for mid-month `oldestDate`; previous-month-anchor includes it across mid-month / month-aligned / recent cases.
- [x] **UI E2E (Playwright, prod build served by `bun build/server/bundle.js` on local pg, admin/budget, real data — admin oldest txn `2021-07-28`, DB non-deleted total **6052**, 3 rows with `updated` in July 2021):**
  - **Fix build** — fresh context (cold load) → after sync settles, `BudgetApp` IndexedDB `transactions` store count = **6052** (0 missing). The 3 previously-dropped rows (`Kq6gY6…`, `k1DkOD…`, `AODkXD…`, all `updated 2021-07-29`) are all present (`get(id)` → found).
  - **Baseline `upstream/main` build** (same DB, port 3435) — same cold load → IndexedDB count = **6049** (3 short); the 3 rows absent. Confirms the fix is what closes the gap.
  - `/transactions` renders without error on the fix build (screenshot `/tmp/pr-434-transactions.png`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
