### PR TITLE
fix(capacities): dedupe duplicate active_from rows on write + one-time DB cleanup

### DIFF
--- a/src/common/utils/dedupeCapacities.test.ts
+++ b/src/common/utils/dedupeCapacities.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { dedupeCapacities } from "./dedupeCapacities";
+import type { JSONCapacity } from "../models/BudgetFamily";
+
+const cap = (active_from?: Date | null, month = 0) =>
+  ({ capacity_id: "x", active_from, month, year: month * 12, isInfinite: false, isIncome: false }) as unknown as JSONCapacity;
+
+describe("dedupeCapacities", () => {
+  test("passes through empty / single-row arrays unchanged", () => {
+    expect(dedupeCapacities([])).toEqual([]);
+    const one = [cap(new Date("2026-07-01"), 100)];
+    expect(dedupeCapacities(one)).toBe(one);
+  });
+
+  test("keeps first occurrence in input order when active_from is the same", () => {
+    const a = cap(new Date("2026-07-01"), 100);
+    const b = cap(new Date("2026-07-01"), 200);
+    const result = dedupeCapacities([a, b]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(a);
+    expect(result[0].month).toBe(100);
+  });
+
+  test("collapses multiple NULL/undefined active_from rows into one", () => {
+    const a = cap(undefined, 100);
+    const b = cap(null, 200);
+    const c = cap(undefined, 300);
+    const result = dedupeCapacities([a, b, c]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(a);
+  });
+
+  test("preserves distinct active_from rows", () => {
+    const jul = cap(new Date("2026-07-01"), 1);
+    const aug = cap(new Date("2026-08-01"), 2);
+    const sep = cap(new Date("2026-09-01"), 3);
+    expect(dedupeCapacities([jul, aug, sep])).toHaveLength(3);
+  });
+
+  test("collapses Date-instance vs string equivalence", () => {
+    const a = cap(new Date("2026-07-01T00:00:00.000Z"), 10);
+    const b = { ...cap(undefined, 20), active_from: "2026-07-01T00:00:00.000Z" } as unknown as JSONCapacity;
+    const result = dedupeCapacities([a, b]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(a);
+  });
+
+  test("non-mutating — input array is unchanged", () => {
+    const a = cap(undefined, 1);
+    const b = cap(undefined, 2);
+    const input = [a, b];
+    const copy = [...input];
+    dedupeCapacities(input);
+    expect(input).toEqual(copy);
+  });
+
+  test("mixed: NULL + distinct dates + duplicates", () => {
+    const n1 = cap(undefined, 0);
+    const n2 = cap(undefined, 99);
+    const jul1 = cap(new Date("2026-07-01"), 1);
+    const jul2 = cap(new Date("2026-07-01"), 2);
+    const aug = cap(new Date("2026-08-01"), 3);
+    const result = dedupeCapacities([n1, jul1, n2, aug, jul2]);
+    expect(result).toHaveLength(3); // NULL, Jul, Aug
+    expect(result[0]).toBe(n1);
+    expect(result[1]).toBe(jul1);
+    expect(result[2]).toBe(aug);
+  });
+});

--- a/src/common/utils/dedupeCapacities.ts
+++ b/src/common/utils/dedupeCapacities.ts
@@ -1,0 +1,30 @@
+import { JSONCapacity } from "../models/BudgetFamily";
+
+/**
+ * Collapse duplicate-`active_from` rows in a capacities array, keeping the
+ * FIRST occurrence in input order.
+ *
+ * Why "first": `BudgetFamily.getActiveCapacity(date)` sorts capacities by
+ * `active_from` DESC (stable in V8) and returns the first row matching
+ * `active_from <= date`. For two rows with the same `active_from`, the
+ * first in the input array wins on display — so dedupe by keeping the
+ * first preserves the value the user is currently seeing.
+ *
+ * `active_from = undefined` / `null` is the "all past" bucket and is
+ * collapsed with other `undefined`/`null` rows. Empty (no capacities)
+ * input passes through unchanged.
+ *
+ * Pure / non-mutating. Returns a new array.
+ */
+export const dedupeCapacities = (capacities: JSONCapacity[]): JSONCapacity[] => {
+  if (!capacities || capacities.length <= 1) return capacities;
+  const seen = new Set<string>();
+  const result: JSONCapacity[] = [];
+  for (const cap of capacities) {
+    const key = cap.active_from ? new Date(cap.active_from).getTime().toString() : "__NULL__";
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(cap);
+  }
+  return result;
+};

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -174,3 +174,4 @@ export * from "./search";
 export * from "./date";
 export * from "./math";
 export * from "./Queue";
+export * from "./dedupeCapacities";

--- a/src/server/lib/postgres/cleanup-capacity-duplicates.ts
+++ b/src/server/lib/postgres/cleanup-capacity-duplicates.ts
@@ -24,8 +24,12 @@ import { logger } from "../logger";
  * empty and the UPDATE is a no-op.
  */
 export const cleanupDuplicateCapacityRows = async (): Promise<void> => {
-  const tables = ["budgets", "sections", "categories"] as const;
-  for (const table of tables) {
+  const targets: Array<{ table: string; idCol: string }> = [
+    { table: "budgets", idCol: "budget_id" },
+    { table: "sections", idCol: "section_id" },
+    { table: "categories", idCol: "category_id" },
+  ];
+  for (const { table, idCol } of targets) {
     const result = await pool.query(
       `
       UPDATE ${table} SET capacities = (
@@ -36,9 +40,9 @@ export const cleanupDuplicateCapacityRows = async (): Promise<void> => {
           ORDER BY COALESCE(e.value->>'active_from', '__NULL__'), e.ord ASC
         ) sub
       )
-      WHERE ${table}_id IN (
-        SELECT t.${table}_id FROM ${table} t, jsonb_array_elements(t.capacities) e
-        GROUP BY t.${table}_id, e.value->>'active_from'
+      WHERE ${idCol} IN (
+        SELECT t.${idCol} FROM ${table} t, jsonb_array_elements(t.capacities) e
+        GROUP BY t.${idCol}, e.value->>'active_from'
         HAVING COUNT(*) > 1
       )
       `,

--- a/src/server/lib/postgres/cleanup-capacity-duplicates.ts
+++ b/src/server/lib/postgres/cleanup-capacity-duplicates.ts
@@ -1,0 +1,51 @@
+import { pool } from "./client";
+import { logger } from "../logger";
+
+/**
+ * One-time cleanup that collapses duplicate `active_from` rows in every
+ * `budgets.capacities` / `sections.capacities` / `categories.capacities`
+ * array, keeping the FIRST occurrence in array order.
+ *
+ * Why dedupe is necessary:
+ *   `BudgetFamily.getActiveCapacity(date)` picks the first
+ *   `active_from <= date` row from a stable-sorted-desc copy. For two
+ *   rows with the same `active_from`, the first in the array wins on
+ *   display. The duplicates are unreachable but still persist to disk
+ *   and pollute every server-side `JSON.parse(capacities).map(...)`
+ *   that touches them.
+ *
+ * Why FIRST not LAST:
+ *   The first-in-array row is the one the user is currently seeing in
+ *   the UI. Picking any other element silently swaps the displayed
+ *   value to one the user never saw.
+ *
+ * Idempotent: skips rows that are already deduplicated. Runs on every
+ * startup; once the data is clean the SELECT in the WHERE clause is
+ * empty and the UPDATE is a no-op.
+ */
+export const cleanupDuplicateCapacityRows = async (): Promise<void> => {
+  const tables = ["budgets", "sections", "categories"] as const;
+  for (const table of tables) {
+    const result = await pool.query(
+      `
+      UPDATE ${table} SET capacities = (
+        SELECT jsonb_agg(c)
+        FROM (
+          SELECT DISTINCT ON (COALESCE(e.value->>'active_from', '__NULL__')) e.value AS c
+          FROM jsonb_array_elements(capacities) WITH ORDINALITY AS e(value, ord)
+          ORDER BY COALESCE(e.value->>'active_from', '__NULL__'), e.ord ASC
+        ) sub
+      )
+      WHERE ${table}_id IN (
+        SELECT t.${table}_id FROM ${table} t, jsonb_array_elements(t.capacities) e
+        GROUP BY t.${table}_id, e.value->>'active_from'
+        HAVING COUNT(*) > 1
+      )
+      `,
+    );
+    const collapsed = result.rowCount ?? 0;
+    if (collapsed > 0) {
+      logger.info(`cleanup-capacity-duplicates: collapsed duplicates in ${collapsed} ${table} rows`);
+    }
+  }
+};

--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -2,6 +2,7 @@ import { pool } from "./client";
 import { searchUser, writeUser } from "./repositories";
 import { buildCreateTable, buildCreateIndex } from "./database";
 import { runMigrations } from "./migration";
+import { cleanupDuplicateCapacityRows } from "./cleanup-capacity-duplicates";
 import { logger } from "server";
 import {
   Table,
@@ -80,6 +81,12 @@ export const initializePostgres = async (): Promise<void> => {
 
     // Run automatic schema migrations to add any missing columns
     await runMigrations(tables.map((t) => ({ name: t.name, schema: t.schema })));
+
+    // One-time idempotent cleanup of duplicate `active_from` rows in
+    // budgets/sections/categories capacities arrays. The FE display dedupes
+    // but the data on disk doesn't — historical inserts left zombie rows
+    // that pollute every server-side traversal of `capacities`.
+    await cleanupDuplicateCapacityRows();
   } catch (error: unknown) {
     logger.error("Failed to create tables", {}, error);
     throw new Error("Failed to setup PostgreSQL tables.");

--- a/src/server/lib/postgres/repositories/budgets.ts
+++ b/src/server/lib/postgres/repositories/budgets.ts
@@ -1,4 +1,4 @@
-import { JSONBudget, JSONSection, JSONCategory } from "common";
+import { JSONBudget, JSONSection, JSONCategory, dedupeCapacities } from "common";
 import {
   MaskedUser,
   BudgetModel,
@@ -46,7 +46,7 @@ export const createBudget = async (
       iso_currency_code: data.iso_currency_code || "USD",
       roll_over: data.roll_over || false,
       roll_over_start_date: data.roll_over_start_date,
-      capacities: data.capacities || [],
+      capacities: dedupeCapacities(data.capacities || []),
     },
     user.user_id,
   );
@@ -67,7 +67,8 @@ export const updateBudget = async (
   if (data.roll_over !== undefined) updates.roll_over = data.roll_over;
   if (data.roll_over_start_date !== undefined)
     updates.roll_over_start_date = data.roll_over_start_date;
-  if (data.capacities !== undefined) updates.capacities = JSON.stringify(data.capacities);
+  if (data.capacities !== undefined)
+    updates.capacities = JSON.stringify(dedupeCapacities(data.capacities));
 
   if (Object.keys(updates).length === 0) return false;
   const model = await budgetsTable.update(budget_id, updates, undefined, user.user_id);
@@ -109,7 +110,7 @@ export const createSection = async (
       name: data.name || "New Section",
       roll_over: data.roll_over || false,
       roll_over_start_date: data.roll_over_start_date,
-      capacities: data.capacities || [],
+      capacities: dedupeCapacities(data.capacities || []),
     },
     user.user_id,
   );
@@ -129,7 +130,8 @@ export const updateSection = async (
   if (data.roll_over !== undefined) updates.roll_over = data.roll_over;
   if (data.roll_over_start_date !== undefined)
     updates.roll_over_start_date = data.roll_over_start_date;
-  if (data.capacities !== undefined) updates.capacities = JSON.stringify(data.capacities);
+  if (data.capacities !== undefined)
+    updates.capacities = JSON.stringify(dedupeCapacities(data.capacities));
 
   if (Object.keys(updates).length === 0) return false;
   const model = await sectionsTable.update(section_id, updates, undefined, user.user_id);
@@ -164,7 +166,7 @@ export const createCategory = async (
       name: data.name || "New Category",
       roll_over: data.roll_over || false,
       roll_over_start_date: data.roll_over_start_date,
-      capacities: data.capacities || [],
+      capacities: dedupeCapacities(data.capacities || []),
     },
     user.user_id,
   );
@@ -184,7 +186,8 @@ export const updateCategory = async (
   if (data.roll_over !== undefined) updates.roll_over = data.roll_over;
   if (data.roll_over_start_date !== undefined)
     updates.roll_over_start_date = data.roll_over_start_date;
-  if (data.capacities !== undefined) updates.capacities = JSON.stringify(data.capacities);
+  if (data.capacities !== undefined)
+    updates.capacities = JSON.stringify(dedupeCapacities(data.capacities));
 
   if (Object.keys(updates).length === 0) return false;
   const model = await categoriesTable.update(category_id, updates, undefined, user.user_id);


### PR DESCRIPTION
## Bug

Read-only scan of the prod-clone DB:

- **3 budgets** have multiple capacities with the same `active_from`
- **12 sections** (59 total duplicate rows)
- **16 categories** (87 total duplicate rows)

Budget `53c90b` is the worst case — 7 capacities all with `active_from = NULL`, each carrying a different `month` value. The FE display dedupes via `getAllCapaciyDates` (showing one "All past" row), but the data on disk is polluted: every server-side traversal that reads `capacities` walks all 7 zombies, and `BudgetFamily.getActiveCapacity` picks one of them non-deterministically (V8 stable sort + `.find` on `active_from <= date`).

Surfaced during the investigation of #439's "sync with children" question — `Σ section.month` and `Σ category.month` reported wildly different totals for the same budget across what should be the same logical period.

## Fix

Three layers:

1. **Pure helper** `src/common/utils/dedupeCapacities.ts` — keeps the FIRST occurrence in input order. That choice matches what the user is currently seeing in the UI (`getActiveCapacity` returns the first row in the stable-sorted-desc copy for same-active_from ties), so dedupe never silently swaps the displayed value to one the user never saw.

2. **Apply on every write** in `src/server/lib/postgres/repositories/budgets.ts` — `createBudget` / `updateBudget` / `createSection` / `updateSection` / `createCategory` / `updateCategory` run `dedupeCapacities` before `JSON.stringify`. Defends against future bug paths that would otherwise re-create duplicates.

3. **One-time DB cleanup** `cleanup-capacity-duplicates.ts`, wired into `initializePostgres` after `runMigrations`. Idempotent UPDATE per table; after the first run the WHERE sub-query returns empty and it's a no-op.

## Test plan

- [x] 7 unit tests on `dedupeCapacities` covering empty / single-row passthrough, same-active_from dedupe, NULL/undefined collapse, distinct-date preservation, Date-instance vs ISO-string equivalence, non-mutation, mixed inputs
- [x] Full suite 727/727 pass
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [ ] Sandbox spin: confirm cleanup runs on startup + collapses duplicates from the 3 budgets / 12 sections / 16 categories observed in prod-clone (will append result here)

## Out of scope

- Does NOT fix the stale-parent-`month` issue (that's #439's job — derive sum-of-children on read instead of persisting it).
- Does NOT fix the MAX_FLOAT propagation issue (sections marked `±MAX_FLOAT` while parent budget shows finite). #439's `Capacity.getActiveAmount` with the "poisons the sum" rule addresses that on the read side.

Related: #439, #433 (sandbox testing trail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)