### PR TITLE
fix(sync): cold-start path persists holdings, not just the warm path (#468)

### DIFF
--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -776,7 +776,7 @@ export const useSync = () => {
       const transfersPromise = fetchTransfers();
 
       const [
-        { accounts, items },
+        { accounts, items, holdings },
         stage1Budgets,
         stage1Charts,
         stage1Institutions,
@@ -799,6 +799,7 @@ export const useSync = () => {
       const stage1 = new Data({
         accounts,
         items,
+        holdings,
         budgets,
         sections,
         categories,
@@ -844,6 +845,7 @@ export const useSync = () => {
       const stage2 = new Data({
         accounts,
         items,
+        holdings,
         budgets,
         sections,
         categories,
@@ -880,6 +882,7 @@ export const useSync = () => {
       const finalData = new Data({
         accounts,
         items,
+        holdings,
         budgets,
         sections,
         categories,


### PR DESCRIPTION
## Problem
`fetchAccounts()` returns `{ accounts, items, holdings }` from `/api/accounts`, and the **warm** sync path threads `holdings` into `Data` correctly. The **cold-start** path (first visit, or after `clean()` / cache clear) destructured only `{ accounts, items }` and built all three `Data` instances — `stage1`, `stage2`, `finalData` — without `holdings`. So:

- `Data.holdings` stays empty for the entire cold session, and
- `indexedDb.saveAllData(finalData)` persists an **empty** holdings store.

A fresh user gets zero holdings in IndexedDB until a later page load happens to take the warm path and self-heal it. This defeats the purpose of the client-side holdings store (commit `0ac69b0`) and is the same cold-vs-warm inconsistency class as #434.

Latent today (no UI reads `Data.holdings` yet — holdings render derives from snapshots), but the cold path is the canonical "build IndexedDB from scratch" path and it stores nothing.

## Fix
Destructure `holdings` in the cold path and pass it into the `stage1`/`stage2`/`finalData` constructions, mirroring the warm path. Holdings come from `/api/accounts` (non-time-partitioned, like `accounts`/`items`), so they belong in stage 1 and carry forward unchanged into stage 2/final — no per-month slicing needed.

```diff
-        { accounts, items },
+        { accounts, items, holdings },
```
plus `holdings,` added to each of the three `new Data({ ... })` literals.

## Testing
- `tsc --noEmit` clean (`holdings` is `Partial<Data>`-typed, matches the field).
- E2E (Playwright vs sandbox, admin login, reading the `BudgetApp` IndexedDB): see PR comment — cold load now persists the holdings store count equal to `/api/accounts` holdings, where before it persisted 0.

No client-sync hook unit harness exists (React hook + IndexedDB + fetch); the bug was originally proven via IndexedDB E2E, so verification uses the same path.

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)