### PR TITLE
feat(suggestions): record user confirm/reject into the suggestions log (#333)

### DIFF
--- a/src/server/lib/index.ts
+++ b/src/server/lib/index.ts
@@ -11,3 +11,4 @@ export * from "./validation";
 export * from "./alarm";
 export * from "./rate-limit";
 export * from "./infer-label-confidence";
+export * from "./record-suggestion-feedback";

--- a/src/server/lib/record-suggestion-feedback.test.ts
+++ b/src/server/lib/record-suggestion-feedback.test.ts
@@ -1,0 +1,161 @@
+// `recordSuggestionFeedback` decides which suggestion-log write a transaction
+// label update implies: a user confirmation (confidence 1), a user rejection
+// (confidence 0, not a budget switch), or nothing. The two upsert helpers it
+// calls run real SQL through `pool.query`, so the leaf mocks `pg` and the test
+// asserts on the captured INSERT — confirm vs reject is distinguished by the
+// `confirmed_at` column, which only the confirmed upsert writes.
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+import { restoreLeaves } from "test-helpers";
+
+// A fully-shaped row so the upserts' `new SuggestionModel(...)` type check
+// passes; the helper ignores the return value, so the contents are arbitrary.
+const okRow = {
+  transaction_id: "tx",
+  user_id: "u-1",
+  category_id: "cat",
+  confidence: 1,
+  is_confirmed: true,
+  is_rejected: false,
+  confirmed_at: null,
+  engine_scored_at: null,
+  updated: null,
+};
+
+const mockQuery = mock(async (_sql: string, _values?: unknown[]) => ({
+  rows: [okRow] as unknown[],
+  rowCount: 1 as number | null,
+}));
+
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+}
+
+mock.module("pg", () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {} },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+}));
+
+const { recordSuggestionFeedback } = await import("./record-suggestion-feedback");
+
+afterAll(restoreLeaves);
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockQuery.mockImplementation(async () => ({ rows: [okRow], rowCount: 1 }));
+});
+
+const user = { user_id: "u-1", username: "alice" } as unknown as Parameters<
+  typeof recordSuggestionFeedback
+>[0];
+
+// Pull the suggestion INSERT out of the captured pool queries.
+const writes = () =>
+  mockQuery.mock.calls.filter((c) => /INSERT INTO suggestions/i.test(c[0] as string));
+
+const isConfirm = (sql: string) => /confirmed_at/i.test(sql);
+
+describe("recordSuggestionFeedback", () => {
+  test("explicit category pick (confidence 1) → confirms the picked category", async () => {
+    await recordSuggestionFeedback(
+      user,
+      "tx-1",
+      { category_id: "cat-1", category_confidence: 1 },
+      { category_id: null, budget_id: "bud-1" },
+    );
+    const w = writes();
+    expect(w).toHaveLength(1);
+    expect(isConfirm(w[0][0] as string)).toBe(true);
+    // values: [transaction_id, user_id, category_id]
+    expect(w[0][1]).toEqual(["tx-1", "u-1", "cat-1"]);
+  });
+
+  test("accept-in-place (confidence 1, no body category) → confirms the row's current category", async () => {
+    await recordSuggestionFeedback(
+      user,
+      "tx-2",
+      { category_confidence: 1 },
+      { category_id: "cat-9", budget_id: "bud-1" },
+    );
+    const w = writes();
+    expect(w).toHaveLength(1);
+    expect(isConfirm(w[0][0] as string)).toBe(true);
+    expect(w[0][1]).toEqual(["tx-2", "u-1", "cat-9"]);
+  });
+
+  test("clear category (confidence 0) → rejects the row's previous category", async () => {
+    await recordSuggestionFeedback(
+      user,
+      "tx-3",
+      { category_id: null, category_confidence: 0 },
+      { category_id: "cat-2", budget_id: "bud-1" },
+    );
+    const w = writes();
+    expect(w).toHaveLength(1);
+    expect(isConfirm(w[0][0] as string)).toBe(false);
+    expect(w[0][1]).toEqual(["tx-3", "u-1", "cat-2"]);
+  });
+
+  test("clear with no previous category → nothing to reject, no write", async () => {
+    await recordSuggestionFeedback(
+      user,
+      "tx-4",
+      { category_id: null, category_confidence: 0 },
+      { category_id: null, budget_id: "bud-1" },
+    );
+    expect(writes()).toHaveLength(0);
+  });
+
+  test("budget switch that clears the category (confidence 0, budget changed) → not a rejection", async () => {
+    await recordSuggestionFeedback(
+      user,
+      "tx-5",
+      { budget_id: "bud-2", category_id: null, category_confidence: 0 },
+      { category_id: "cat-3", budget_id: "bud-1" },
+    );
+    expect(writes()).toHaveLength(0);
+  });
+
+  test("category clear that leaves the budget unchanged → still a rejection", async () => {
+    await recordSuggestionFeedback(
+      user,
+      "tx-6",
+      { budget_id: "bud-1", category_id: null, category_confidence: 0 },
+      { category_id: "cat-4", budget_id: "bud-1" },
+    );
+    const w = writes();
+    expect(w).toHaveLength(1);
+    expect(isConfirm(w[0][0] as string)).toBe(false);
+    expect(w[0][1]).toEqual(["tx-6", "u-1", "cat-4"]);
+  });
+
+  test("engine-fractional confidence → no user-action write", async () => {
+    await recordSuggestionFeedback(
+      user,
+      "tx-7",
+      { category_id: "cat-5", category_confidence: 0.97 },
+      { category_id: null, budget_id: "bud-1" },
+    );
+    expect(writes()).toHaveLength(0);
+  });
+
+  test("label without category_confidence → no-op", async () => {
+    await recordSuggestionFeedback(
+      user,
+      "tx-8",
+      { budget_id: "bud-2" },
+      { category_id: "cat-6", budget_id: "bud-1" },
+    );
+    expect(writes()).toHaveLength(0);
+  });
+
+  test("undefined label → no-op", async () => {
+    await recordSuggestionFeedback(user, "tx-9", undefined, {
+      category_id: "cat-7",
+      budget_id: "bud-1",
+    });
+    expect(writes()).toHaveLength(0);
+  });
+});

--- a/src/server/lib/record-suggestion-feedback.ts
+++ b/src/server/lib/record-suggestion-feedback.ts
@@ -1,0 +1,77 @@
+import type { JSONTransactionLabel } from "common";
+import {
+  MaskedUser,
+  upsertUserConfirmedSuggestion,
+  upsertUserRejectedSuggestion,
+} from "./postgres";
+
+interface PreviousLabel {
+  category_id: string | null;
+  budget_id: string | null;
+}
+
+/**
+ * Mirror a user's category action on a transaction into the `suggestions`
+ * event log so the auto-suggest engine can learn from confirmations and
+ * rejections (#333). The denormalized `transactions.label_*` columns stay
+ * the read cache; this writes the append-only user-intent signal the engine
+ * reads. Called at the route boundary (after a successful transaction
+ * update) so every confirm/reject path — explicit category pick,
+ * accept-in-place, and clear-to-reject — funnels through one choke point.
+ *
+ * Intent is read from `category_confidence` (set by `inferLabelConfidence`):
+ *  - `1` → the user confirmed a category. The confirmed category is the one
+ *    in the request body, or — for accept-in-place, where the body carries
+ *    only `category_confidence` — the category already on the row.
+ *  - `0` → the user rejected a category (cleared the select). The body's
+ *    `category_id` is null, so the rejected category is the one that was on
+ *    the row before the clear.
+ *
+ * Fractional confidence (engine writes) and absent confidence (no-op label
+ * updates) never reach here — only the two explicit user actions feed the
+ * signal.
+ *
+ * Stage 2a of #333: this records the signal. The read switch that makes
+ * `getMerchantSignal` source confirm/reject counts from this table is a
+ * follow-up.
+ */
+export const recordSuggestionFeedback = async (
+  user: MaskedUser,
+  transaction_id: string,
+  label: Partial<JSONTransactionLabel> | undefined,
+  previous: PreviousLabel,
+): Promise<void> => {
+  if (!label) return;
+  const { category_confidence } = label;
+  if (category_confidence !== 0 && category_confidence !== 1) return;
+
+  // The body carries `category_id` only on an explicit pick; accept-in-place
+  // and clear-to-reject omit it (or send null), so fall back to the category
+  // that was on the row before this update.
+  const bodyCategoryId =
+    "category_id" in label ? label.category_id ?? null : null;
+  const category_id = bodyCategoryId ?? previous.category_id;
+  if (!category_id) return;
+
+  if (category_confidence === 1) {
+    await upsertUserConfirmedSuggestion(user, transaction_id, category_id);
+    return;
+  }
+
+  // category_confidence === 0 — a rejection, UNLESS this request is a budget
+  // switch that cleared the category as a side effect. Switching budgets is
+  // not a category rejection and must not feed negative merchant signal. A
+  // budget switch sends a `budget_id` that differs from the row's current
+  // one; a genuine category clear leaves the budget unchanged (or only fills
+  // an empty one with the account default). Err toward NOT recording a
+  // false rejection: a budget change on an already-budgeted row is treated
+  // as a switch, not a reject.
+  const budgetSwitched =
+    "budget_id" in label &&
+    label.budget_id != null &&
+    previous.budget_id != null &&
+    label.budget_id !== previous.budget_id;
+  if (budgetSwitched) return;
+
+  await upsertUserRejectedSuggestion(user, transaction_id, category_id);
+};

--- a/src/server/routes/accounts/post-transaction.ts
+++ b/src/server/routes/accounts/post-transaction.ts
@@ -5,6 +5,8 @@ import {
   requireStringField,
   validationError,
   inferLabelConfidence,
+  getTransaction,
+  recordSuggestionFeedback,
 } from "server";
 import type { PartialTransaction } from "server";
 import { logger } from "server/lib/logger";
@@ -39,12 +41,20 @@ export const postTransactionRoute = new Route<TransactionPostResponse>(
     try {
       // Cast is safe after validation above
       const transaction = inferLabelConfidence(bodyResult.data! as PartialTransaction);
+      // Capture the label that's on the row BEFORE the update — a reject
+      // clears `label_category_id` to null, so the rejected category can only
+      // be read from the pre-update state.
+      const existing = await getTransaction(user, txIdResult.data!);
       const response = await updateTransactions(user, [transaction]);
       const result = response[0];
       if (!result || result.status >= 400) {
         throw new Error("Database responded with an error.");
       }
       const transaction_id = result.update._id || "";
+      await recordSuggestionFeedback(user, txIdResult.data!, transaction.label, {
+        category_id: existing?.label.category_id ?? null,
+        budget_id: existing?.label.budget_id ?? null,
+      });
       return { status: "success", body: { transaction_id } };
     } catch (error: unknown) {
       logger.error("Failed to update transaction", { transactionId: txIdResult.data }, error);


### PR DESCRIPTION
## Stage 2a of #333 — record the user signal

PR #496 introduced the `suggestions` event log as **dormant infrastructure** ("No route, engine, or FE code reads from or writes to the table yet — that's Stage 2"). This PR is the **write half** of Stage 2: the transaction route now records every user category action into the log.

### The bug, restated
`getMerchantSignal` computes `rejected` from `transactions` rows with `label_category_confidence = 0`, but a reject **clears** `label_category_id` to null, so rejected rows fall into the NULL bucket and are dropped — `rejected` is always 0. Hoie's locked design (on #333 / #496) is a separate `suggestions` log keyed on `(transaction_id, category_id)` with explicit `is_confirmed` / `is_rejected` flags, so user intent is recorded directly instead of inferred from `confidence`.

### What this PR does
- **`recordSuggestionFeedback`** (new route-boundary helper) maps a label update to one suggestion-log write:
  - `category_confidence === 1` → `upsertUserConfirmedSuggestion`. The confirmed category is the body's pick, or — for **accept-in-place** (yellow dot), where the body carries only `{ category_confidence: 1 }` — the category already on the row.
  - `category_confidence === 0` → `upsertUserRejectedSuggestion`. The body's `category_id` is null on a clear, so the rejected category is read from the row's **pre-update** state.
- **Budget-switch disambiguation.** `onChangeBudgetSelect` also clears the category and posts `category_confidence: 0`, but switching budgets is *not* a category rejection (it must not feed negative merchant signal — see the #333 discussion). The helper treats a confidence-0 update that changes an **already-set** budget as a switch, not a rejection. It errs toward *not* recording a false rejection.
- **`post-transaction` route** reads the existing row before the update (the rejected/accept-in-place category can only be read pre-clear) and calls the helper after a successful write. Single choke point — every FE confirm/reject path flows through it (explicit pick, accept-in-place, clear-to-reject, Accept-All).

### Scope
- **Transactions only.** The `suggestions` table FKs `transaction_id` to `transactions`; split and investment transactions live in other tables and cannot have suggestion rows by design. Deferred accordingly.
- **No engine read change.** `getMerchantSignal` is untouched, so suggestion *output* is identical to `upstream/main` — zero money-path regression risk. This PR only adds rows to the log.

### Follow-ups (Stage 2b, next run)
- Switch `getMerchantSignal` to source confirm/reject counts from `suggestions` (the change that actually closes the user-visible "rejected always 0" symptom). It changes engine behavior on real data and deserves its own focused, heavily-E2E'd PR.
- Have `applyLabel` write `upsertEngineSuggestion` so engine scores live in the log too.

Part of #333 (does not close it — Stage 2b does).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test src/server` — 583 pass / 0 fail
- [x] new `record-suggestion-feedback.test.ts` — 9 pass (confirm-pick, accept-in-place, clear-reject, no-previous no-op, budget-switch-not-reject, budget-unchanged-reject, engine-fractional no-op, no-confidence no-op, undefined-label no-op)
- [x] **UI E2E (Playwright, sandbox port 20500, logged in admin, `/transactions` Yearly view)** — drove the real budget/category `<select>`s and asserted against the `suggestions` table in the DB the server actually used:
  - **Confirm** — picked a different category on a row → POST `/api/transaction {category_id, category_confidence:1}` → DB: `suggestions(tx, category)` with `is_confirmed=true, confidence=1`. ✓
  - **Reject** — cleared a row's category (→ "Select Category") → POST `{category_id:null, category_confidence:0}` → DB: `suggestions(tx, previous_category)` with `is_rejected=true, confidence=0`. ✓
  - **Budget switch (disambiguation)** — changed a categorized row's *budget* (clears the category, also posts `category_confidence:0`) → POST `{budget_id:new, category_id:null, category_confidence:0}` → DB: **no rejection row written** for that transaction. ✓ — confirms a budget switch is not mistaken for a category rejection.
  - Screenshot: `/tmp/pr-500-year.png` (transactions year view with the selects driven).

> ⚠️ Verification note: the budget sandbox server inherited `POSTGRES_DATABASE=budget` from the spawn environment, overriding the per-sandbox clone (`budget_sandbox_20500`) — the same isolation leak flagged for the inbox sandbox on 2026-06-08, now confirmed for budget. The E2E assertions are valid (they were checked against the DB the running server actually read/wrote), but the run mutated the local `budget` DB; the 3 touched transaction labels and the test suggestion rows were restored afterward. Fix belongs in `~/claude/scripts/up-sandbox-app.ts` (force/unset `POSTGRES_DATABASE` in the spawned server env).
