### PR TITLE
fix(flow-chart): net per-section amounts so self-cancelling transfers don't double-count

### DIFF
--- a/src/client/components/FlowChartRow/lib.test.ts
+++ b/src/client/components/FlowChartRow/lib.test.ts
@@ -1,0 +1,189 @@
+import { describe, test, expect } from "bun:test";
+import { ViewDate } from "common";
+import {
+  Account,
+  Budget,
+  BudgetDictionary,
+  Category,
+  CategoryDictionary,
+  Section,
+  SectionDictionary,
+  Transaction,
+  TransactionDictionary,
+  InvestmentTransactionDictionary,
+} from "client";
+import { getSankeyData } from "./lib";
+
+// ---------------------------------------------------------------------------
+// Fixture helpers — minimal shapes that exercise getSankeyData's aggregation.
+// We're testing the partition-by-net logic, not the model classes themselves.
+// ---------------------------------------------------------------------------
+
+const TX_DATE = "2026-06-05T00:00:00";
+const view = new ViewDate("month", new Date(2026, 5, 15)); // June 2026
+
+const makeBudget = (id: string, name: string): Budget =>
+  new Budget({
+    budget_id: id,
+    name,
+    iso_currency_code: "USD",
+    capacities: [{ capacity_id: "c", month: 0 }],
+  });
+
+const makeSection = (id: string, name: string, budget_id: string): Section =>
+  new Section({
+    section_id: id,
+    budget_id,
+    name,
+    capacities: [{ capacity_id: "c", month: 0 }],
+  });
+
+const makeCategory = (id: string, name: string, section_id: string): Category =>
+  new Category({
+    category_id: id,
+    section_id,
+    name,
+    capacities: [{ capacity_id: "c", month: 0 }],
+  });
+
+const makeAccount = (id: string, budget_id: string): Account =>
+  new Account({
+    account_id: id,
+    name: "Account",
+    balances: { available: 0, current: 0, iso_currency_code: "USD" } as never,
+    label: { budget_id },
+    hide: false,
+  } as never);
+
+const makeTx = (id: string, account_id: string, amount: number, label: object): Transaction =>
+  new Transaction({
+    transaction_id: id,
+    account_id,
+    amount,
+    date: TX_DATE,
+    authorized_date: TX_DATE,
+    label: label as never,
+    iso_currency_code_at_purchase: "USD",
+  } as never);
+
+const sankeyTotalsBySectionId = (sankey: ReturnType<typeof getSankeyData>) => {
+  const out = new Map<string, { side: "income" | "expense"; amount: number }>();
+  // column1 = income sections; column5 = expense sections
+  sankey.graphData[0].forEach((r) => out.set(r.id, { side: "income", amount: r.amount }));
+  sankey.graphData[4].forEach((r) => out.set(r.id, { side: "expense", amount: r.amount }));
+  return out;
+};
+
+describe("getSankeyData — net-by-section partition", () => {
+  const buildScene = (txs: Transaction[]) => {
+    const budgets = new BudgetDictionary();
+    budgets.set("budget-expense", makeBudget("budget-expense", "Spending"));
+    budgets.set("budget-income", makeBudget("budget-income", "Income"));
+    budgets.set("budget-transfer", makeBudget("budget-transfer", "Transfers"));
+
+    const sections = new SectionDictionary();
+    sections.set("sec-shopping", makeSection("sec-shopping", "Shopping", "budget-expense"));
+    sections.set("sec-salary", makeSection("sec-salary", "Salary", "budget-income"));
+    sections.set("sec-transfer", makeSection("sec-transfer", "Transfers", "budget-transfer"));
+
+    const categories = new CategoryDictionary();
+    categories.set("cat-shopping", makeCategory("cat-shopping", "Misc", "sec-shopping"));
+    categories.set("cat-salary", makeCategory("cat-salary", "Paycheck", "sec-salary"));
+    categories.set("cat-transfer", makeCategory("cat-transfer", "Transfers", "sec-transfer"));
+
+    const accounts = [
+      makeAccount("acc-1", "budget-expense"),
+      makeAccount("acc-2", "budget-income"),
+    ];
+
+    const txDict = new TransactionDictionary();
+    txs.forEach((t) => txDict.set(t.transaction_id, t));
+
+    return getSankeyData(
+      accounts,
+      txDict,
+      new InvestmentTransactionDictionary(),
+      budgets,
+      sections,
+      categories,
+      view,
+    );
+  };
+
+  test("transfer pair (one section, +X and −X) → section drops from BOTH sides; income/expense unchanged", () => {
+    // Two transfer legs labeled to the Transfers section. The signed sum
+    // is 0; nothing should land on either side of the chart.
+    const result = buildScene([
+      makeTx("tx-a", "acc-1", 100, { budget_id: "budget-transfer", category_id: "cat-transfer" }),
+      makeTx("tx-b", "acc-2", -100, { budget_id: "budget-transfer", category_id: "cat-transfer" }),
+    ]);
+
+    const totals = sankeyTotalsBySectionId(result);
+    expect(totals.has("sec-transfer")).toBe(false);
+    expect(result.tableData.income).toBe(0);
+    expect(result.tableData.expense).toBe(0);
+  });
+
+  test("pure expense section (Shopping, all positive amounts) → routes to expense side only", () => {
+    const result = buildScene([
+      makeTx("tx-1", "acc-1", 50, { budget_id: "budget-expense", category_id: "cat-shopping" }),
+      makeTx("tx-2", "acc-1", 30, { budget_id: "budget-expense", category_id: "cat-shopping" }),
+    ]);
+
+    const totals = sankeyTotalsBySectionId(result);
+    expect(totals.get("sec-shopping")).toEqual({ side: "expense", amount: 80 });
+    expect(result.tableData.expense).toBe(80);
+    expect(result.tableData.income).toBe(0);
+  });
+
+  test("pure income section (Salary, all negative amounts) → routes to income side only with absolute magnitude", () => {
+    const result = buildScene([
+      makeTx("tx-3", "acc-2", -2000, { budget_id: "budget-income", category_id: "cat-salary" }),
+    ]);
+
+    const totals = sankeyTotalsBySectionId(result);
+    expect(totals.get("sec-salary")).toEqual({ side: "income", amount: 2000 });
+    expect(result.tableData.income).toBe(2000);
+    expect(result.tableData.expense).toBe(0);
+  });
+
+  test("mixed section (refund inside Shopping) → routes to net-sign side with REDUCED magnitude", () => {
+    // $200 purchase + $50 refund → net $150 expense.
+    // Pre-fix this would have shown $200 on expense AND $50 on income for
+    // the same section. Post-fix: only $150 on expense.
+    const result = buildScene([
+      makeTx("tx-buy", "acc-1", 200, { budget_id: "budget-expense", category_id: "cat-shopping" }),
+      makeTx("tx-refund", "acc-1", -50, { budget_id: "budget-expense", category_id: "cat-shopping" }),
+    ]);
+
+    const totals = sankeyTotalsBySectionId(result);
+    expect(totals.get("sec-shopping")).toEqual({ side: "expense", amount: 150 });
+    expect(result.tableData.expense).toBe(150);
+    expect(result.tableData.income).toBe(0);
+  });
+
+  test("multiple sections — independent partition", () => {
+    const result = buildScene([
+      makeTx("tx-buy", "acc-1", 100, { budget_id: "budget-expense", category_id: "cat-shopping" }),
+      makeTx("tx-pay", "acc-2", -500, { budget_id: "budget-income", category_id: "cat-salary" }),
+      // transfer pair — should drop entirely
+      makeTx("tx-out", "acc-1", 200, { budget_id: "budget-transfer", category_id: "cat-transfer" }),
+      makeTx("tx-in", "acc-2", -200, { budget_id: "budget-transfer", category_id: "cat-transfer" }),
+    ]);
+
+    const totals = sankeyTotalsBySectionId(result);
+    expect(totals.get("sec-shopping")).toEqual({ side: "expense", amount: 100 });
+    expect(totals.get("sec-salary")).toEqual({ side: "income", amount: 500 });
+    expect(totals.has("sec-transfer")).toBe(false);
+    expect(result.tableData.expense).toBe(100);
+    expect(result.tableData.income).toBe(500);
+  });
+
+  test("a transaction with amount=0 is skipped (no zero rows on either side)", () => {
+    const result = buildScene([
+      makeTx("tx-zero", "acc-1", 0, { budget_id: "budget-expense", category_id: "cat-shopping" }),
+    ]);
+    expect(result.graphData[0]).toHaveLength(0);
+    expect(result.graphData[4]).toHaveLength(0);
+  });
+});

--- a/src/client/components/FlowChartRow/lib.ts
+++ b/src/client/components/FlowChartRow/lib.ts
@@ -17,6 +17,22 @@ export interface SankeyData {
   tableData: { income: number; expense: number };
 }
 
+/**
+ * Internal accumulator: signed sum per (section_id / budget_id) before
+ * partitioning into income vs expense. Sign convention follows Plaid /
+ * `transactions.amount` — positive = debit (money out, expense),
+ * negative = credit (money in, income). After all transactions are
+ * processed we partition by net sign so a section whose debits and
+ * credits cancel (Transfers) doesn't double-count on both sides of
+ * the chart.
+ */
+interface SignedRow {
+  id: string;
+  name: string;
+  signedAmount: number;
+  next?: string;
+}
+
 export const getSankeyData = (
   accounts: Account[],
   transactions: TransactionDictionary,
@@ -26,13 +42,8 @@ export const getSankeyData = (
   categories: CategoryDictionary,
   viewDate: ViewDate,
 ): SankeyData => {
-  const incomeBudgets = new Map<string, SankeyRow>();
-  const incomeSections = new Map<string, SankeyRow>();
-  const expenseBudgets = new Map<string, SankeyRow>();
-  const expenseSections = new Map<string, SankeyRow>();
-
-  let income = 0;
-  let expense = 0;
+  const sectionTotals = new Map<string, SignedRow>();
+  const budgetTotals = new Map<string, SignedRow>();
 
   const processTransaction = (t: Transaction | InvestmentTransaction) => {
     const isInvestment = t instanceof InvestmentTransaction;
@@ -49,39 +60,70 @@ export const getSankeyData = (
     const section_id = (category && category.section_id) || `${budget_id}_Unknown`;
     const section = sections.get(section_id);
     const amount = isInvestment ? -(t.price * t.quantity) : t.amount;
-    if (amount < 0) {
-      income -= amount;
-      incomeSections.set(section_id, {
-        id: section_id,
-        name: section?.name || "Unsorted",
-        amount: (incomeSections.get(section_id)?.amount || 0) - amount,
-        next: budget_id,
-      });
-      incomeBudgets.set(budget_id, {
-        id: budget_id,
-        name: budgetName,
-        amount: (incomeBudgets.get(budget_id)?.amount || 0) - amount,
-        next: "Total",
-      });
-    } else if (amount > 0) {
-      expense += amount;
-      expenseSections.set(section_id, {
-        id: section_id,
-        name: section?.name || "Unsorted",
-        amount: (expenseSections.get(section_id)?.amount || 0) + amount,
-        next: budget_id,
-      });
-      expenseBudgets.set(budget_id, {
-        id: budget_id,
-        name: budgetName,
-        amount: (expenseBudgets.get(budget_id)?.amount || 0) + amount,
-        next: "Total",
-      });
-    }
+    if (amount === 0) return;
+
+    const prevSection = sectionTotals.get(section_id);
+    sectionTotals.set(section_id, {
+      id: section_id,
+      name: section?.name || "Unsorted",
+      signedAmount: (prevSection?.signedAmount || 0) + amount,
+      next: budget_id,
+    });
+
+    const prevBudget = budgetTotals.get(budget_id);
+    budgetTotals.set(budget_id, {
+      id: budget_id,
+      name: budgetName,
+      signedAmount: (prevBudget?.signedAmount || 0) + amount,
+    });
   };
 
   transactions.forEach(processTransaction);
   investmentTransactions.forEach(processTransaction);
+
+  // Partition by net sign. A section/budget whose debits and credits
+  // perfectly cancel (e.g. self-transfers labeled to the Transfers
+  // section) nets to 0 and drops out entirely — matching the Budget
+  // page's `sorted_amount` aggregation. Magnitude on the chart is the
+  // absolute net, so partial offsets (a refund inside a Shopping
+  // section) reduce the bar to the remaining net spending.
+  const incomeBudgets = new Map<string, SankeyRow>();
+  const incomeSections = new Map<string, SankeyRow>();
+  const expenseBudgets = new Map<string, SankeyRow>();
+  const expenseSections = new Map<string, SankeyRow>();
+
+  let income = 0;
+  let expense = 0;
+
+  sectionTotals.forEach((row) => {
+    if (row.signedAmount < 0) {
+      const abs = -row.signedAmount;
+      incomeSections.set(row.id, { id: row.id, name: row.name, amount: abs, next: row.next });
+    } else if (row.signedAmount > 0) {
+      expenseSections.set(row.id, {
+        id: row.id,
+        name: row.name,
+        amount: row.signedAmount,
+        next: row.next,
+      });
+    }
+  });
+
+  budgetTotals.forEach((row) => {
+    if (row.signedAmount < 0) {
+      const abs = -row.signedAmount;
+      income += abs;
+      incomeBudgets.set(row.id, { id: row.id, name: row.name, amount: abs, next: "Total" });
+    } else if (row.signedAmount > 0) {
+      expense += row.signedAmount;
+      expenseBudgets.set(row.id, {
+        id: row.id,
+        name: row.name,
+        amount: row.signedAmount,
+        next: "Total",
+      });
+    }
+  });
 
   const total = Math.max(income, expense);
 


### PR DESCRIPTION
## What

The Sankey flow chart on the dashboard / chart pages was double-counting self-transfers. Both legs of a transfer pair (`+X` and `−X`) landed on opposite sides of the chart as ABSOLUTE magnitudes, even though they cancel — so the Transfers section showed up on both the income and expense sides at magnitude X, but the Budget page (which nets per category) showed it correctly at $0.

## Repro on prod data

For Hoie's prod budget (June 2026):

| Transfer pair | leg A | leg B |
|---|---|---|
| 1 | +A | −A |
| 2 | +B | −B |
| 3 | +C | −C |

All labeled to the Transfers budget/section/category. Signed sum = $0 (each pair self-cancels). Budget page showed $0. Flow chart showed $[redacted] on the expense side AND on the income side for the same Transfers section.

## Root cause

`getSankeyData` in `src/client/components/FlowChartRow/lib.ts` segregated each transaction by sign at ingest time into TWO maps (`expenseSections` and `incomeSections`), each holding absolute magnitudes. There was no point at which the +X and −X legs of a transfer pair could cancel — they ended up on opposite sides as same-magnitude entries.

`getBudgetData` (in `src/client/lib/hooks/calculation/budgets.ts`) does the right thing: each transaction's `amount += sorted_amount` on the section, so signed sums net naturally.

## Fix

Mirror the Budget page's aggregation:

1. Accumulate signed amounts per (section_id, budget_id) into single intermediate maps.
2. After processing all transactions, partition each section/budget by net sign:
   - `net < 0` → income side (magnitude = `|net|`)
   - `net > 0` → expense side (magnitude = `net`)
   - `net = 0` → drop entirely

Self-cancelling transfers (net = 0) disappear from the chart. Partial offsets — a refund inside a Shopping section — correctly reduce the bar to the remaining net spending instead of double-counting both legs.

## Tests (6 new in `src/client/components/FlowChartRow/lib.test.ts`)

- transfer pair → section drops from both sides; income/expense totals unchanged
- pure expense section → expense side only
- pure income section → income side only with absolute magnitude
- mixed section (refund inside Shopping) → routes to net-sign with reduced magnitude
- multi-section batch — independent partition
- `amount=0` transactions skipped (no zero rows)

Full suite 801/801 pass; typecheck + lint clean.

## E2E verification (to follow on sandbox spin)

Sandbox at port 20503 — will drive the Dashboard's flow chart against unscrambled prod data, screenshot, and compare against the Budget page's Transfers section reading $0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*[Edited 2026-06-11: redacted real prod-budget dollar figures (transfer-pair magnitudes + section total) per §2a PII policy. Structure/logic unchanged.]*