### PR TITLE
feat(auto-suggest): read rejected count from rejected_categories

### DIFF
--- a/src/server/lib/compute-tools/auto-suggest.test.ts
+++ b/src/server/lib/compute-tools/auto-suggest.test.ts
@@ -483,4 +483,93 @@ describe("runAutoSuggestions", () => {
       expect(matches.length).toBeGreaterThanOrEqual(2);
     });
   });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Merchant signal SQL shape (Stage 2b: rejected reads from
+  // rejected_categories instead of transactions.label_category_confidence)
+  // ──────────────────────────────────────────────────────────────────────
+
+  describe("merchant signal SQL shape", () => {
+    const captureSignalSql = async () => {
+      userRows = [userRow({ user_id: "u-shape" })];
+      unlabeledByUser.set("u-shape", [
+        txRow({ transaction_id: "txn-shape", user_id: "u-shape", merchant_name: "Probe Co" }),
+      ]);
+      signalRow = {
+        label_category_id: "cat-shape",
+        label_budget_id: "bud-shape",
+        accepted: "5",
+        rejected: "0",
+      };
+      await runAutoSuggestions();
+      const signalQuery = mockQuery.mock.calls.find((c) =>
+        /similarity\(merchant_name/i.test(c[0] as string),
+      );
+      expect(signalQuery).toBeDefined();
+      return signalQuery![0] as string;
+    };
+
+    test("ACCEPTED is read from transactions WHERE label_category_confidence = 1.0 only", async () => {
+      const sql = await captureSignalSql();
+      // Inner pool of confirmed transactions narrows on conf=1.0 — not
+      // `IS NOT NULL` (the pre-Stage-2b shape) and not `= 0.0` (the old
+      // rejected-as-conf-zero pattern, now retired).
+      expect(sql).toMatch(/label_category_confidence\s*=\s*1\.0/);
+      expect(sql).not.toMatch(/label_category_confidence\s+IS NOT NULL/);
+      expect(sql).not.toMatch(/label_category_confidence\s*=\s*0\.0/);
+    });
+
+    test("REJECTED is read from rejected_categories joined to transactions for merchant match", async () => {
+      const sql = await captureSignalSql();
+      // The subquery for `rejected` references the new table directly,
+      // joins to `transactions` for the merchant filter, and scopes by
+      // user_id on BOTH sides (defense-in-depth against future schema
+      // changes that could let a transaction_id appear under another user).
+      expect(sql).toMatch(/FROM\s+rejected_categories\s+rc/);
+      expect(sql).toMatch(
+        /JOIN\s+transactions\s+t\s+ON\s+t\.transaction_id\s*=\s*rc\.transaction_id/,
+      );
+      expect(sql).toMatch(/rc\.user_id\s*=\s*\$1/);
+      expect(sql).toMatch(/rc\.category_id\s*=\s*w\.label_category_id/);
+    });
+
+    test("merchant similarity filter applies to BOTH accepted and rejected", async () => {
+      const sql = await captureSignalSql();
+      // similarity(...) must appear at least three times: the inner
+      // ORDER BY for ranking confirms, the inner WHERE for confirms, and
+      // the rejection subquery's t.merchant_name filter. Two-or-fewer
+      // would mean a side dropped the merchant filter — that would
+      // double-count rejections from unrelated merchants.
+      const matches = sql.match(/similarity\(/g) ?? [];
+      expect(matches.length).toBeGreaterThanOrEqual(3);
+    });
+
+    test("soft-deleted transactions are excluded from BOTH accepted and rejected counts", async () => {
+      const sql = await captureSignalSql();
+      // Both the accepted-side and the rejected-side joins must filter
+      // out soft-deleted rows so a stale `is_deleted = true` row can't
+      // inflate either side's signal.
+      const matches =
+        sql.match(/is_deleted\s+IS\s+NULL\s+OR\s+(?:\w+\.)?is_deleted\s*=\s*FALSE/gi) ?? [];
+      expect(matches.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test("recent-confirms pool is bounded by LIMIT $4 (MERCHANT_SIGNAL_LIMIT)", async () => {
+      const sql = await captureSignalSql();
+      // The recency cap on the accepted pool is what keeps an ancient
+      // merchant-confirm pattern from out-voting a recent one. Rejected
+      // count is INTENTIONALLY uncapped (explicit user feedback should
+      // stick), so the LIMIT only governs the confirms pool.
+      expect(sql).toMatch(/LIMIT\s+\$4/);
+    });
+
+    test("winning category is picked by accepted COUNT DESC (recent confirms only)", async () => {
+      const sql = await captureSignalSql();
+      // ORDER BY COUNT(*) DESC LIMIT 1 in the winning CTE — rejections
+      // do not influence WHICH category wins, only the gate that filters
+      // the suggestion downstream.
+      expect(sql).toMatch(/ORDER\s+BY\s+COUNT\(\*\)\s+DESC/i);
+      expect(sql).toMatch(/WITH\s+winning\s+AS/i);
+    });
+  });
 });

--- a/src/server/lib/compute-tools/auto-suggest.ts
+++ b/src/server/lib/compute-tools/auto-suggest.ts
@@ -156,15 +156,17 @@ const applyLabelToSplit = async (
  *
  * Logic:
  * - For each user, find transactions with no category confidence (never labeled)
- * - For each such transaction's merchant_name, look at recent labeled transactions
- *   matching the merchant via pg_trgm fuzzy similarity
+ * - For each such transaction's merchant_name, look at recent confirmed
+ *   transactions matching the merchant via pg_trgm fuzzy similarity, AND
+ *   count rejections of the winning category from `rejected_categories`
  * - If enough signal (>= 3 labeled, <= 10% reject rate, >= 95% confidence for best category),
  *   apply the suggestion with confidence = accepted / total_labeled (capped at 0.99)
  *
  * Direct SQL is reserved for the merchant-signal query, which uses pg_trgm
- * `similarity(...)` and a SUM(CASE WHEN ...) aggregation that the standard
- * Table helpers cannot express. The unlabeled fetch and the label-apply
- * use `transactionsTable.query` / `transactionsTable.update` (the standard pattern).
+ * `similarity(...)` and a cross-table count (transactions + rejected_categories)
+ * that the standard Table helpers cannot express. The unlabeled fetch and the
+ * label-apply use `transactionsTable.query` / `transactionsTable.update` (the
+ * standard pattern).
  */
 export const runAutoSuggestions = async (): Promise<void> => {
   logger.info("Auto-suggestion job started");
@@ -269,38 +271,60 @@ const getMerchantSignal = async (
   userId: string,
   merchantName: string,
 ): Promise<MerchantSignal | null> => {
-  // Fuzzy-match merchant_name via pg_trgm similarity so that variants like
-  // "STARBUCKS #1234" and "STARBUCKS COFFEE 9876" feed the same signal.
-  // Inner SELECT picks the most-recent N transactions whose merchant_name is
-  // similar enough, then we group by category and take the most-accepted one.
-  // Stays raw SQL: similarity(...) + SUM(CASE WHEN ...) aggregation isn't
-  // expressible via the standard Table.query helpers.
-  // The outer query also joins categories → sections so the winning
-  // category's actual parent budget is carried out alongside it. We need
-  // that downstream when applying the label so the suggested row's
-  // `label_budget_id` matches its `label_category_id` (otherwise the UI
-  // select renders empty — see MerchantSignal docstring).
+  // Two-source signal:
+  //  - ACCEPTED: `transactions.label_category_confidence = 1.0` rows. The
+  //    inner SELECT picks the top-N most-recent similar-merchant confirms,
+  //    grouped by category, winner = max accepted.
+  //  - REJECTED: `rejected_categories` rows joined to transactions for the
+  //    merchant filter. Counts ALL rejections of the winning category for
+  //    this user against this merchant — unbounded by the recency LIMIT
+  //    above. Rationale: a rejection is an explicit user signal; it should
+  //    stick until the user re-picks that category (which triggers
+  //    `removeRejectedCategory`).
+  //
+  // Raw SQL stays because pg_trgm `similarity(...)` and the cross-table
+  // count aren't expressible via standard Table.query helpers.
+  //
+  // The outer JOIN to categories → sections carries the winning category's
+  // parent budget along — applied label needs both so the UI category
+  // select renders against the right budget (see MerchantSignal docstring).
   const result = await pool.query(
-    `SELECT
-       recent.label_category_id,
+    `WITH winning AS (
+       SELECT label_category_id, COUNT(*) AS accepted
+       FROM (
+         SELECT label_category_id
+         FROM transactions
+         WHERE user_id = $1
+           AND merchant_name IS NOT NULL
+           AND similarity(merchant_name, $2) >= $3
+           AND label_category_confidence = 1.0
+           AND (is_deleted IS NULL OR is_deleted = FALSE)
+         ORDER BY similarity(merchant_name, $2) DESC, date DESC
+         LIMIT $4
+       ) recent_confirms
+       GROUP BY label_category_id
+       ORDER BY COUNT(*) DESC
+       LIMIT 1
+     )
+     SELECT
+       w.label_category_id,
        sections.budget_id AS label_budget_id,
-       SUM(CASE WHEN recent.label_category_confidence = 1.0 THEN 1 ELSE 0 END) AS accepted,
-       SUM(CASE WHEN recent.label_category_confidence = 0.0 THEN 1 ELSE 0 END) AS rejected
-     FROM (
-       SELECT label_category_id, label_category_confidence
-       FROM transactions
-       WHERE user_id = $1
-         AND merchant_name IS NOT NULL
-         AND similarity(merchant_name, $2) >= $3
-         AND label_category_confidence IS NOT NULL
-         AND (is_deleted IS NULL OR is_deleted = FALSE)
-       ORDER BY similarity(merchant_name, $2) DESC, date DESC
-       LIMIT $4
-     ) recent
-     JOIN categories ON categories.category_id = recent.label_category_id
+       w.accepted,
+       (
+         SELECT COUNT(*)
+         FROM rejected_categories rc
+         JOIN transactions t
+           ON t.transaction_id = rc.transaction_id
+           AND t.user_id = rc.user_id
+         WHERE rc.user_id = $1
+           AND rc.category_id = w.label_category_id
+           AND t.merchant_name IS NOT NULL
+           AND similarity(t.merchant_name, $2) >= $3
+           AND (t.is_deleted IS NULL OR t.is_deleted = FALSE)
+       ) AS rejected
+     FROM winning w
+     JOIN categories ON categories.category_id = w.label_category_id
      JOIN sections ON sections.section_id = categories.section_id
-     GROUP BY recent.label_category_id, sections.budget_id
-     ORDER BY accepted DESC
      LIMIT 1`,
     [userId, merchantName, MERCHANT_SIMILARITY_THRESHOLD, MERCHANT_SIGNAL_LIMIT],
   );


### PR DESCRIPTION
## Summary

Stage 2b of the labels refactor (#333). Now that #501 retired the `transactions.label_category_confidence = 0.0` storage for rejections in favor of an explicit `rejected_categories` table, the engine-side `getMerchantSignal` SQL needs to source its `rejected` count from the new table.

Two-source signal:
- **accepted** — `transactions.label_category_confidence = 1.0` rows in the recent-N similar-merchant pool. Same `MERCHANT_SIGNAL_LIMIT` recency cap as before.
- **rejected** — `rejected_categories` rows for the winning category, joined to `transactions` for the merchant-similarity filter. **Unbounded** by the recency LIMIT — an explicit user "no, not this category" should stick until they re-pick that category (which triggers `removeRejectedCategory`).

The winning category is still picked by `accepted COUNT(*) DESC LIMIT 1` in a `WITH winning AS (...)` CTE. Rejections do NOT influence which category wins, only the gate (`evaluateSignal`) downstream. A category with 0 confirms in the recent pool can never win — same as the pre-2b shape.

## Test plan

- [x] Suite: 822 / 822 pass (16 existing auto-suggest tests + 6 new SQL-shape assertions, +800 elsewhere unchanged)
- [x] Typecheck clean
- [x] Lint clean
- [x] Sandbox E2E against unscrambled prod-clone — `rejected_categories` populated by the post-#502 mirror is read correctly by the engine; confirm a merchant whose user-rejection history blocks the suggestion gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)