### PR TITLE
chore(init): drop the one-shot DROP TABLE IF EXISTS suggestions

### DIFF
--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -69,13 +69,6 @@ export const initializePostgres = async (): Promise<void> => {
     // (used by auto-categorization to group merchant_name variants).
     await pool.query("CREATE EXTENSION IF NOT EXISTS pg_trgm");
 
-    // Drop the dormant `suggestions` table introduced by #496 (replaced by
-    // `rejected_categories` here — same goal, ~half the storage, no
-    // duplication of the confirmed labels already in `transactions`).
-    // Idempotent; no rows depended on it because the table never gained
-    // any callers.
-    await pool.query("DROP TABLE IF EXISTS suggestions CASCADE");
-
     for (const table of tables) {
       const createTableSql = buildCreateTable(table.name, table.schema, table.constraints);
       await pool.query(createTableSql);


### PR DESCRIPTION
## Summary

Removes the \`DROP TABLE IF EXISTS suggestions CASCADE\` line from \`initializePostgres()\`. It was a one-shot migration introduced by #501 to retire the dormant \`suggestions\` table (originally added in #496, replaced by \`rejected_categories\` on the same PR) and has already run on every environment that came up after #501 — production, all sandboxes, and local dev.

The table doesn't exist in the catalog anymore on any live database; the DDL is a no-op there. Removing it shrinks the boot path by one DB round-trip and makes "what init does" closer to "what's in \`tables[]\`" — no side-channel tombstone for an absent table.

## Test plan

- [x] Suite: 822 / 822 pass (no init-path test depended on the DROP)
- [x] Typecheck clean
- [x] Lint clean
- [x] Sandbox spin verified the table-creation path still runs against a clean prod-clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)