### PR TITLE
fix(holdings): bucket security price index by snapshot date, not close_price_as_of (#511)

### DIFF
--- a/src/client/lib/hooks/calculation/holdings.test.ts
+++ b/src/client/lib/hooks/calculation/holdings.test.ts
@@ -125,6 +125,36 @@ describe("buildSecurityPriceIndex", () => {
     expect(index.get("sec1")?.get("2026-01")).toEqual({ price: 105, sourceDate: "2026-01-25" });
   });
 
+  test("keeps one bucket per snapshot month when every snapshot shares one close_price_as_of", () => {
+    // Real-world shape: the `securities` table holds a single `close_price_as_of`
+    // (the latest price's as-of date), and the server join stamps it onto every
+    // historical snapshot while preserving each snapshot's own `close_price`. The
+    // index must bucket by the per-snapshot recording date, not that shared field,
+    // or the whole price history collapses into one month.
+    const sharedAsOf = "2026-03-30";
+    const months = [
+      { date: "2026-01-15", price: 515.8 },
+      { date: "2026-02-15", price: 631.04 },
+      { date: "2026-03-15", price: 580.93 },
+      { date: "2026-06-10", price: 667.05 },
+    ];
+    const snapshots = new SecuritySnapshotDictionary();
+    months.forEach(({ date, price }, i) => {
+      const snap = createSecuritySnapshot("sec1", price, date);
+      snap.security.close_price_as_of = sharedAsOf; // every snapshot carries the same as-of
+      snapshots.set(`snap${i}`, snap);
+    });
+
+    const index = buildSecurityPriceIndex(snapshots);
+
+    // Four distinct monthly buckets, each priced at its own snapshot's close.
+    expect(index.get("sec1")?.size).toBe(4);
+    expect(index.get("sec1")?.get("2026-01")).toEqual({ price: 515.8, sourceDate: "2026-01-15" });
+    expect(index.get("sec1")?.get("2026-02")).toEqual({ price: 631.04, sourceDate: "2026-02-15" });
+    expect(index.get("sec1")?.get("2026-03")).toEqual({ price: 580.93, sourceDate: "2026-03-15" });
+    expect(index.get("sec1")?.get("2026-06")).toEqual({ price: 667.05, sourceDate: "2026-06-10" });
+  });
+
   test("should skip snapshots with null close_price", () => {
     const snapshots = new SecuritySnapshotDictionary();
     const snapshot = createSecuritySnapshot("sec1", 100, "2026-01-15");

--- a/src/client/lib/hooks/calculation/holdings.ts
+++ b/src/client/lib/hooks/calculation/holdings.ts
@@ -11,10 +11,17 @@ import { HoldingSnapshot } from "../../models/Snapshot";
 import { InvestmentTransaction } from "../../models/InvestmentTransaction";
 
 /**
- * One entry in the price index. `sourceDate` is the date the price was
- * recorded (`close_price_as_of` if Plaid surfaced it, otherwise the snapshot
- * date). It's needed downstream so we can compare security-snapshot freshness
- * against the holding snapshot's own date and pick whichever's more recent.
+ * One entry in the price index. `sourceDate` is the snapshot's own recording
+ * date — the date that `close_price` was captured. It's needed downstream so we
+ * can compare security-snapshot freshness against the holding snapshot's own
+ * date and pick whichever's more recent.
+ *
+ * NB: we deliberately do NOT use the security's `close_price_as_of` here. That
+ * column lives on the `securities` table and holds only the *latest* price's
+ * as-of date; the server join stamps it onto every historical snapshot while
+ * preserving each snapshot's own `close_price`. Bucketing by it would collapse
+ * a security's entire price history into one month (the `close_price_as_of`
+ * month) and value holdings at an arbitrary wrong-date close.
  */
 export interface PriceIndexEntry {
   price: number;
@@ -37,11 +44,13 @@ export const buildSecurityPriceIndex = (
 
   securitySnapshots.forEach((snapshot) => {
     const { security } = snapshot;
-    const { security_id, close_price, close_price_as_of } = security;
+    const { security_id, close_price } = security;
 
     if (!security_id || close_price === null || close_price === undefined) return;
 
-    const dateStr = close_price_as_of || snapshot.snapshot.date;
+    // Bucket by the snapshot's own recording date — when this `close_price` was
+    // captured — not the security's live `close_price_as_of` (see PriceIndexEntry).
+    const dateStr = snapshot.snapshot.date;
     if (!dateStr) return;
 
     const date = new LocalDate(dateStr);


### PR DESCRIPTION
## What

`buildSecurityPriceIndex` (`src/client/lib/hooks/calculation/holdings.ts`) bucketed each monthly price entry by the security's `close_price_as_of`. That column lives on the `securities` table and holds only the **latest** price's as-of date; the server join (`repositories/snapshots.ts`) stamps it onto every historical snapshot while preserving each snapshot's own `close_price`.

So for any security with a set `close_price_as_of`, every snapshot in its history mapped to the **same** `yearMonth` bucket, and an arbitrary snapshot's price won it (the `dateStr > existing.sourceDate` tie-break can never fire when all `sourceDate`s are identical). `findLatestEntryLessThanOrEqual` then returned that one wrong-priced bucket for every view month from the `close_price_as_of` month onward, and `undefined` for earlier months — so Holdings Composition showed wrong per-security **Value / Growth / %** at recent view dates, plus a spurious `Unknown` reconciliation row. Account-level totals stayed correct (pinned to balance), which is why it was easy to miss.

Fixes #511.

## Fix

Bucket by `snapshot.snapshot.date` — the date that `close_price` was actually captured — instead of `close_price_as_of`. `sourceDate` (used downstream by `getPriceForHolding` for the security-vs-institution freshness compare) is now the per-snapshot date, which is the correct per-date signal. Read-path only; no schema/server change.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx eslint` (changed files) — clean
- [x] `bun test src` — **823 pass / 0 fail**
- [x] **Regression test** (`holdings.test.ts`): an N-month series sharing one `close_price_as_of` must produce N distinct monthly buckets, each at its own snapshot close. Confirmed it **fails on pre-fix code** (1 fail) and **passes on the fix** (36/36).
- [x] **Index proof on the real served `/api/snapshots?snapshot-type=security` payload** (sandbox, real prod-clone data): for a synced ETF holding (hundreds of snapshots, all carrying one identical `close_price_as_of`) the **old bucketing collapses to 1 month bucket**; the **fix yields the expected distinct monthly buckets** with the correct per-month closes. For a second holding (older `close_price_as_of`) the old index is **1 bucket keyed to that month but holding a much later month's price** — a stale-keyed bucket serving a forward price — vs the fix's correct per-month buckets.
- [x] **Resolved-price proof via the real `getPriceForHolding`** (same real data, a manual security with no `institution_price`, so the security snapshot is the only price source and the defect can't be masked): at an earlier view month the old code resolves a **forward price (~13% too high)** vs the fix's correct contemporaneous close; at a still-earlier month the old code resolves **null** (holding unvaluable — no bucket ≤ that month) vs the fix's correct close. This is exactly the issue's symptom, observed at the calculation boundary that feeds Holdings Composition.
- [x] **UI E2E** (Playwright, sandbox port 20512, admin) — `/account-detail` Holdings Composition renders correctly on the fix at Mar/May/Jun 2026 (holding row priced, Growth/%, no crash; screenshots `/tmp/pr-512-fix-*.png`). Verified **no regression vs current `upstream/main`** built against the same DB (port 20002): renders identically on the synced holding, where `getPriceForHolding`'s freshness tie-break selects `institution_price` every month and thus masks the index difference.
- [ ] **Note — visible $-divergence not surfaced in this clone (honest limitation):** the affected holdings' snapshot dates don't align to expose the symptom in *this* fresh scramble — synced holdings carry a fresh `institution_price` every month so the freshness tie-break hides the index defect, and the only manual-security holding has a single *current* snapshot so it renders only at the current month, where old/new coincidentally agree. The defect and the fix are therefore proven deterministically at the calculation boundary (the two proofs above) rather than via a screenshot dollar-diff. The issue author hit a prod-data alignment (a holding staler than its security data) that does surface it visibly.

*[Edited 2026-06-12: redacted security tickers and per-share prices per security policy §2a — holdings-identity / financial-signal leak. Technical argument preserved.]*