### PR TITLE
fix(securities): SecurityModel.toJSON reads raw Plaid fields instead of hardcoding null

### DIFF
--- a/src/server/lib/postgres/models/security.test.ts
+++ b/src/server/lib/postgres/models/security.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, expect, mock, afterAll } from "bun:test";
+import { restoreLeaves } from "test-helpers";
+
+const mockQuery = mock(async (_sql: string, _values?: unknown[]) => ({
+  rows: [] as unknown[],
+  rowCount: 0 as number | null,
+}));
+
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+}
+
+mock.module("pg", () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {} },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+}));
+
+const { SecurityModel } = await import("./security");
+
+afterAll(restoreLeaves);
+
+const baseRow = {
+  security_id: "sec-1",
+  name: "Tether",
+  ticker_symbol: "USDT",
+  type: "cryptocurrency",
+  close_price: 1,
+  close_price_as_of: "2026-06-01",
+  iso_currency_code: "USD",
+  isin: null,
+  cusip: null,
+  updated: "2026-06-01T00:00:00Z",
+};
+
+describe("SecurityModel.toJSON — round-trips raw Plaid fields (regression for #492)", () => {
+  test("is_cash_equivalent=true surfaces from raw instead of hardcoded null", () => {
+    const model = new SecurityModel({
+      ...baseRow,
+      raw: { is_cash_equivalent: true },
+    });
+    expect(model.toJSON().is_cash_equivalent).toBe(true);
+  });
+
+  test("is_cash_equivalent=false is preserved (not coerced to null)", () => {
+    const model = new SecurityModel({
+      ...baseRow,
+      raw: { is_cash_equivalent: false },
+    });
+    expect(model.toJSON().is_cash_equivalent).toBe(false);
+  });
+
+  test("missing raw → null, no crash", () => {
+    const model = new SecurityModel({ ...baseRow, raw: null });
+    expect(model.toJSON().is_cash_equivalent).toBeNull();
+  });
+
+  test("raw without the key → null", () => {
+    const model = new SecurityModel({ ...baseRow, raw: { sector: "Technology" } });
+    expect(model.toJSON().is_cash_equivalent).toBeNull();
+  });
+
+  test("other previously-hardcoded fields round-trip from raw", () => {
+    const model = new SecurityModel({
+      ...baseRow,
+      raw: {
+        sedol: "B0YQ5W0",
+        institution_security_id: "inst-sec-9",
+        institution_id: "ins_3",
+        proxy_security_id: "prox-1",
+        unofficial_currency_code: null,
+        market_identifier_code: "XNAS",
+        sector: "Technology",
+        industry: "Software",
+        option_contract: null,
+        fixed_income: null,
+      },
+    });
+    const json = model.toJSON();
+    expect(json.sedol).toBe("B0YQ5W0");
+    expect(json.institution_security_id).toBe("inst-sec-9");
+    expect(json.institution_id).toBe("ins_3");
+    expect(json.proxy_security_id).toBe("prox-1");
+    expect(json.market_identifier_code).toBe("XNAS");
+    expect(json.sector).toBe("Technology");
+    expect(json.industry).toBe("Software");
+  });
+
+  test("column-sourced fields are unaffected", () => {
+    const model = new SecurityModel({ ...baseRow, raw: { is_cash_equivalent: true } });
+    const json = model.toJSON();
+    expect(json.security_id).toBe("sec-1");
+    expect(json.ticker_symbol).toBe("USDT");
+    expect(json.close_price).toBe(1);
+    expect(json.iso_currency_code).toBe("USD");
+  });
+});

--- a/src/server/lib/postgres/models/security.ts
+++ b/src/server/lib/postgres/models/security.ts
@@ -70,6 +70,11 @@ export class SecurityModel extends Model<JSONSecurity, SecuritySchema> implement
   }
 
   toJSON(): JSONSecurity {
+    // Fields without a dedicated column are round-tripped through `raw` (the
+    // JSONSecurity stored by fromJSON). Reading them back instead of hardcoding
+    // null preserves Plaid signals the FE/BE rely on — notably is_cash_equivalent,
+    // which feeds the cash-holding detectors. See #492.
+    const raw = (this.raw ?? {}) as Partial<JSONSecurity>;
     return {
       security_id: this.security_id,
       name: this.name,
@@ -80,17 +85,17 @@ export class SecurityModel extends Model<JSONSecurity, SecuritySchema> implement
       iso_currency_code: this.iso_currency_code,
       isin: this.isin,
       cusip: this.cusip,
-      sedol: null,
-      institution_security_id: null,
-      institution_id: null,
-      proxy_security_id: null,
-      is_cash_equivalent: null,
-      unofficial_currency_code: null,
-      market_identifier_code: null,
-      sector: null,
-      industry: null,
-      option_contract: null,
-      fixed_income: null,
+      sedol: raw.sedol ?? null,
+      institution_security_id: raw.institution_security_id ?? null,
+      institution_id: raw.institution_id ?? null,
+      proxy_security_id: raw.proxy_security_id ?? null,
+      is_cash_equivalent: raw.is_cash_equivalent ?? null,
+      unofficial_currency_code: raw.unofficial_currency_code ?? null,
+      market_identifier_code: raw.market_identifier_code ?? null,
+      sector: raw.sector ?? null,
+      industry: raw.industry ?? null,
+      option_contract: raw.option_contract ?? null,
+      fixed_income: raw.fixed_income ?? null,
     };
   }
 


### PR DESCRIPTION
Closes #492

## Problem

`SecurityModel.toJSON()` returned `is_cash_equivalent: null` as a hardcoded literal (along with a dozen other column-less fields), ignoring the value round-tripped through the `securities.raw` JSON column. Any security Plaid tagged `is_cash_equivalent: true` — money-market funds, broker sweeps, USDT/BTC — got stripped of that signal before either the FE or BE ever saw it.

This left the `if (sec.is_cash_equivalent) return true;` branch of both cash detectors dead:
- BE `isCashLikeSecurity` (`compute-tools/cash-holding.ts`)
- FE `buildCashSecurityIds` (`client/lib/hooks/calculation/holdings.ts`, PR #425)

so the only cash signals that still fired were `type === "cash"` and `CUR:*` tickers — missing exactly the money-market case `is_cash_equivalent` was meant to catch.

## Fix

`raw` is populated by `fromJSON` (which stores the full `JSONSecurity`), so the missing fields are already there. Read them back with `?? null` instead of hardcoding: `is_cash_equivalent`, `sedol`, `institution_security_id`, `institution_id`, `proxy_security_id`, `unofficial_currency_code`, `market_identifier_code`, `sector`, `industry`, `option_contract`, `fixed_income`. Column-sourced fields (security_id, name, ticker_symbol, type, close_price, …) are untouched.

## Tests

New `security.test.ts` (6 tests, FakePool/`mock.module("pg")` + `restoreLeaves`):
- `is_cash_equivalent=true` surfaces from raw; `false` is preserved (not coerced to null)
- missing `raw` (null) → null, no crash; `raw` without the key → null
- the other previously-hardcoded fields round-trip from raw
- column-sourced fields unaffected

Full server suite: **595 pass / 0 fail**. tsc clean.

## E2E — real prod-clone data

Loaded the actual `securities` rows whose `raw.is_cash_equivalent = true` through the fixed model:

```
0USDPRAA7                          → is_cash_equivalent = true
QACDS  (Chase Deposit Sweep)       → is_cash_equivalent = true
USDT   (Tether)                    → is_cash_equivalent = true
BTC    (Bitcoin)                   → is_cash_equivalent = true
CUR:USD (U S Dollar)               → is_cash_equivalent = true
Control (VFFVX, 92202V484)         → is_cash_equivalent = false   # correctly preserved, not null
```

Before the fix every one of these returned `null` on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
