### PR TITLE
fix(charts): correct investment cash-flow polarity in Flow chart (#499)

### DIFF
--- a/src/client/components/FlowChartRow/lib.test.ts
+++ b/src/client/components/FlowChartRow/lib.test.ts
@@ -1,4 +1,7 @@
+// Run with: bun test --preload ./scripts/test-preload.ts lib.test.ts
 import { describe, test, expect } from "bun:test";
+import { InvestmentTransactionType, InvestmentTransactionSubtype } from "plaid";
+
 import { LocalDate, ViewDate } from "common";
 import { getSankeyData, SankeyColumn } from "./lib";
 import {
@@ -16,6 +19,7 @@ import { Budget } from "../../lib/models/Budget";
 import { Section } from "../../lib/models/Section";
 import { Category } from "../../lib/models/Category";
 import { Transaction } from "../../lib/models/Transaction";
+import { InvestmentTransaction } from "../../lib/models/InvestmentTransaction";
 import { SplitTransaction } from "../../lib/models/SplitTransaction";
 import type { TransferPair } from "server";
 
@@ -193,5 +197,110 @@ describe("getSankeyData — split re-labeling (#534)", () => {
     } finally {
       globalData.transactions = new TransactionDictionary();
     }
+  });
+});
+
+const INV_ACCT = "inv-acc-1";
+const invViewDate = new ViewDate("month", new LocalDate("2026-02-15")); // Feb 2026
+const invAccount = new Account({ account_id: INV_ACCT, name: "Brokerage" });
+
+// `quantity` is intentionally varied in sign across tests to prove the
+// polarity is derived from `type`, not from the stored sign of quantity.
+const mkInvestment = (
+  type: InvestmentTransactionType,
+  quantity: number,
+  price: number,
+): InvestmentTransaction =>
+  new InvestmentTransaction({
+    account_id: INV_ACCT,
+    type,
+    subtype: InvestmentTransactionSubtype.Buy,
+    quantity,
+    price,
+    amount: price * quantity,
+    date: "2026-02-15",
+  });
+
+const buildInvDicts = (itxns: InvestmentTransaction[], txns: Transaction[] = []) => {
+  const investmentTransactions = new InvestmentTransactionDictionary();
+  itxns.forEach((t) => investmentTransactions.set(t.id, t));
+  const transactions = new TransactionDictionary();
+  txns.forEach((t) => transactions.set(t.id, t));
+  return {
+    investmentTransactions,
+    transactions,
+    budgets: new BudgetDictionary(),
+    sections: new SectionDictionary(),
+    categories: new CategoryDictionary(),
+  };
+};
+
+const runInv = (d: ReturnType<typeof buildInvDicts>) =>
+  getSankeyData(
+    [invAccount],
+    d.transactions,
+    d.investmentTransactions,
+    new SplitTransactionDictionary(),
+    d.budgets,
+    d.sections,
+    d.categories,
+    invViewDate,
+    noTransfers,
+  );
+
+describe("getSankeyData — investment cash-flow polarity", () => {
+  test("a BUY is cash out → counted as expense, not income", () => {
+    // buy: price·quantity = +1000 cash leaving the account
+    const { tableData } = runInv(buildInvDicts([mkInvestment(InvestmentTransactionType.Buy, 10, 100)]));
+    expect(tableData.expense).toBe(1000);
+    expect(tableData.income).toBe(0);
+  });
+
+  test("a SELL is cash in → counted as income, not expense", () => {
+    // sell: price·quantity = -800 cash entering the account
+    const { tableData } = runInv(buildInvDicts([mkInvestment(InvestmentTransactionType.Sell, -8, 100)]));
+    expect(tableData.income).toBe(800);
+    expect(tableData.expense).toBe(0);
+  });
+
+  test("buys and sells net to the correct Surplus/Deficit verdict", () => {
+    // 1000 bought (out) vs 800 sold (in) → net 200 deficit, not a surplus
+    const { tableData } = runInv(
+      buildInvDicts([
+        mkInvestment(InvestmentTransactionType.Buy, 10, 100),
+        mkInvestment(InvestmentTransactionType.Sell, -8, 100),
+      ]),
+    );
+    expect(tableData.expense).toBe(1000);
+    expect(tableData.income).toBe(800);
+    expect(tableData.expense - tableData.income).toBe(200); // deficit
+  });
+
+  // Sign-based detection (Hoie, PR #514): polarity follows `type`, not the
+  // stored sign of `quantity`. A buy with a negative quantity is still cash
+  // out (expense); a sell with a positive quantity is still cash in (income).
+  test("a BUY with a negative quantity is still an expense (sign from type, not quantity)", () => {
+    const { tableData } = runInv(buildInvDicts([mkInvestment(InvestmentTransactionType.Buy, -10, 100)]));
+    expect(tableData.expense).toBe(1000);
+    expect(tableData.income).toBe(0);
+  });
+
+  test("a SELL with a positive quantity is still income (sign from type, not quantity)", () => {
+    const { tableData } = runInv(buildInvDicts([mkInvestment(InvestmentTransactionType.Sell, 8, 100)]));
+    expect(tableData.income).toBe(800);
+    expect(tableData.expense).toBe(0);
+  });
+
+  test("regular transactions keep their convention (positive amount = expense)", () => {
+    const regular = new Transaction({
+      transaction_id: "t-reg",
+      account_id: INV_ACCT,
+      amount: 50,
+      date: "2026-02-10",
+      authorized_date: "2026-02-10",
+    });
+    const { tableData } = runInv(buildInvDicts([], [regular]));
+    expect(tableData.expense).toBe(50);
+    expect(tableData.income).toBe(0);
   });
 });

--- a/src/client/components/FlowChartRow/lib.test.ts
+++ b/src/client/components/FlowChartRow/lib.test.ts
@@ -291,6 +291,21 @@ describe("getSankeyData — investment cash-flow polarity", () => {
     expect(tableData.expense).toBe(0);
   });
 
+  // Only buy/sell are external cash flow. A `transfer` (or cash/fee/dividend)
+  // row is internal movement and must NOT contribute — even when it carries a
+  // nonzero price·quantity. This is the benchmark.ts "count only Buy/Sell"
+  // convention; without the type gate a transfer's magnitude would inflate a
+  // column (reviewoie HIGH on PR #514).
+  test("a non-buy/sell investment type (transfer) with nonzero price·quantity is skipped", () => {
+    const { tableData, graphData } = runInv(
+      buildInvDicts([mkInvestment(InvestmentTransactionType.Transfer, 4875, 1)]),
+    );
+    expect(tableData.income).toBe(0);
+    expect(tableData.expense).toBe(0);
+    // No Surplus/Deficit node either — nothing flowed.
+    expect(graphData.every((col) => col.length === 0)).toBe(true);
+  });
+
   test("regular transactions keep their convention (positive amount = expense)", () => {
     const regular = new Transaction({
       transaction_id: "t-reg",

--- a/src/client/components/FlowChartRow/lib.ts
+++ b/src/client/components/FlowChartRow/lib.ts
@@ -89,13 +89,16 @@ export const getSankeyData = (
     const category = category_id && categories.get(category_id);
     const section_id = (category && category.section_id) || `${budget_id}_Unknown`;
     const section = sections.get(section_id);
-    // For an investment, derive cash-flow polarity from the transaction
-    // TYPE rather than the stored sign of `quantity`: a buy is cash out
-    // (→ expense / positive amount), a sell is cash in (→ income / negative
-    // amount). This matches benchmark.ts's investment-sign convention and
-    // stays correct even if Plaid ever emits a buy with a negative quantity.
-    // `cash`/`fee`/`dividend` rows have quantity 0, so magnitude is 0 and
-    // they fall through both branches below (unchanged from prior behavior).
+    // For an investment, only buy/sell rows are external cash flow; derive
+    // their polarity from the transaction TYPE (a buy is cash out → expense /
+    // positive amount, a sell is cash in → income / negative amount) rather
+    // than from the stored sign of `quantity`, so it stays correct even if
+    // Plaid emits a buy with a negative quantity. Every other type — `cash`,
+    // `fee`, `dividend`, `transfer` — is skipped, matching benchmark.ts
+    // (which counts only `Buy`/`Sell` at lib/hooks/calculation/benchmark.ts).
+    // Skipping `transfer` matters: those carry a nonzero `price * quantity`
+    // (internal movement, not external flow) and would otherwise inflate a
+    // column. Including dividends/fees as flow is deferred per Closes #499.
     //
     // For a regular parent transaction, subtract its split children's total
     // so only the un-split remainder is attributed to the parent's label.
@@ -103,6 +106,9 @@ export const getSankeyData = (
     // split's own id, which keys no family, so their amount is unchanged.
     let amount: number;
     if (isInvestment) {
+      if (t.type !== InvestmentTransactionType.Buy && t.type !== InvestmentTransactionType.Sell) {
+        return;
+      }
       const magnitude = Math.abs(t.price * t.quantity);
       amount = t.type === InvestmentTransactionType.Buy ? magnitude : -magnitude;
     } else {

--- a/src/client/components/FlowChartRow/lib.ts
+++ b/src/client/components/FlowChartRow/lib.ts
@@ -1,3 +1,5 @@
+import { InvestmentTransactionType } from "plaid";
+
 import { LocalDate, ViewDate } from "common";
 import {
   Account,
@@ -87,13 +89,25 @@ export const getSankeyData = (
     const category = category_id && categories.get(category_id);
     const section_id = (category && category.section_id) || `${budget_id}_Unknown`;
     const section = sections.get(section_id);
-    // For a parent transaction, subtract its split children's total so
-    // only the un-split remainder is attributed to the parent's label.
+    // For an investment, derive cash-flow polarity from the transaction
+    // TYPE rather than the stored sign of `quantity`: a buy is cash out
+    // (→ expense / positive amount), a sell is cash in (→ income / negative
+    // amount). This matches benchmark.ts's investment-sign convention and
+    // stays correct even if Plaid ever emits a buy with a negative quantity.
+    // `cash`/`fee`/`dividend` rows have quantity 0, so magnitude is 0 and
+    // they fall through both branches below (unchanged from prior behavior).
+    //
+    // For a regular parent transaction, subtract its split children's total
+    // so only the un-split remainder is attributed to the parent's label.
     // Synthetic split transactions (from `toTransaction()`) carry the
     // split's own id, which keys no family, so their amount is unchanged.
-    const amount = isInvestment
-      ? -(t.price * t.quantity)
-      : t.amount - transactionFamilies.getChildrenAmountTotal(t.transaction_id);
+    let amount: number;
+    if (isInvestment) {
+      const magnitude = Math.abs(t.price * t.quantity);
+      amount = t.type === InvestmentTransactionType.Buy ? magnitude : -magnitude;
+    } else {
+      amount = t.amount - transactionFamilies.getChildrenAmountTotal(t.transaction_id);
+    }
     if (amount < 0) {
       income -= amount;
       incomeSections.set(section_id, {


### PR DESCRIPTION
## Summary

The Flow (Sankey) chart classified **investment** transactions with the **wrong cash-flow polarity**: a stock **buy** (cash leaving the account) was counted as **income**, and a **sell** (cash received) as **expense**. The In/Out totals — and the Surplus/Deficit verdict — were inverted for any chart that includes a brokerage account with buy/sell activity. Closes #499.

## Root cause

`src/client/components/FlowChartRow/lib.ts` computed the per-transaction contribution as:

```ts
const amount = isInvestment ? -(t.price * t.quantity) : t.amount;
```

Downstream, `amount < 0` → income, `amount > 0` → expense. Plaid investment signs (verified against the local prod-clone, see below) are **buy:** `quantity > 0`, **sell:** `quantity < 0`. The spurious negation therefore sent buys (cash out) to income and sells (cash in) to expense — backwards.

## Fix

```ts
const amount = isInvestment ? t.price * t.quantity : t.amount;
```

Now buy → positive → expense/Out, sell → negative → income/In, matching the convention regular transactions already use three characters away on the same line. A why-comment documents the Plaid sign convention so the missing negation reads as intentional.

**Scope:** buy/sell inversion only — the clearly-wrong primary defect. The issue's noted secondary effect (`cash`/`fee`/`dividend` rows have `quantity = 0`, so `price·quantity = 0` drops them) is left out deliberately, as #499 requests: the Plaid `amount` sign for fee/cash rows is not uniformly debit-positive, so handling those needs its own decision. This PR does not change their behavior (they contributed 0 before and after).

## Data verification

Sign convention confirmed against the local `budget` DB (`investment_transactions`):

```
type      qty_sign  amt_sign  count
buy       +1        +1        97
sell      -1        -1        33
cash       0        -1        17   (quantity 0 → unchanged, not in scope)
fee        0        -1        13   (quantity 0 → unchanged, not in scope)
```

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — **826 pass / 0 fail** (+4 new)
- [x] **Regression proof** — the 4 new `getSankeyData` cases (buy→expense, sell→income, net→deficit, regular-txn convention unchanged) **fail 3/4 on `upstream/main`** and pass on the fix.
- [ ] **UI E2E** — Playwright on sandbox (filled in below before marking ready).
