### PR TITLE
fix(accounts): credit rows and donut honor viewDate (#515)

### DIFF
--- a/src/client/components/AccountsDonut/BalanceInfo.tsx
+++ b/src/client/components/AccountsDonut/BalanceInfo.tsx
@@ -21,7 +21,6 @@ export const BalanceInfo = ({
   const { calculations, viewDate } = useAppContext();
   const { balanceData } = calculations;
 
-  const viewDateSpan = Math.max(-viewDate.getSpanFrom(new Date()), 0);
   const previousDate = viewDate.clone().previous().getEndDate();
 
   const previousAmount = donutData.reduce((a, { id }) => {
@@ -44,7 +43,7 @@ export const BalanceInfo = ({
           <br />
           <Changes
             currentAmount={0}
-            previousAmount={!viewDateSpan ? totalCredit : 0}
+            previousAmount={totalCredit}
             currencySymbol={currencySymbol}
           />
           <div className="credit label">outstanding</div>

--- a/src/client/components/AccountsTable/Balance.tsx
+++ b/src/client/components/AccountsTable/Balance.tsx
@@ -14,7 +14,6 @@ export const Balance = ({ account }: BalanceProps) => {
   const { available, current, iso_currency_code, unofficial_currency_code } = balances;
 
   const symbol = currencyCodeToSymbol(iso_currency_code || unofficial_currency_code || "USD");
-  const currentString = numberToCommaString(current!);
 
   const today = new Date();
   const viewDateDate = viewDate.getEndDate();
@@ -27,13 +26,27 @@ export const Balance = ({ account }: BalanceProps) => {
   const previousAmount = balanceHistory.get(previousDate) || 0;
 
   if (type === AccountType.Credit) {
-    const availableString = numberToCommaString(available!);
+    // "spent" is the outstanding balance (balances.current). Honor the viewDate
+    // the same way every other account type does via `dynamicAmount`: render the
+    // month's historical snapshot for past dates and the live balance for
+    // current/future ones. This branch used to ignore the viewDate entirely and
+    // always show the live balance, which also made the row contradict the
+    // donut's outstanding-credit headline for past months.
+    const spentString = numberToCommaString(dynamicAmount);
+    // `available` isn't snapshotted historically. For past months derive it from
+    // the (roughly constant) credit limit minus the outstanding balance so the
+    // two figures stay coherent; keep the live value for current/future months
+    // and for SimpleFin accounts, which report no limit.
+    const { limit } = balances;
+    const availableAmount =
+      viewDateDate > today || limit == null ? available! : limit - dynamicAmount;
+    const availableString = numberToCommaString(availableAmount);
     return (
       <div className="Balance credit">
         <div>
           <span>
             {symbol}
-            {currentString}
+            {spentString}
           </span>
           <span>spent</span>
         </div>

--- a/src/client/pages/AccountsPage/index.tsx
+++ b/src/client/pages/AccountsPage/index.tsx
@@ -33,12 +33,6 @@ export const AccountsPage = () => {
       return !hide && type !== AccountType.Credit;
     });
 
-    sortedAccounts.forEach(({ hide, type, balances }) => {
-      if (hide || type !== AccountType.Credit) return;
-      totalCredit += balances.current || 0;
-      numberOfCredits++;
-    });
-
     // For yearly view of the current (incomplete) year, viewDate.getEndDate()
     // returns Dec 31 which has no balance data yet. Cap the lookup to the
     // current month so the donut reflects actual accumulated balances.
@@ -48,6 +42,18 @@ export const AccountsPage = () => {
       viewDate.getInterval() === "year" && endDate > today
         ? new ViewDate("month").getEndDate()
         : endDate;
+
+    sortedAccounts.forEach((a) => {
+      if (a.hide || a.type !== AccountType.Credit) return;
+      // Honor the viewDate like the account rows do: historical outstanding for
+      // past months, live balance for current/future. Summing the live
+      // `balances.current` here made the donut's outstanding-credit headline
+      // disagree with the viewDate-aware credit rows on every past month.
+      const balanceHistory = balanceData.get(a.id);
+      const fallback = viewDateDate > today ? getAccountBalance(a) : 0;
+      totalCredit += balanceHistory.get(viewDateDate) ?? fallback;
+      numberOfCredits++;
+    });
 
     filteredAccounts.forEach((a, i) => {
       const balanceHistory = balanceData.get(a.id);


### PR DESCRIPTION
## Summary

Closes #515. Credit-card account rows ignored the viewDate selector: every other account type (depository, investment, crypto-exchange) re-renders its **historical** snapshot balance as you step the month selector back, but the credit branch in `Balance.tsx` returned early using only the live `balances.current` / `balances.available`. The page was also internally inconsistent — `AccountsPage` summed `totalCredit` from live `balances.current`, and `BalanceInfo` only rendered the outstanding-credit headline at the current month, so for any past month the donut reported **$0 outstanding** while the rows still showed full live balances.

The non-credit paths were migrated to viewDate-awareness across #310 / #312 / #318; the credit branch predates those and was never updated.

## Changes

- **`AccountsTable/Balance.tsx`** — the credit "spent" value now uses the viewDate-aware `dynamicAmount` (historical snapshot for past months, live balance for current/future — identical to the other account types). "available" is derived from the credit limit minus the outstanding for past months so the two figures stay coherent (`spent + available = limit`); current/future months and SimpleFin accounts (which report no limit) keep the live value.
- **`pages/AccountsPage/index.tsx`** — `totalCredit` is summed from the viewDate-aware balance history (`balanceHistory.get(viewDateDate) ?? fallback`) instead of live `balances.current`, mirroring the existing non-credit donut loop directly below it.
- **`AccountsDonut/BalanceInfo.tsx`** — render the outstanding-credit headline for all months (dropped the `!viewDateSpan` gate) now that `totalCredit` is viewDate-aware, so the donut and the rows agree at every viewDate.

Scope is the one bug: credit rows honoring viewDate + the donut/rows agreement. No change to non-credit rows, the calculation hook, or current-month behavior (`BalanceHistory.get` buckets by year-month, so at the current month it returns the value set at `today` = the live balance).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — 822 pass / 0 fail
- [x] **UI E2E** — Playwright, fix sandbox `:20516` vs `upstream/main` baseline `:20000` (same deterministic scramble → apples-to-apples), logged in as `admin`, **Accounts** page. Read-only (no DB writes). Four credit accounts present (limits known), stepped the selector Jun 2026 → Feb 2026:
  - **Current month (Jun 2026) — no regression.** Both fix and baseline identical: `61dObo` spent **$[redacted]** (= live), donut headline **-$[redacted] outstanding in 4 Credits** (= sum of the 4 rows' spent).
  - **Past month (Feb 2026):**
    - **Baseline (bug):** all credit rows frozen on the live balance — `61dObo` still **$[redacted]**, `QPLNzz` **$0.00**, `vj76b7` **$[redacted]** — and the donut headline collapses to **"–" ($0 outstanding)**. Rows and donut disagree.
    - **Fix:** rows render the historical balance — `61dObo` spent **$[redacted]** (available **$[redacted]** = limit $[redacted] − $[redacted], coherent), `QPLNzz` **$[redacted]**, `vj76b7` **$[redacted]** — and the donut headline shows **-$[redacted] outstanding** = exactly the sum of the 4 historical spents. Rows and donut **agree**.
  - Screenshots (read back): `/tmp/pr-516-fix-past.png` (donut "-$[redacted]"), `/tmp/pr-516-baseline-past.png` (donut "–"), plus `*-current.png` for both.

*[Edited 2026-06-14: redacted sandbox account balances/limits per security §2a — concrete per-account currency figures over $[redacted] removed; the row/donut-agreement logic is unchanged.]*

---

*[Edited 2026-06-28: redacted dollar figures via a retroactive sweep after the daily-security-review's body-scan + shorthand-currency regex gap (found via issue #381 — see channel 1520705621228388514). Original detail removed.]*
