### PR TITLE
feat(sync): deliver transaction tombstones via include-deleted flag

### DIFF
--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -177,12 +177,9 @@ const fetchTransactions = async (
       params.append("start-date", getDateString(startDate));
       params.append("end-date", getDateString(endDate));
       params.append("account-id", a.id);
-      // Receive soft-deleted rows as tombstones so the FE can evict them
-      // from IDB + dict. The server's `is_deleted` filter is otherwise
-      // unconditional; without this param a server-side
-      // `softDelete`/Plaid-`removed` propagation is invisible to the
-      // client until the per-month Cache API key rolls over.
-      params.append("include-deleted", "true");
+      // Route hardcodes `includeDeleted: true` (matches snapshots) — the
+      // soft-deleted rows arrive as tombstones in the response and are
+      // dropped from `result.transactions` / IDB below.
       const path = transactionsApiPath + "?" + params.toString();
       const isRecent = endDate.getTime() >= recentSinceMs;
 
@@ -229,11 +226,12 @@ const fetchTransactions = async (
   await Promise.all(promises);
 
   // Apply tombstones after every parallel ingest has landed — same
-  // semantics as the snapshot path: drop from the dict (in case a
-  // stale `cachedCall` response re-added the row) AND evict from IDB
-  // directly (the downstream `saveAllData` is additive — it never
-  // DROPS rows absent from a result dict, so without the explicit
-  // IDB.remove the row stays cached forever).
+  // semantics as the snapshot path. The eager `indexedDb.remove` is
+  // load-bearing for the partial-failure branch in `useSync` (line
+  // ~671): when any fetch fails, `clearAllData → saveAllData` is
+  // skipped, so the only thing that drops the tombstoned row from IDB
+  // is this explicit remove. (The happy-path branches still
+  // clear-then-save from `result`, which would also drop it.)
   tombstones.transaction.forEach((id) => {
     result.transactions.delete(id);
     indexedDb.remove(StoreName.transactions, id).catch(console.error);

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -152,6 +152,16 @@ const fetchTransactions = async (
     networkFailed: false,
   };
 
+  // Tombstones collected from any month's response. Applied at the end
+  // so eviction wins regardless of which parallel response arrived
+  // last — mirrors the snapshot-side handling and avoids a stale
+  // `cachedCall` response re-adding a row the live query already
+  // marked deleted.
+  const tombstones = {
+    transaction: new Set<string>(),
+    investmentTransaction: new Set<string>(),
+  };
+
   const transactionsApiPath = "/api/transactions";
   const viewDate = new ViewDate("month");
   // Walk back to the first month whose start < range.until.
@@ -167,6 +177,12 @@ const fetchTransactions = async (
       params.append("start-date", getDateString(startDate));
       params.append("end-date", getDateString(endDate));
       params.append("account-id", a.id);
+      // Receive soft-deleted rows as tombstones so the FE can evict them
+      // from IDB + dict. The server's `is_deleted` filter is otherwise
+      // unconditional; without this param a server-side
+      // `softDelete`/Plaid-`removed` propagation is invisible to the
+      // client until the per-month Cache API key rolls over.
+      params.append("include-deleted", "true");
       const path = transactionsApiPath + "?" + params.toString();
       const isRecent = endDate.getTime() >= recentSinceMs;
 
@@ -185,9 +201,17 @@ const fetchTransactions = async (
 
         const { transactions, investmentTransactions } = response.body;
         transactions.forEach((t) => {
+          if (t.is_deleted) {
+            tombstones.transaction.add(t.transaction_id);
+            return;
+          }
           result.transactions.set(t.transaction_id, new Transaction(t));
         });
         investmentTransactions.forEach((t) => {
+          if (t.is_deleted) {
+            tombstones.investmentTransaction.add(t.investment_transaction_id);
+            return;
+          }
           result.investmentTransactions.set(
             t.investment_transaction_id,
             new InvestmentTransaction(t),
@@ -203,6 +227,21 @@ const fetchTransactions = async (
   }
 
   await Promise.all(promises);
+
+  // Apply tombstones after every parallel ingest has landed — same
+  // semantics as the snapshot path: drop from the dict (in case a
+  // stale `cachedCall` response re-added the row) AND evict from IDB
+  // directly (the downstream `saveAllData` is additive — it never
+  // DROPS rows absent from a result dict, so without the explicit
+  // IDB.remove the row stays cached forever).
+  tombstones.transaction.forEach((id) => {
+    result.transactions.delete(id);
+    indexedDb.remove(StoreName.transactions, id).catch(console.error);
+  });
+  tombstones.investmentTransaction.forEach((id) => {
+    result.investmentTransactions.delete(id);
+    indexedDb.remove(StoreName.investmentTransactions, id).catch(console.error);
+  });
 
   return result;
 };

--- a/src/common/models/Transaction.ts
+++ b/src/common/models/Transaction.ts
@@ -52,6 +52,10 @@ export interface JSONTransaction extends PlaidTransaction {
    * Represents relations by pair of budget_id and category_id
    */
   label: JSONTransactionLabel;
+  /** Soft-delete marker. Present when the GET endpoint is called with
+   *  `?include-deleted=true` (the FE sync path); the client treats rows
+   *  with this flag as tombstones for IDB/dict eviction. */
+  is_deleted?: boolean;
 }
 
 export type TransferPairStatus = "suggested" | "confirmed";
@@ -69,6 +73,9 @@ export interface JSONInvestmentTransaction extends PlaidInvestmentTransaction {
    * Represents relations by pair of budget_id and category_id
    */
   label: JSONTransactionLabel;
+  /** Soft-delete marker — same tombstone semantics as
+   *  `JSONTransaction.is_deleted`. */
+  is_deleted?: boolean;
 }
 
 export interface RemovedTransaction {

--- a/src/common/models/Transaction.ts
+++ b/src/common/models/Transaction.ts
@@ -52,9 +52,10 @@ export interface JSONTransaction extends PlaidTransaction {
    * Represents relations by pair of budget_id and category_id
    */
   label: JSONTransactionLabel;
-  /** Soft-delete marker. Present when the GET endpoint is called with
-   *  `?include-deleted=true` (the FE sync path); the client treats rows
-   *  with this flag as tombstones for IDB/dict eviction. */
+  /** Soft-delete marker. Always present on rows from `/api/transactions`
+   *  (the route hardcodes `includeDeleted: true`, matching the snapshots
+   *  route); the FE treats rows with this flag as tombstones for IDB +
+   *  dict eviction. */
   is_deleted?: boolean;
 }
 
@@ -74,7 +75,8 @@ export interface JSONInvestmentTransaction extends PlaidInvestmentTransaction {
    */
   label: JSONTransactionLabel;
   /** Soft-delete marker — same tombstone semantics as
-   *  `JSONTransaction.is_deleted`. */
+   *  `JSONTransaction.is_deleted`; always present on rows from
+   *  `/api/transactions`. */
   is_deleted?: boolean;
 }
 

--- a/src/server/lib/postgres/models/investment_transaction.ts
+++ b/src/server/lib/postgres/models/investment_transaction.ts
@@ -120,6 +120,7 @@ export class InvTxModel extends Model<JSONInvTx, InvTxSchema> implements InvTxRo
         category_id: this.label_category_id,
         memo: this.label_memo,
       },
+      is_deleted: this.is_deleted ?? false,
     };
   }
 

--- a/src/server/lib/postgres/models/transaction.ts
+++ b/src/server/lib/postgres/models/transaction.ts
@@ -159,6 +159,7 @@ export class TransactionModel extends Model<JSONTransaction, TxSchema> implement
       authorized_datetime: null,
       datetime: null,
       transaction_code: null,
+      is_deleted: this.is_deleted ?? false,
     };
   }
 

--- a/src/server/lib/postgres/repositories/transactions.ts
+++ b/src/server/lib/postgres/repositories/transactions.ts
@@ -32,6 +32,12 @@ export interface SearchTransactionsOptions {
   pending?: boolean;
   limit?: number;
   offset?: number;
+  /** When true, soft-deleted (`is_deleted = TRUE`) rows are INCLUDED in
+   *  the response so the client can treat them as tombstones and evict
+   *  them from its local cache (IDB + in-memory dict). Defaults to
+   *  `false` — consumers that filter to active-only rows (the engine,
+   *  the sync-plaid delta computation) keep their previous behavior. */
+  includeDeleted?: boolean;
 }
 
 export type PartialTransaction = { transaction_id: string } & Partial<JSONTransaction>;
@@ -50,6 +56,7 @@ export const getTransactions = async (
     orderBy: `${DATE} DESC`,
     limit: options.limit,
     offset: options.offset,
+    excludeDeleted: !options.includeDeleted,
   });
   const result = await pool.query<Record<string, unknown>>(sql, values);
   return result.rows.map((row) => new TransactionModel(row).toJSON());
@@ -86,6 +93,7 @@ export const searchTransactions = async (
     orderBy: `${DATE} DESC`,
     limit: options.limit,
     offset: options.offset,
+    excludeDeleted: !options.includeDeleted,
   });
   const result = await pool.query<Record<string, unknown>>(sql, values);
   const investment_transactions = result.rows.map((row) => new InvTxModel(row).toJSON());

--- a/src/server/routes/accounts/get-transactions.ts
+++ b/src/server/routes/accounts/get-transactions.ts
@@ -20,17 +20,25 @@ export const getTransactionsRoute = new Route<TransactionsGetResponse>(
 
     const startResult = optionalQueryString(req, "start-date");
     if (!startResult.success) return validationError(startResult.error!);
-    
+
     const endResult = optionalQueryString(req, "end-date");
     if (!endResult.success) return validationError(endResult.error!);
-    
+
     const accountResult = optionalQueryString(req, "account-id");
     if (!accountResult.success) return validationError(accountResult.error!);
+
+    const includeDeletedResult = optionalQueryString(req, "include-deleted");
+    if (!includeDeletedResult.success) return validationError(includeDeletedResult.error!);
 
     const options: SearchTransactionsOptions = {};
     if (startResult.data) options.startDate = startResult.data;
     if (endResult.data) options.endDate = endResult.data;
     if (accountResult.data) options.account_id = accountResult.data;
+    // Pass-through tombstone delivery — repo will return soft-deleted
+    // rows (`is_deleted = TRUE`) alongside active ones so the FE can
+    // evict them from local cache. Defaults to false; the historic
+    // contract (active-only) is preserved when the param is absent.
+    if (includeDeletedResult.data === "true") options.includeDeleted = true;
 
     const response = await searchTransactions(user, options);
 

--- a/src/server/routes/accounts/get-transactions.ts
+++ b/src/server/routes/accounts/get-transactions.ts
@@ -27,18 +27,17 @@ export const getTransactionsRoute = new Route<TransactionsGetResponse>(
     const accountResult = optionalQueryString(req, "account-id");
     if (!accountResult.success) return validationError(accountResult.error!);
 
-    const includeDeletedResult = optionalQueryString(req, "include-deleted");
-    if (!includeDeletedResult.success) return validationError(includeDeletedResult.error!);
-
-    const options: SearchTransactionsOptions = {};
+    const options: SearchTransactionsOptions = {
+      // Always return soft-deleted rows so the FE can treat them as
+      // tombstones and evict from local cache — matches the snapshot
+      // route's hardcoded contract (`get-snapshots.ts`). Direct repo
+      // callers (engine, sync-plaid delta) still default to active-only
+      // because they don't pass `includeDeleted`.
+      includeDeleted: true,
+    };
     if (startResult.data) options.startDate = startResult.data;
     if (endResult.data) options.endDate = endResult.data;
     if (accountResult.data) options.account_id = accountResult.data;
-    // Pass-through tombstone delivery — repo will return soft-deleted
-    // rows (`is_deleted = TRUE`) alongside active ones so the FE can
-    // evict them from local cache. Defaults to false; the historic
-    // contract (active-only) is preserved when the param is absent.
-    if (includeDeletedResult.data === "true") options.includeDeleted = true;
 
     const response = await searchTransactions(user, options);
 


### PR DESCRIPTION
## Summary

Closes a half-wired tombstone path: the FE `useSync` hook already has the eviction logic (`indexedDb.remove` on `is_deleted: true` rows for snapshots), but the transactions endpoint never returned soft-deleted rows, so removed transactions stayed in the local cache forever.

- `SearchTransactionsOptions.includeDeleted` flag forwarded to `buildSelectWithFilters({excludeDeleted: !includeDeleted})` in both the transactions and investment_transactions blocks
- `/api/transactions` route hardcodes `includeDeleted: true` (matches the existing snapshots route — no opt-in query param); direct repo callers (engine, sync-plaid) still get active-only via the default-false flag on `SearchTransactionsOptions`
- `is_deleted?: boolean` added to `JSONTransaction` + `JSONInvestmentTransaction`; both model `toJSON()`s now emit `is_deleted: this.is_deleted ?? false`
- `useSync` collects tombstone ids in `tombstones.transaction` / `tombstones.investmentTransaction` during the forEach over each per-month-per-account response, and after `Promise.all` settles, evicts each id from the in-memory dict AND from IDB

Default behavior is preserved everywhere else: the engine, sync-plaid delta computation, and any other caller that doesn't pass `includeDeleted` still get the active-only set.

This is **PR A** of a 3-PR series toward pure-IDB delta-sync:
- PR A (this) — wire transaction tombstone delivery so FE eviction actually fires
- PR B — switch sync to delta-by-updated-cursor (skip the Cache API layer entirely)
- PR C — remove Cache API + the dual-write paths

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test src/server` — 619 pass, 0 fail
- [x] Sandbox E2E (PR 520): confirmed Plaid-removed transaction tombstone propagates to FE eviction (see comment with results table)
- [x] Reviewoie round 1 + round 2 — findings addressed in commits 22b27ff + 340f0e9 (see follow-up comments)