### PR TITLE
feat(sync): server tombstone delivery for split transactions on every sync (#521)

### DIFF
--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -873,16 +873,21 @@ export const useSync = () => {
       });
 
       let stage3Transactions: FetchTransactionsResult | null = null;
+      let stage3SplitTxns: FetchSplitTransactionsResult | null = null;
       let stage3Snapshots: FetchSnapshotsResult | null = null;
       if (olderFrom < olderUntil) {
-        [stage3Transactions, stage3Snapshots] = await Promise.all([
+        [stage3Transactions, stage3SplitTxns, stage3Snapshots] = await Promise.all([
           fetchTransactions(accounts, olderRange),
+          fetchSplitTransactions(accounts, olderRange),
           fetchSnapshots(accounts, olderRange),
         ]);
 
         stage3Transactions.transactions.forEach((t, id) => finalData.transactions.set(id, t));
         stage3Transactions.investmentTransactions.forEach((t, id) =>
           finalData.investmentTransactions.set(id, t),
+        );
+        stage3SplitTxns.splitTransactions.forEach((s, id) =>
+          finalData.splitTransactions.set(id, s),
         );
         stage3Snapshots.accountSnapshots.forEach((s, id) => finalData.accountSnapshots.set(id, s));
         stage3Snapshots.holdingSnapshots.forEach((s, id) => finalData.holdingSnapshots.set(id, s));
@@ -909,6 +914,7 @@ export const useSync = () => {
         stage2SplitTxns.networkFailed ||
         stage2Snapshots.networkFailed ||
         (stage3Transactions?.networkFailed ?? false) ||
+        (stage3SplitTxns?.networkFailed ?? false) ||
         (stage3Snapshots?.networkFailed ?? false);
 
       if (!coldFetchFailed) {

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -249,21 +249,67 @@ interface FetchSplitTransactionsResult {
   networkFailed: boolean;
 }
 
-const fetchSplitTransactions = async (): Promise<FetchSplitTransactionsResult> => {
+const fetchSplitTransactions = async (
+  accounts: AccountDictionary,
+  range: FetchRange,
+  recentSinceMs: number = Date.now() - THIRTY_DAYS,
+): Promise<FetchSplitTransactionsResult> => {
   const result: FetchSplitTransactionsResult = {
     splitTransactions: new SplitTransactionDictionary(),
     networkFailed: false,
   };
 
-  const response = await call
-    .get<SplitTransactionsGetResponse>("/api/split-transactions")
-    .catch(console.error);
-  if (!response || response.status === "error") {
-    result.networkFailed = true;
-    return result;
+  const tombstones = new Set<string>();
+
+  const splitsApiPath = "/api/split-transactions";
+  const viewDate = new ViewDate("month");
+  while (viewDate.getStartDate() >= range.until) viewDate.previous();
+
+  const promises: Promise<void>[] = [];
+
+  while (range.from < viewDate.getStartDate()) {
+    accounts?.forEach((a) => {
+      const params = new URLSearchParams();
+      const startDate = viewDate.getStartDate();
+      const endDate = viewDate.clone().next().getStartDate();
+      params.append("start-date", getDateString(startDate));
+      params.append("end-date", getDateString(endDate));
+      params.append("account-id", a.id);
+      const path = splitsApiPath + "?" + params.toString();
+      const isRecent = endDate.getTime() >= recentSinceMs;
+
+      const fetchSplitsForAccount = async () => {
+        let response: ApiResponse<SplitTransactionsGetResponse> | void;
+        if (isRecent) {
+          response = await call.get<SplitTransactionsGetResponse>(path).catch(console.error);
+        } else {
+          response = await cachedCall<SplitTransactionsGetResponse>(path).catch(console.error);
+        }
+        if (!response || response.status === "error") {
+          result.networkFailed = true;
+          return;
+        }
+        if (!response.body) return;
+
+        response.body.forEach((t) => {
+          if (t.is_deleted) {
+            tombstones.add(t.split_transaction_id);
+            return;
+          }
+          result.splitTransactions.set(t.split_transaction_id, new SplitTransaction(t));
+        });
+      };
+      promises.push(fetchSplitsForAccount());
+    });
+
+    viewDate.previous();
   }
-  response.body?.forEach((t) => {
-    result.splitTransactions.set(t.split_transaction_id, new SplitTransaction(t));
+
+  await Promise.all(promises);
+
+  tombstones.forEach((id) => {
+    result.splitTransactions.delete(id);
+    indexedDb.remove(StoreName.splitTransactions, id).catch(console.error);
   });
 
   return result;
@@ -628,7 +674,7 @@ export const useSync = () => {
         ] = await Promise.all([
           fetchBudgets(),
           fetchCharts(),
-          fetchSplitTransactions(),
+          fetchSplitTransactions(accounts, fullRange, recentSinceMs),
           fetchTransactions(accounts, fullRange, recentSinceMs),
           fetchSnapshots(accounts, fullRange, recentSinceMs),
           fetchInstitutions(accounts),
@@ -760,7 +806,7 @@ export const useSync = () => {
 
       const [stage2Transactions, stage2SplitTxns, stage2Snapshots] = await Promise.all([
         fetchTransactions(accounts, recentRange),
-        fetchSplitTransactions(),
+        fetchSplitTransactions(accounts, recentRange),
         fetchSnapshots(accounts, recentRange),
       ]);
       const {

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -249,11 +249,17 @@ interface FetchSplitTransactionsResult {
   networkFailed: boolean;
 }
 
-const fetchSplitTransactions = async (
-  accounts: AccountDictionary,
-  range: FetchRange,
-  recentSinceMs: number = Date.now() - THIRTY_DAYS,
-): Promise<FetchSplitTransactionsResult> => {
+const fetchSplitTransactions = async (): Promise<FetchSplitTransactionsResult> => {
+  // Single unbounded GET — splits are small (well under any pagination
+  // threshold for current users) and the per-month-per-account paged
+  // shape from the initial draft of this PR introduced an FE coverage
+  // regression under high concurrency (1100+ in-flight fetches dropped
+  // rows across the response stream — see PR #522 thread). The
+  // `is_deleted` flag still rides on every row so the FE can branch into
+  // active vs tombstone here, matching the snapshot path's eviction
+  // semantics. The server still supports the paged shape (route + repo
+  // accept startDate/endDate/account-id) so a future delta-cursor design
+  // can adopt pagination uniformly across all three stores at once.
   const result: FetchSplitTransactionsResult = {
     splitTransactions: new SplitTransactionDictionary(),
     networkFailed: false,
@@ -261,54 +267,23 @@ const fetchSplitTransactions = async (
 
   const tombstones = new Set<string>();
 
-  const splitsApiPath = "/api/split-transactions";
-  const viewDate = new ViewDate("month");
-  while (viewDate.getStartDate() >= range.until) viewDate.previous();
-
-  const promises: Promise<void>[] = [];
-
-  while (range.from < viewDate.getStartDate()) {
-    accounts?.forEach((a) => {
-      const params = new URLSearchParams();
-      const startDate = viewDate.getStartDate();
-      const endDate = viewDate.clone().next().getStartDate();
-      params.append("start-date", getDateString(startDate));
-      params.append("end-date", getDateString(endDate));
-      params.append("account-id", a.id);
-      const path = splitsApiPath + "?" + params.toString();
-      const isRecent = endDate.getTime() >= recentSinceMs;
-
-      const fetchSplitsForAccount = async () => {
-        let response: ApiResponse<SplitTransactionsGetResponse> | void;
-        if (isRecent) {
-          response = await call.get<SplitTransactionsGetResponse>(path).catch(console.error);
-        } else {
-          response = await cachedCall<SplitTransactionsGetResponse>(path).catch(console.error);
-        }
-        if (!response || response.status === "error") {
-          result.networkFailed = true;
-          return;
-        }
-        if (!response.body) return;
-
-        response.body.forEach((t) => {
-          if (t.is_deleted) {
-            tombstones.add(t.split_transaction_id);
-            return;
-          }
-          result.splitTransactions.set(t.split_transaction_id, new SplitTransaction(t));
-        });
-      };
-      promises.push(fetchSplitsForAccount());
-    });
-
-    viewDate.previous();
+  const response = await call
+    .get<SplitTransactionsGetResponse>("/api/split-transactions")
+    .catch(console.error);
+  if (!response || response.status === "error") {
+    result.networkFailed = true;
+    return result;
   }
 
-  await Promise.all(promises);
+  response.body?.forEach((t) => {
+    if (t.is_deleted) {
+      tombstones.add(t.split_transaction_id);
+      return;
+    }
+    result.splitTransactions.set(t.split_transaction_id, new SplitTransaction(t));
+  });
 
   tombstones.forEach((id) => {
-    result.splitTransactions.delete(id);
     indexedDb.remove(StoreName.splitTransactions, id).catch(console.error);
   });
 
@@ -674,7 +649,7 @@ export const useSync = () => {
         ] = await Promise.all([
           fetchBudgets(),
           fetchCharts(),
-          fetchSplitTransactions(accounts, fullRange, recentSinceMs),
+          fetchSplitTransactions(),
           fetchTransactions(accounts, fullRange, recentSinceMs),
           fetchSnapshots(accounts, fullRange, recentSinceMs),
           fetchInstitutions(accounts),
@@ -806,7 +781,7 @@ export const useSync = () => {
 
       const [stage2Transactions, stage2SplitTxns, stage2Snapshots] = await Promise.all([
         fetchTransactions(accounts, recentRange),
-        fetchSplitTransactions(accounts, recentRange),
+        fetchSplitTransactions(),
         fetchSnapshots(accounts, recentRange),
       ]);
       const {
@@ -873,21 +848,18 @@ export const useSync = () => {
       });
 
       let stage3Transactions: FetchTransactionsResult | null = null;
-      let stage3SplitTxns: FetchSplitTransactionsResult | null = null;
       let stage3Snapshots: FetchSnapshotsResult | null = null;
       if (olderFrom < olderUntil) {
-        [stage3Transactions, stage3SplitTxns, stage3Snapshots] = await Promise.all([
+        // Splits aren't paged (stage 2 already fetched the full active set
+        // in one shot), so stage 3 only covers transactions + snapshots.
+        [stage3Transactions, stage3Snapshots] = await Promise.all([
           fetchTransactions(accounts, olderRange),
-          fetchSplitTransactions(accounts, olderRange),
           fetchSnapshots(accounts, olderRange),
         ]);
 
         stage3Transactions.transactions.forEach((t, id) => finalData.transactions.set(id, t));
         stage3Transactions.investmentTransactions.forEach((t, id) =>
           finalData.investmentTransactions.set(id, t),
-        );
-        stage3SplitTxns.splitTransactions.forEach((s, id) =>
-          finalData.splitTransactions.set(id, s),
         );
         stage3Snapshots.accountSnapshots.forEach((s, id) => finalData.accountSnapshots.set(id, s));
         stage3Snapshots.holdingSnapshots.forEach((s, id) => finalData.holdingSnapshots.set(id, s));
@@ -914,7 +886,6 @@ export const useSync = () => {
         stage2SplitTxns.networkFailed ||
         stage2Snapshots.networkFailed ||
         (stage3Transactions?.networkFailed ?? false) ||
-        (stage3SplitTxns?.networkFailed ?? false) ||
         (stage3Snapshots?.networkFailed ?? false);
 
       if (!coldFetchFailed) {

--- a/src/common/models/Transaction.ts
+++ b/src/common/models/Transaction.ts
@@ -99,6 +99,11 @@ export interface JSONSplitTransaction {
    * Represents relations by pair of budget_id and category_id
    */
   label: JSONTransactionLabel;
+  /** Soft-delete marker — same tombstone semantics as
+   *  `JSONTransaction.is_deleted`. Always present on rows from
+   *  `/api/split-transactions` (the route hardcodes
+   *  `includeDeleted: true`, matching transactions + snapshots). */
+  is_deleted?: boolean;
 }
 
 export interface RemovedSplitTransaction {

--- a/src/server/lib/postgres/models/base.ts
+++ b/src/server/lib/postgres/models/base.ts
@@ -9,6 +9,7 @@ import {
   AdditionalWhere,
   ParamValue,
   QueryData,
+  SearchFilters,
 } from "../database";
 
 /** Query executor - either pool or a transaction client */
@@ -121,10 +122,22 @@ export abstract class Table<
     }
   }
 
-  async query(filters: Record<string, ParamValue | unknown> = {}): Promise<TModel[]> {
+  async query(
+    filters: Record<string, ParamValue | unknown> = {},
+    options: Omit<SearchFilters, "filters"> = {},
+  ): Promise<TModel[]> {
     const { sql, values } = buildSelectWithFilters(this.name, "*", {
       filters,
-      excludeDeleted: this.supportsSoftDelete,
+      // `supportsSoftDelete` stays the default; callers can override
+      // (e.g. tombstone-delivery routes set `excludeDeleted: false`).
+      excludeDeleted: options.excludeDeleted ?? this.supportsSoftDelete,
+      user_id: options.user_id,
+      primaryKey: options.primaryKey,
+      inFilters: options.inFilters,
+      dateRange: options.dateRange,
+      orderBy: options.orderBy,
+      limit: options.limit,
+      offset: options.offset,
     });
     const result = await pool.query(sql, values);
     return result.rows.map((row: unknown) => new this.ModelClass(row));

--- a/src/server/lib/postgres/models/split_transaction.ts
+++ b/src/server/lib/postgres/models/split_transaction.ts
@@ -95,6 +95,7 @@ export class SplitTransactionModel extends Model<JSONSplitTransaction, SplitTxSc
         memo: this.label_memo,
         category_confidence: this.label_category_confidence,
       },
+      is_deleted: this.is_deleted ?? false,
     };
   }
 

--- a/src/server/lib/postgres/repositories/split_transactions.test.ts
+++ b/src/server/lib/postgres/repositories/split_transactions.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+import { restoreLeaves } from "test-helpers";
+
+const mockQuery = mock(async (_sql: string, _values?: unknown[]) => ({
+  rows: [] as unknown[],
+  rowCount: 0 as number | null,
+}));
+
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+}
+
+mock.module("pg", () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {} },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+}));
+
+const { searchSplitTransactions } = await import("./split_transactions");
+
+afterAll(restoreLeaves);
+
+function makeSplitRow(overrides: Record<string, unknown> = {}) {
+  return {
+    split_transaction_id: "split-1",
+    user_id: "usr-1",
+    transaction_id: "tx-1",
+    account_id: "acc-1",
+    amount: 12.5,
+    date: "2026-03-01",
+    custom_name: "groceries portion",
+    label_budget_id: null,
+    label_category_id: null,
+    label_memo: null,
+    label_category_confidence: null,
+    updated: "2026-03-01T00:00:00Z",
+    is_deleted: false,
+    ...overrides,
+  };
+}
+
+const testUser = { user_id: "usr-1", username: "hoie" };
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+describe("searchSplitTransactions", () => {
+  test("defaults to active-only (excludeDeleted when includeDeleted unset)", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await searchSplitTransactions(testUser);
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain("is_deleted IS NULL OR is_deleted = FALSE");
+  });
+
+  test("includeDeleted=true drops the soft-delete predicate", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await searchSplitTransactions(testUser, { includeDeleted: true });
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).not.toContain("is_deleted IS NULL OR is_deleted = FALSE");
+  });
+
+  test("passes user_id and account_id filters", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await searchSplitTransactions(
+      { user_id: "usr-99", username: "test" },
+      { account_id: "acc-specific" },
+    );
+    const values = mockQuery.mock.calls[0][1] as string[];
+    expect(values).toContain("usr-99");
+    expect(values).toContain("acc-specific");
+  });
+
+  test("applies date range on UPDATED column when provided", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await searchSplitTransactions(testUser, {
+      startDate: "2026-03-01",
+      endDate: "2026-04-01",
+    });
+    const sql = mockQuery.mock.calls[0][0] as string;
+    const values = mockQuery.mock.calls[0][1] as string[];
+    expect(sql).toContain("updated");
+    expect(values).toContain("2026-03-01");
+    expect(values).toContain("2026-04-01");
+  });
+
+  test("toJSON emits is_deleted alongside the existing fields", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [makeSplitRow({ is_deleted: true })],
+      rowCount: 1,
+    });
+    const result = await searchSplitTransactions(testUser, { includeDeleted: true });
+    expect(result).toHaveLength(1);
+    expect(result[0].is_deleted).toBe(true);
+    expect(result[0].split_transaction_id).toBe("split-1");
+  });
+
+  test("returns is_deleted=false for active rows when column is null/missing", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [makeSplitRow({ is_deleted: null })],
+      rowCount: 1,
+    });
+    const result = await searchSplitTransactions(testUser);
+    expect(result[0].is_deleted).toBe(false);
+  });
+});

--- a/src/server/lib/postgres/repositories/split_transactions.ts
+++ b/src/server/lib/postgres/repositories/split_transactions.ts
@@ -7,14 +7,23 @@ import {
   TRANSACTION_ID,
   ACCOUNT_ID,
   USER_ID,
+  UPDATED,
+  DATE,
   QueryExecutor,
 } from "../models";
-import { UpsertResult, successResult, errorResult, noChangeResult } from "../database";
+import { pool } from "../client";
+import { buildSelectWithFilters, UpsertResult, successResult, errorResult, noChangeResult } from "../database";
 import { logger } from "../../logger";
 
 export interface SearchSplitTransactionsOptions {
   transaction_id?: string;
   account_id?: string;
+  startDate?: string;
+  endDate?: string;
+  /** When true, soft-deleted (`is_deleted = TRUE`) rows are INCLUDED in
+   *  the response so the client can treat them as tombstones and evict
+   *  them from its local cache. Defaults to `false`. */
+  includeDeleted?: boolean;
 }
 
 export type PartialSplitTransaction = {
@@ -52,12 +61,22 @@ export const searchSplitTransactions = async (
   user: MaskedUser,
   options: SearchSplitTransactionsOptions = {},
 ): Promise<JSONSplitTransaction[]> => {
-  const filters: Record<string, unknown> = { [USER_ID]: user.user_id };
+  const filters: Record<string, unknown> = {};
   if (options.transaction_id) filters[TRANSACTION_ID] = options.transaction_id;
   if (options.account_id) filters[ACCOUNT_ID] = options.account_id;
 
-  const models = await splitTransactionsTable.query(filters);
-  return models.map((m) => m.toJSON());
+  const { sql, values } = buildSelectWithFilters("split_transactions", "*", {
+    user_id: user.user_id,
+    filters,
+    dateRange:
+      options.startDate || options.endDate
+        ? { column: UPDATED, start: options.startDate, end: options.endDate }
+        : undefined,
+    orderBy: `${DATE} DESC`,
+    excludeDeleted: !options.includeDeleted,
+  });
+  const result = await pool.query<Record<string, unknown>>(sql, values);
+  return result.rows.map((row) => new SplitTransactionModel(row).toJSON());
 };
 
 export const upsertSplitTransactions = async (

--- a/src/server/lib/postgres/repositories/split_transactions.ts
+++ b/src/server/lib/postgres/repositories/split_transactions.ts
@@ -11,8 +11,7 @@ import {
   DATE,
   QueryExecutor,
 } from "../models";
-import { pool } from "../client";
-import { buildSelectWithFilters, UpsertResult, successResult, errorResult, noChangeResult } from "../database";
+import { UpsertResult, successResult, errorResult, noChangeResult } from "../database";
 import { logger } from "../../logger";
 
 export interface SearchSplitTransactionsOptions {
@@ -61,13 +60,11 @@ export const searchSplitTransactions = async (
   user: MaskedUser,
   options: SearchSplitTransactionsOptions = {},
 ): Promise<JSONSplitTransaction[]> => {
-  const filters: Record<string, unknown> = {};
+  const filters: Record<string, unknown> = { [USER_ID]: user.user_id };
   if (options.transaction_id) filters[TRANSACTION_ID] = options.transaction_id;
   if (options.account_id) filters[ACCOUNT_ID] = options.account_id;
 
-  const { sql, values } = buildSelectWithFilters("split_transactions", "*", {
-    user_id: user.user_id,
-    filters,
+  const models = await splitTransactionsTable.query(filters, {
     dateRange:
       options.startDate || options.endDate
         ? { column: UPDATED, start: options.startDate, end: options.endDate }
@@ -75,8 +72,7 @@ export const searchSplitTransactions = async (
     orderBy: `${DATE} DESC`,
     excludeDeleted: !options.includeDeleted,
   });
-  const result = await pool.query<Record<string, unknown>>(sql, values);
-  return result.rows.map((row) => new SplitTransactionModel(row).toJSON());
+  return models.map((m) => m.toJSON());
 };
 
 export const upsertSplitTransactions = async (

--- a/src/server/routes/accounts/get-split-transactions.ts
+++ b/src/server/routes/accounts/get-split-transactions.ts
@@ -15,10 +15,24 @@ export const getSplitTransactionsRoute = new Route<SplitTransactionsGetResponse>
       };
     }
 
+    const startResult = optionalQueryString(req, "start-date");
+    if (!startResult.success) return validationError(startResult.error!);
+
+    const endResult = optionalQueryString(req, "end-date");
+    if (!endResult.success) return validationError(endResult.error!);
+
     const accountResult = optionalQueryString(req, "account-id");
     if (!accountResult.success) return validationError(accountResult.error!);
 
-    const options: SearchSplitTransactionsOptions = {};
+    const options: SearchSplitTransactionsOptions = {
+      // Always return soft-deleted rows so the FE can treat them as
+      // tombstones and evict from local cache — matches the snapshots +
+      // transactions route contract. Direct repo callers default to
+      // active-only because they don't pass `includeDeleted`.
+      includeDeleted: true,
+    };
+    if (startResult.data) options.startDate = startResult.data;
+    if (endResult.data) options.endDate = endResult.data;
     if (accountResult.data) options.account_id = accountResult.data;
 
     const splitTransactions = await searchSplitTransactions(user, options);


### PR DESCRIPTION
Closes #521.

## Summary

Propagates server-side soft-deletes of split transactions to FE eviction on every sync tick — the same partial-failure gap #520 closed for transactions — via server-emitted tombstones.

- **Server**: `searchSplitTransactions` routes through `splitTransactionsTable.query(filters, { dateRange, excludeDeleted })` — `Table.query` was extended to take an optional `options` arg (per Hoie's "extend Table methods, don't bypass" note) rather than reaching for `buildSelectWithFilters` + direct `pool.query`. The `/api/split-transactions` route requests `includeDeleted: true` so soft-deleted rows are delivered as tombstones; direct repo callers stay active-only by default.
- **Shared**: `JSONSplitTransaction` gains `is_deleted?: boolean`; `SplitTransactionModel.toJSON()` emits `is_deleted: this.is_deleted ?? false`. The DB column already existed (no schema change).
- **FE**: `fetchSplitTransactions` does a single `GET /api/split-transactions`, collects tombstones from the delivered set, and evicts them from `result.splitTransactions` + IDB after the fetch, then writes the refreshed dict (`sync.ts` ~252–286).

## Why

Server-side soft-deletes (UI `DELETE /split-transaction`, or cascade via `deleteTransactions` → `bulkSoftDeleteByColumn`) now propagate to FE eviction on every sync tick, not only when `clearAllData → saveAllData` runs.

## Notes (addressing the round-3 review)

- An earlier revision paged the FE per-month-per-account (mirroring `fetchTransactions`); that was **reverted** to a single unbounded GET (split history is well under the paging threshold for current users). The server date-range surface (`startDate`/`endDate` repo options + route `start-date`/`end-date` params) is **retained but currently has no live caller** — reserved for the PR B delta-by-cursor work. Called out here so it reads as a conscious decision, not orphaned code.
- Tombstone application uses whole-dict replace, consistent with the merged #520 pattern. The delta-sync design's explicit `setData((old) => …)` requirement is PR B's scope and is intentionally not applied here.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test src/server` repositories suite green (CI `test` + `build` checks passing on HEAD)
- [x] Sandbox E2E (PR 522): soft-delete on a split propagates to FE eviction on next sync — see the E2E comment in this thread.
