### PR TITLE
fix(holdings): key security price index by snapshot date, not close_price_as_of

### DIFF
--- a/src/client/lib/hooks/calculation/holdings.test.ts
+++ b/src/client/lib/hooks/calculation/holdings.test.ts
@@ -142,6 +142,35 @@ describe("buildSecurityPriceIndex", () => {
 
     expect(index.size).toBe(0);
   });
+
+  test("buckets by each snapshot's own date even when all share one close_price_as_of", () => {
+    // The server stamps the security's single live `close_price_as_of` onto
+    // every historical snapshot. The price series must still spread across
+    // distinct month buckets keyed by each snapshot's own recording date —
+    // not collapse into the one month named by close_price_as_of.
+    const sharedAsOf = "2026-03-30";
+    const snapshots = new SecuritySnapshotDictionary();
+    const months: [string, number][] = [
+      ["2026-01-15", 100],
+      ["2026-02-15", 110],
+      ["2026-03-15", 120],
+    ];
+    months.forEach(([date, price], i) => {
+      const snap = createSecuritySnapshot("sec1", price, date);
+      snap.security.close_price_as_of = sharedAsOf;
+      snapshots.set(`snap${i}`, snap);
+    });
+
+    const index = buildSecurityPriceIndex(snapshots);
+
+    // Three distinct monthly buckets, each holding its own date's price —
+    // not a single "2026-03" bucket with one arbitrary winner.
+    const sec1 = index.get("sec1");
+    expect(sec1?.size).toBe(3);
+    expect(sec1?.get("2026-01")).toEqual({ price: 100, sourceDate: "2026-01-15" });
+    expect(sec1?.get("2026-02")).toEqual({ price: 110, sourceDate: "2026-02-15" });
+    expect(sec1?.get("2026-03")).toEqual({ price: 120, sourceDate: "2026-03-15" });
+  });
 });
 
 describe("getPriceForHolding", () => {

--- a/src/client/lib/hooks/calculation/holdings.ts
+++ b/src/client/lib/hooks/calculation/holdings.ts
@@ -11,10 +11,10 @@ import { HoldingSnapshot } from "../../models/Snapshot";
 import { InvestmentTransaction } from "../../models/InvestmentTransaction";
 
 /**
- * One entry in the price index. `sourceDate` is the date the price was
- * recorded (`close_price_as_of` if Plaid surfaced it, otherwise the snapshot
- * date). It's needed downstream so we can compare security-snapshot freshness
- * against the holding snapshot's own date and pick whichever's more recent.
+ * One entry in the price index. `sourceDate` is the snapshot's own recording
+ * date — the date that `close_price` was captured. It's needed downstream so we
+ * can compare security-snapshot freshness against the holding snapshot's own
+ * date and pick whichever's more recent.
  */
 export interface PriceIndexEntry {
   price: number;
@@ -37,11 +37,15 @@ export const buildSecurityPriceIndex = (
 
   securitySnapshots.forEach((snapshot) => {
     const { security } = snapshot;
-    const { security_id, close_price, close_price_as_of } = security;
+    const { security_id, close_price } = security;
 
     if (!security_id || close_price === null || close_price === undefined) return;
 
-    const dateStr = close_price_as_of || snapshot.snapshot.date;
+    // Bucket by the snapshot's own recording date — the date this `close_price`
+    // was captured. The security's `close_price_as_of` is a single per-security
+    // constant (the latest price's as-of date), not a per-snapshot date, so it
+    // cannot key a historical price series.
+    const dateStr = snapshot.snapshot.date;
     if (!dateStr) return;
 
     const date = new LocalDate(dateStr);


### PR DESCRIPTION
## Summary

`buildSecurityPriceIndex` bucketed each security snapshot by the security's `close_price_as_of` instead of the snapshot's own date. `close_price_as_of` is a single per-security constant — the *latest* price's as-of date — that the server stamps onto every historical snapshot (the `snapshots` table has no such column; it's joined live from `securities`). Keying the monthly price index by it collapsed a security's entire price history into **one** month bucket, and whichever snapshot was iterated in first won that bucket. So holdings were valued at the wrong-date price at every view date from the `close_price_as_of` month onward.

Closes #511

## Root cause

`src/client/lib/hooks/calculation/holdings.ts` — `buildSecurityPriceIndex`:

```ts
const dateStr = close_price_as_of || snapshot.snapshot.date; // same value for every snapshot
const yearMonth = getYearMonthString(new LocalDate(dateStr)); // → one month for all
```

All N monthly snapshots map to the single `yearMonth` named by `close_price_as_of`, and because every `sourceDate` is identical the "keep the most recent per month" tie-break can never fire. `findLatestEntryLessThanOrEqual` then returns that one wrong-priced bucket for any view month ≥ the `close_price_as_of` month.

## Fix

Bucket by `snapshot.snapshot.date` — the date that snapshot's `close_price` was actually captured. One-line key change; `close_price_as_of` is dropped from the destructure. `sourceDate` (used downstream by `getPriceForHolding` to compare security-snapshot freshness vs the holding's institution price) becomes the per-snapshot date, which is more correct than the previous per-security constant.

## Tests

- New unit test in `holdings.test.ts`: an N-month series sharing one `close_price_as_of` now produces N distinct monthly buckets, each holding its own date's price (previously collapsed to one). Pins the regression.
- Full `src/client/lib/hooks/calculation` + `Calculations.holdings` suites green (115 tests). The existing `buildSecurityPriceIndex` tests set `close_price_as_of === snapshot.date`, so they never exercised the divergence and stay green unchanged.
- `tsc --noEmit` clean.

## E2E (Playwright, real Holdings Composition UI, before/after on one running dev server)

Drove the Accounts → account-detail Holdings Composition for an investment account holding a security whose `close_price_as_of` (March) predates its latest snapshot (June), stepping the view date back month-by-month. Same server, HMR-swapped the one-line key to capture buggy vs fixed:

At a view month **≥ the security's `close_price_as_of` month** (March):
- **Buggy:** the security was priced at its *June* monthly close (the latest snapshot won the collapsed bucket) → its row rendered at **113.5%** of the account, forcing a spurious **"Unknown" reconciliation row at −14.7%** to balance back to the account total.
- **Fixed:** priced at the correct *March* monthly close → **98.8%**, and the spurious Unknown row is **gone**. Implied per-share price equals the public March close (fixed) vs the public June close (buggy), at an identical share count — i.e. the difference is pure mispricing.

At **older** view months (Feb / Jan): both builds render identically — the collapsed bucket sits *after* those months, so the code falls back to `institution_price` and the bug is masked. This matches the issue's prediction that the defect bites only at view months ≥ `close_price_as_of`.

Per-account dollar figures redacted (real local data); percentages are ratios and public ETF closes are referenced qualitatively.
