### PR TITLE
fix(holdings): bucket security price index by snapshot date, not close_price_as_of

### DIFF
--- a/src/client/lib/hooks/calculation/holdings.test.ts
+++ b/src/client/lib/hooks/calculation/holdings.test.ts
@@ -142,6 +142,35 @@ describe("buildSecurityPriceIndex", () => {
 
     expect(index.size).toBe(0);
   });
+
+  test("buckets by snapshot date, not the security's shared close_price_as_of", () => {
+    // In production the server attaches the security's single live
+    // `close_price_as_of` to every historical snapshot in the join, so all
+    // snapshots of one security share an identical `close_price_as_of` while
+    // their `close_price` and snapshot dates differ per month. Bucketing off
+    // `close_price_as_of` would collapse the whole series into one month.
+    const sharedAsOf = "2026-03-30";
+    const snapshots = new SecuritySnapshotDictionary();
+    for (const [date, price] of [
+      ["2026-01-15", 100],
+      ["2026-02-15", 110],
+      ["2026-03-15", 120],
+    ] as const) {
+      const snap = createSecuritySnapshot("sec1", price, date);
+      snap.security.close_price_as_of = sharedAsOf;
+      snapshots.set(`snap_${date}`, snap);
+    }
+
+    const index = buildSecurityPriceIndex(snapshots);
+
+    // Three distinct monthly buckets, each priced and dated by its own snapshot
+    // — not one collapsed "2026-03" bucket.
+    const sec1 = index.get("sec1");
+    expect(sec1?.size).toBe(3);
+    expect(sec1?.get("2026-01")).toEqual({ price: 100, sourceDate: "2026-01-15" });
+    expect(sec1?.get("2026-02")).toEqual({ price: 110, sourceDate: "2026-02-15" });
+    expect(sec1?.get("2026-03")).toEqual({ price: 120, sourceDate: "2026-03-15" });
+  });
 });
 
 describe("getPriceForHolding", () => {

--- a/src/client/lib/hooks/calculation/holdings.ts
+++ b/src/client/lib/hooks/calculation/holdings.ts
@@ -11,10 +11,16 @@ import { HoldingSnapshot } from "../../models/Snapshot";
 import { InvestmentTransaction } from "../../models/InvestmentTransaction";
 
 /**
- * One entry in the price index. `sourceDate` is the date the price was
- * recorded (`close_price_as_of` if Plaid surfaced it, otherwise the snapshot
- * date). It's needed downstream so we can compare security-snapshot freshness
- * against the holding snapshot's own date and pick whichever's more recent.
+ * One entry in the price index. `sourceDate` is the snapshot's own recording
+ * date — i.e. when that month's `close_price` was captured. It's needed
+ * downstream so we can compare security-snapshot freshness against the holding
+ * snapshot's own date and pick whichever's more recent.
+ *
+ * We deliberately do NOT use the security's `close_price_as_of`: that field is
+ * a single per-security constant (the as-of date of the security's *latest*
+ * price) that the server attaches to every historical snapshot in the join.
+ * Keying off it collapses a security's entire price history into one month
+ * bucket and breaks the per-month tie-break (every sourceDate is identical).
  */
 export interface PriceIndexEntry {
   price: number;
@@ -37,11 +43,13 @@ export const buildSecurityPriceIndex = (
 
   securitySnapshots.forEach((snapshot) => {
     const { security } = snapshot;
-    const { security_id, close_price, close_price_as_of } = security;
+    const { security_id, close_price } = security;
 
     if (!security_id || close_price === null || close_price === undefined) return;
 
-    const dateStr = close_price_as_of || snapshot.snapshot.date;
+    // Bucket by the snapshot's own date: that's when this `close_price` was
+    // recorded. (Not `close_price_as_of` — see PriceIndexEntry doc above.)
+    const dateStr = snapshot.snapshot.date;
     if (!dateStr) return;
 
     const date = new LocalDate(dateStr);


### PR DESCRIPTION
## Problem

`buildSecurityPriceIndex` (`src/client/lib/hooks/calculation/holdings.ts`) bucketed each per-month price entry by the security's `close_price_as_of`. That field is a **single per-security constant** — the as-of date of the security's *latest* price — which the server attaches to every historical snapshot when it joins `snapshots` (which has no `close_price_as_of`) against `securities` (which holds exactly one).

So every snapshot of a given security carried an identical `close_price_as_of`, which meant:

1. The whole price history collapsed into **one** `yearMonth` bucket (the `close_price_as_of` month).
2. The per-month tie-break (`dateStr > existing.sourceDate`) could never fire — every `sourceDate` compared equal — so an arbitrary snapshot's price won the bucket.

`HoldingsComposition` then valued holdings at a wrong-date close price for any view month at or after that as-of, inflating per-security Value/Growth/% and producing a spurious "Unknown" reconciliation row to absorb the gap. Account-level totals stayed correct (pinned to balance), which masked it.

## Fix

Bucket by the snapshot's own date (`snapshot.snapshot.date`) — that's when the month's `close_price` was actually recorded. `sourceDate` now carries that date, which is also the correct basis for the security-vs-`institution_price` freshness comparison in `getPriceForHolding` (the comment there already wanted "when the security price was recorded", not a forward as-of).

Scope kept to the client calculation layer; the server enrichment is unchanged (the optional server-side null-out from the issue would broaden scope without being needed to fix the symptom).

## Test plan

- **New regression test** `buildSecurityPriceIndex > buckets by snapshot date, not the security's shared close_price_as_of`: builds a 3-month series for one security all sharing one `close_price_as_of` (the prod-join shape) and asserts 3 distinct monthly buckets, each priced/dated by its own snapshot. **Verified it fails on the pre-fix line** (collapses to 1 bucket) and passes after.
- Full `holdings.test.ts` suite green (37 pass). Existing tests unaffected — their helper set `close_price_as_of == snapshot date`, so they never exercised the prod skew.
- `bun run typecheck` clean; `eslint` clean on both changed files.

Closes #511
