### PR TITLE
fix(budgets): yearly capacity sums each month's rate, not year-end rate × 12 (#526)

### DIFF
--- a/src/client/lib/models/BudgetFamily.test.ts
+++ b/src/client/lib/models/BudgetFamily.test.ts
@@ -1,0 +1,90 @@
+import { test, expect, describe } from "bun:test";
+import { MAX_FLOAT } from "common";
+// Prime the model graph before importing the concrete subclasses. Data.ts
+// fully evaluates BudgetFamily before reaching Budget/Section/Category (which
+// `extends BudgetFamily`); importing Budget first instead hits a circular-
+// import TDZ ("Cannot access 'BudgetFamily' before initialization").
+import "./Data";
+import { Budget } from "./Budget";
+import { Capacity } from "./Capacity";
+
+// ---------------------------------------------------------------------------
+// BudgetFamily.getActiveAmount / getYearlyAmount
+//
+// Regression coverage for #526: the yearly capacity must be the sum of each
+// of the 12 months' active capacities, NOT the single year-end rate × 12.
+// Mirrors Calculations.aggregateYear on the spending side so the LabeledBar's
+// `left = capacity − spent` compares like-aggregated quantities.
+// ---------------------------------------------------------------------------
+
+// A date inside 2026 — getYearlyAmount only reads getFullYear().
+const IN_2026 = new Date(2026, 5, 15);
+
+describe("BudgetFamily.getActiveAmount('year')", () => {
+  test("single constant capacity → month × 12 (numerically neutral with the old path)", () => {
+    const b = new Budget({ capacities: [new Capacity({ month: 1000 })] });
+    expect(b.getActiveAmount(IN_2026, "year")).toBe(12000);
+  });
+
+  test("mid-year rate cut sums each month, not year-end rate × 12 (#526 repro)", () => {
+    // $4000/mo default, lowered to $3000/mo effective 2026-02-01.
+    const b = new Budget({
+      capacities: [
+        new Capacity({ month: 4000 }),
+        new Capacity({ month: 3000, active_from: "2026-02-01" as unknown as Date }),
+      ],
+    });
+    // Jan@4000 + Feb–Dec@3000 = 4000 + 11 × 3000 = 37000 — NOT 3000 × 12 = 36000.
+    expect(b.getActiveAmount(IN_2026, "year")).toBe(37000);
+  });
+
+  test("mid-year rate raise also sums each month", () => {
+    // $2000/mo default, raised to $5000/mo effective 2026-07-01.
+    const b = new Budget({
+      capacities: [
+        new Capacity({ month: 2000 }),
+        new Capacity({ month: 5000, active_from: "2026-07-01" as unknown as Date }),
+      ],
+    });
+    // Jan–Jun@2000 + Jul–Dec@5000 = 6 × 2000 + 6 × 5000 = 42000 — NOT 5000 × 12 = 60000.
+    expect(b.getActiveAmount(IN_2026, "year")).toBe(42000);
+  });
+
+  test("a capacity change in a LATER year does not affect the displayed year", () => {
+    const b = new Budget({
+      capacities: [
+        new Capacity({ month: 1000 }),
+        new Capacity({ month: 9999, active_from: "2027-01-01" as unknown as Date }),
+      ],
+    });
+    expect(b.getActiveAmount(IN_2026, "year")).toBe(12000);
+  });
+
+  test("infinite (MAX_FLOAT) capacity poisons the year to +MAX_FLOAT, no overflow", () => {
+    const b = new Budget({ capacities: [new Capacity({ month: MAX_FLOAT })] });
+    expect(b.getActiveAmount(IN_2026, "year")).toBe(MAX_FLOAT);
+  });
+
+  test("infinite income (-MAX_FLOAT) capacity poisons the year to -MAX_FLOAT", () => {
+    const b = new Budget({ capacities: [new Capacity({ month: -MAX_FLOAT })] });
+    expect(b.getActiveAmount(IN_2026, "year")).toBe(-MAX_FLOAT);
+  });
+
+  test("income (negative finite) capacity stays negative across the year", () => {
+    const b = new Budget({ capacities: [new Capacity({ month: -1500 })] });
+    expect(b.getActiveAmount(IN_2026, "year")).toBe(-18000);
+  });
+
+  test("month interval is unchanged — resolves the period-end active capacity", () => {
+    const b = new Budget({
+      capacities: [
+        new Capacity({ month: 4000 }),
+        new Capacity({ month: 3000, active_from: "2026-02-01" as unknown as Date }),
+      ],
+    });
+    // March 2026 → the $3000 capacity is active.
+    expect(b.getActiveAmount(new Date(2026, 2, 15), "month")).toBe(3000);
+    // January 2026 → still the $4000 default.
+    expect(b.getActiveAmount(new Date(2026, 0, 15), "month")).toBe(4000);
+  });
+});

--- a/src/client/lib/models/BudgetFamily.ts
+++ b/src/client/lib/models/BudgetFamily.ts
@@ -1,4 +1,12 @@
-import { assign, excludeEnumeration, getDateTimeString, JSONBudgetFamily, LocalDate } from "common";
+import {
+  assign,
+  excludeEnumeration,
+  getDateTimeString,
+  JSONBudgetFamily,
+  LocalDate,
+  MAX_FLOAT,
+  ViewDate,
+} from "common";
 import { Capacity, sortCapacities, type Interval } from "./Capacity";
 import { globalData } from "./Data";
 import { CapacityData } from "client";
@@ -55,6 +63,7 @@ export class BudgetFamily {
       "sortCapacities",
       "getActiveCapacity",
       "getActiveAmount",
+      "getYearlyAmount",
       "isChildrenSynced",
       "getChildren",
       "getParent",
@@ -107,8 +116,39 @@ export class BudgetFamily {
    * through to the stored `month` for non-synced rows.
    */
   getActiveAmount = (date: Date, interval: Interval): number => {
+    if (interval === "year") return this.getYearlyAmount(date);
     const capacity = this.getActiveCapacity(date);
     return capacity.getActiveAmount(date, interval, this.getChildren());
+  };
+
+  /**
+   * Yearly amount = the sum of each of the 12 months' active capacities,
+   * NOT the single year-end rate annualized (`month × 12`). A budget whose
+   * monthly capacity changed mid-year (e.g. $4000/mo through Jan, $3000/mo
+   * from Feb) must report Jan@4000 + Feb–Dec@3000, not Dec-rate × 12.
+   *
+   * This mirrors `Calculations.aggregateYear` on the spending side: the
+   * `LabeledBar` computes `left = capacity − spent`, and `spent` is the
+   * true per-month sum across the year, so the capacity side must aggregate
+   * the same way or the two halves of the bar disagree about the year's
+   * budget. Walking the months also resolves synced rows correctly (each
+   * month sums children at that month's active capacities).
+   *
+   * Infinity poisons the year to ±MAX_FLOAT — summing 12 × MAX_FLOAT would
+   * overflow the sentinel — matching `Capacity.year`'s own guard.
+   */
+  getYearlyAmount = (date: Date): number => {
+    const year = date.getFullYear();
+    const children = this.getChildren();
+    let total = 0;
+    for (let month = 0; month < 12; month++) {
+      const monthEnd = new ViewDate("month", new Date(year, month, 1)).getEndDate();
+      const amount = this.getActiveCapacity(monthEnd).getActiveAmount(monthEnd, "month", children);
+      if (Number.isNaN(amount)) continue;
+      if (Math.abs(amount) === MAX_FLOAT) return amount > 0 ? MAX_FLOAT : -MAX_FLOAT;
+      total += amount;
+    }
+    return total;
   };
 
   isChildrenSynced = (capacityData: CapacityData) => {


### PR DESCRIPTION
## Summary

Closes #526.

In **Yearly** budget view the `LabeledBar` rendered `left = capacity − spent` where the two halves used **inconsistent aggregation**:

- **spent** = the true per-month sum across the year (`Calculations.aggregateYear`).
- **capacity** = the single year-end monthly rate annualized (`month × 12`), via `Capacity.year`.

For any budget whose monthly capacity **changed mid-year**, the yearly "of …" and "left" were wrong relative to the per-month budget the user configured — and inconsistent with the spent figure they're compared against.

## Fix

`BudgetFamily.getActiveAmount` now dispatches `interval === "year"` to a new `getYearlyAmount`, which **sums each of the 12 months' active capacities** (`getActiveCapacity(monthEnd).getActiveAmount(monthEnd, "month", children)`), mirroring `aggregateYear` on the spending side.

- **Single-capacity budgets are numerically neutral** — `rate × 12` equals the 12-month sum, so unchanged budgets render exactly as before.
- **Infinite capacities still poison the year to ±`MAX_FLOAT`** (12 × `MAX_FLOAT` would overflow the sentinel) — matching `Capacity.year`'s guard.
- **Synced rows resolve correctly** — each month sums children at that month's active capacities.
- Landed at the shared `BudgetFamily` boundary, so every yearly consumer (`LabeledBar`, `BalanceChartRow`, `BudgetDonut`, `ChartAccountsPage`, `BudgetDetailPage` graph) stays consistent — no cross-view split.

Net +41/−1 source, 1 file, plus a new `BudgetFamily.test.ts`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — 884 pass / 0 fail
- [x] **New regression test** (`BudgetFamily.test.ts`) — fails on baseline (year-end rate × 12), passes on fix (12-month sum); stash/pop verified. Covers: single-capacity neutrality, mid-year cut, mid-year raise, later-year change ignored, ±infinite poisoning, negative-income, month-interval unchanged.
- [ ] **UI E2E** — pending sandbox walkthrough (Budgets page, Yearly 2026, the one mid-year-rate-change budget; fix vs `upstream/main` baseline).
