### PR TITLE
feat(transfers): exclude confirmed pairs from budget + flow calculations

### DIFF
--- a/src/client/components/App/AppContext.tsx
+++ b/src/client/components/App/AppContext.tsx
@@ -5,7 +5,6 @@ import {
   Context,
   useRouter,
   reduceStatuses,
-  useTransfers,
 } from "client";
 import { MaskedUser } from "server";
 import { Interval, ViewDate } from "common";
@@ -27,7 +26,6 @@ const AppContext = ({ initialUser, children }: Props) => {
 
   const [viewDate, setViewDate] = useState(new ViewDate(selectedInterval));
   const router = useRouter();
-  const transfers = useTransfers(user);
 
   const status = reduceStatuses(data?.status, calculations?.status);
 
@@ -46,9 +44,20 @@ const AppContext = ({ initialUser, children }: Props) => {
       viewDate,
       setViewDate,
       screenType,
-      transfers,
     }),
-    [data, setData, calculations, calculate, status, user, router, selectedInterval, setSelectedInterval, viewDate, screenType, transfers],
+    [
+      data,
+      setData,
+      calculations,
+      calculate,
+      status,
+      user,
+      router,
+      selectedInterval,
+      setSelectedInterval,
+      viewDate,
+      screenType,
+    ],
   );
 
   return <Context.Provider value={contextValue}>{children}</Context.Provider>;

--- a/src/client/components/App/Utility.tsx
+++ b/src/client/components/App/Utility.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useAppContext, useSync, PATH, useDebounce } from "client";
+import { useAppContext, useSync, useTransfers, PATH, useDebounce } from "client";
 
 /**
  * This component is used to run useEffect hooks dependant on context variables.
@@ -7,13 +7,13 @@ import { useAppContext, useSync, PATH, useDebounce } from "client";
  * dev engineers to find them easily.
  */
 const Utility = () => {
-  const { user, router, setSelectedInterval, data, calculate, viewDate, transfers } =
-    useAppContext();
+  const { user, router, setSelectedInterval, data, calculate, viewDate } = useAppContext();
 
   const userLoggedIn = !!user;
   const { path, go } = router;
 
   const { sync, clean } = useSync();
+  const { refresh: refreshTransfers } = useTransfers();
   const debouncer = useDebounce();
 
   /**
@@ -32,21 +32,24 @@ const Utility = () => {
     else clean();
   }, [userLoggedIn, sync, clean]);
 
-  // `transfers.confirmedTransferByTransactionId` is already a
-  // Map<transaction_id, ConfirmedTransfer>; its `.has(id)` answers the
-  // exact question the calcs ask. Feeding the Map straight through
-  // avoids a redundant Set materialization (Hoie review 2026-06-19).
-  // Per-account balance calc intentionally does not consume this —
-  // see `useData`'s `calculateAll` comment.
-  const confirmedTransferIds = transfers.confirmedTransferByTransactionId;
+  /**
+   * Refresh transfer pairs on login so `data.suggestedPairByTransactionId`
+   * / `data.confirmedTransferByTransactionId` are populated for the
+   * first calculator run + the transactions-table render. Each
+   * mutation method on `useTransfers()` re-runs refresh internally;
+   * this effect handles the initial cold load only.
+   */
+  useEffect(() => {
+    if (userLoggedIn) refreshTransfers();
+  }, [userLoggedIn, refreshTransfers]);
 
   /**
    * Calculate balance history when data is updated
    */
   useEffect(() => {
     if (!data.status.isInit) return;
-    debouncer(() => calculate(data, { confirmedTransferIds }));
-  }, [data, calculate, debouncer, confirmedTransferIds]);
+    debouncer(() => calculate(data));
+  }, [data, calculate, debouncer]);
 
   /**
    * Update viewDate when user selects different interval

--- a/src/client/components/App/Utility.tsx
+++ b/src/client/components/App/Utility.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { useAppContext, useSync, PATH, useDebounce } from "client";
 
 /**
@@ -32,25 +32,21 @@ const Utility = () => {
     else clean();
   }, [userLoggedIn, sync, clean]);
 
-  // Confirmed-transfer transaction id set, derived once per
-  // `transfers.confirmedTransferByTransactionId` ref change. Threaded
-  // into `calculate(...)` so `getBudgetData` (and any future calc
-  // wanting to skip transfers) sees the latest pair set. Per-account
-  // balance calc intentionally does not consume this — see
-  // `useData`'s `calculateAll` comment.
-  const confirmedTransferTxIds = useMemo(() => {
-    const set = new Set<string>();
-    transfers.confirmedTransferByTransactionId.forEach((_pair, txId) => set.add(txId));
-    return set;
-  }, [transfers.confirmedTransferByTransactionId]);
+  // `transfers.confirmedTransferByTransactionId` is already a
+  // Map<transaction_id, ConfirmedTransfer>; its `.has(id)` answers the
+  // exact question the calcs ask. Feeding the Map straight through
+  // avoids a redundant Set materialization (Hoie review 2026-06-19).
+  // Per-account balance calc intentionally does not consume this —
+  // see `useData`'s `calculateAll` comment.
+  const confirmedTransferIds = transfers.confirmedTransferByTransactionId;
 
   /**
    * Calculate balance history when data is updated
    */
   useEffect(() => {
     if (!data.status.isInit) return;
-    debouncer(() => calculate(data, { confirmedTransferTxIds }));
-  }, [data, calculate, debouncer, confirmedTransferTxIds]);
+    debouncer(() => calculate(data, { confirmedTransferIds }));
+  }, [data, calculate, debouncer, confirmedTransferIds]);
 
   /**
    * Update viewDate when user selects different interval

--- a/src/client/components/App/Utility.tsx
+++ b/src/client/components/App/Utility.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useAppContext, useSync, PATH, useDebounce } from "client";
 
 /**
@@ -7,7 +7,8 @@ import { useAppContext, useSync, PATH, useDebounce } from "client";
  * dev engineers to find them easily.
  */
 const Utility = () => {
-  const { user, router, setSelectedInterval, data, calculate, viewDate } = useAppContext();
+  const { user, router, setSelectedInterval, data, calculate, viewDate, transfers } =
+    useAppContext();
 
   const userLoggedIn = !!user;
   const { path, go } = router;
@@ -31,13 +32,25 @@ const Utility = () => {
     else clean();
   }, [userLoggedIn, sync, clean]);
 
+  // Confirmed-transfer transaction id set, derived once per
+  // `transfers.confirmedTransferByTransactionId` ref change. Threaded
+  // into `calculate(...)` so `getBudgetData` (and any future calc
+  // wanting to skip transfers) sees the latest pair set. Per-account
+  // balance calc intentionally does not consume this — see
+  // `useData`'s `calculateAll` comment.
+  const confirmedTransferTxIds = useMemo(() => {
+    const set = new Set<string>();
+    transfers.confirmedTransferByTransactionId.forEach((_pair, txId) => set.add(txId));
+    return set;
+  }, [transfers.confirmedTransferByTransactionId]);
+
   /**
    * Calculate balance history when data is updated
    */
   useEffect(() => {
     if (!data.status.isInit) return;
-    debouncer(() => calculate(data));
-  }, [data, calculate, debouncer]);
+    debouncer(() => calculate(data, { confirmedTransferTxIds }));
+  }, [data, calculate, debouncer, confirmedTransferTxIds]);
 
   /**
    * Update viewDate when user selects different interval

--- a/src/client/components/App/Utility.tsx
+++ b/src/client/components/App/Utility.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useAppContext, useSync, useTransfers, PATH, useDebounce } from "client";
+import { useAppContext, useSync, PATH, useDebounce } from "client";
 
 /**
  * This component is used to run useEffect hooks dependant on context variables.
@@ -13,7 +13,6 @@ const Utility = () => {
   const { path, go } = router;
 
   const { sync, clean } = useSync();
-  const { refresh: refreshTransfers } = useTransfers();
   const debouncer = useDebounce();
 
   /**
@@ -31,17 +30,6 @@ const Utility = () => {
     if (userLoggedIn) sync();
     else clean();
   }, [userLoggedIn, sync, clean]);
-
-  /**
-   * Refresh transfer pairs on login so `data.suggestedPairByTransactionId`
-   * / `data.confirmedTransferByTransactionId` are populated for the
-   * first calculator run + the transactions-table render. Each
-   * mutation method on `useTransfers()` re-runs refresh internally;
-   * this effect handles the initial cold load only.
-   */
-  useEffect(() => {
-    if (userLoggedIn) refreshTransfers();
-  }, [userLoggedIn, refreshTransfers]);
 
   /**
    * Calculate balance history when data is updated

--- a/src/client/components/App/lib/hooks.ts
+++ b/src/client/components/App/lib/hooks.ts
@@ -12,7 +12,17 @@ import {
 } from "client";
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from "react";
 
-type CalculateFn = ((data: Data) => void) & {
+export interface CalculateOptions {
+  /** Confirmed-transfer transaction ids — threaded into `getBudgetData`
+   *  so the spent/income aggregation skips internal-movement
+   *  transactions. Not threaded into balance calcs (per Hoie
+   *  2026-06-18: per-account historical balance MUST still include
+   *  transfer effects, since the account's balance really did change).
+   *  Empty / omitted = pre-PR behavior. */
+  confirmedTransferTxIds?: ReadonlySet<string>;
+}
+
+type CalculateFn = ((data: Data, opts?: CalculateOptions) => void) & {
   cache: {
     capacityData: (updater: (current: CapacityData) => CapacityData) => void;
   };
@@ -34,7 +44,7 @@ export const useData = () => {
   const [calculations, setCalculations] = useState(new Calculations());
 
   const calculateAll = useCallback(
-    (data: Data) => {
+    (data: Data, opts?: CalculateOptions) => {
       const {
         accounts,
         accountSnapshots,
@@ -49,9 +59,16 @@ export const useData = () => {
         categories,
       } = data;
 
+      const confirmedTransferTxIds = opts?.confirmedTransferTxIds;
+
       setCalculations((oldCalculations) => {
         const newCalculations = new Calculations(oldCalculations);
 
+        // Balance data intentionally does NOT receive confirmedTransferTxIds:
+        // per-account historical balance is supposed to reflect the actual
+        // value held in each account at each point in time. A transfer
+        // moves real dollars between accounts, so dropping it would
+        // de-sync the chart from the snapshot baseline (Hoie 2026-06-18).
         const balanceData = getBalanceData(
           accounts,
           accountSnapshots,
@@ -67,6 +84,7 @@ export const useData = () => {
           budgets,
           sections,
           categories,
+          confirmedTransferTxIds,
         );
 
         const capacityData = getCapacityData(budgets, sections, categories);

--- a/src/client/components/App/lib/hooks.ts
+++ b/src/client/components/App/lib/hooks.ts
@@ -54,11 +54,11 @@ export const useData = () => {
         const newCalculations = new Calculations(oldCalculations);
 
         // Balance data intentionally does NOT receive `transfers`:
-        // per-account historical balance is supposed to reflect the
-        // actual value held in each account at each point in time. A
+        // per-account historical balance must reflect the actual
+        // value held in each account at each point in time. A
         // transfer moves real dollars between accounts, so dropping
         // its halves would de-sync the chart from the snapshot
-        // baseline (Hoie 2026-06-18).
+        // baseline.
         const balanceData = getBalanceData(
           accounts,
           accountSnapshots,

--- a/src/client/components/App/lib/hooks.ts
+++ b/src/client/components/App/lib/hooks.ts
@@ -12,19 +12,7 @@ import {
 } from "client";
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from "react";
 
-export interface CalculateOptions {
-  /** Membership-test for confirmed-transfer transaction ids — threaded
-   *  into `getBudgetData` so spent/income aggregation skips
-   *  internal-movement transactions. Typed structurally on `has` so
-   *  the standard call site can pass
-   *  `transfers.confirmedTransferByTransactionId` (a Map) directly
-   *  without materializing a parallel Set. Not threaded into balance
-   *  calcs (per Hoie 2026-06-18: per-account historical balance MUST
-   *  still include transfer effects). Omitted = pre-PR behavior. */
-  confirmedTransferIds?: { has(transaction_id: string): boolean };
-}
-
-type CalculateFn = ((data: Data, opts?: CalculateOptions) => void) & {
+type CalculateFn = ((data: Data) => void) & {
   cache: {
     capacityData: (updater: (current: CapacityData) => CapacityData) => void;
   };
@@ -46,7 +34,7 @@ export const useData = () => {
   const [calculations, setCalculations] = useState(new Calculations());
 
   const calculateAll = useCallback(
-    (data: Data, opts?: CalculateOptions) => {
+    (data: Data) => {
       const {
         accounts,
         accountSnapshots,
@@ -59,18 +47,18 @@ export const useData = () => {
         budgets,
         sections,
         categories,
+        confirmedTransferByTransactionId,
       } = data;
-
-      const confirmedTransferIds = opts?.confirmedTransferIds;
 
       setCalculations((oldCalculations) => {
         const newCalculations = new Calculations(oldCalculations);
 
-        // Balance data intentionally does NOT receive confirmedTransferIds:
-        // per-account historical balance is supposed to reflect the actual
-        // value held in each account at each point in time. A transfer
-        // moves real dollars between accounts, so dropping it would
-        // de-sync the chart from the snapshot baseline (Hoie 2026-06-18).
+        // Balance data intentionally does NOT receive
+        // confirmedTransferByTransactionId: per-account historical
+        // balance is supposed to reflect the actual value held in
+        // each account at each point in time. A transfer moves real
+        // dollars between accounts, so dropping it would de-sync the
+        // chart from the snapshot baseline (Hoie 2026-06-18).
         const balanceData = getBalanceData(
           accounts,
           accountSnapshots,
@@ -86,7 +74,7 @@ export const useData = () => {
           budgets,
           sections,
           categories,
-          confirmedTransferIds,
+          confirmedTransferByTransactionId,
         );
 
         const capacityData = getCapacityData(budgets, sections, categories);

--- a/src/client/components/App/lib/hooks.ts
+++ b/src/client/components/App/lib/hooks.ts
@@ -47,18 +47,18 @@ export const useData = () => {
         budgets,
         sections,
         categories,
-        confirmedTransferByTransactionId,
+        transfers,
       } = data;
 
       setCalculations((oldCalculations) => {
         const newCalculations = new Calculations(oldCalculations);
 
-        // Balance data intentionally does NOT receive
-        // confirmedTransferByTransactionId: per-account historical
-        // balance is supposed to reflect the actual value held in
-        // each account at each point in time. A transfer moves real
-        // dollars between accounts, so dropping it would de-sync the
-        // chart from the snapshot baseline (Hoie 2026-06-18).
+        // Balance data intentionally does NOT receive `transfers`:
+        // per-account historical balance is supposed to reflect the
+        // actual value held in each account at each point in time. A
+        // transfer moves real dollars between accounts, so dropping
+        // its halves would de-sync the chart from the snapshot
+        // baseline (Hoie 2026-06-18).
         const balanceData = getBalanceData(
           accounts,
           accountSnapshots,
@@ -74,7 +74,7 @@ export const useData = () => {
           budgets,
           sections,
           categories,
-          confirmedTransferByTransactionId,
+          transfers,
         );
 
         const capacityData = getCapacityData(budgets, sections, categories);

--- a/src/client/components/App/lib/hooks.ts
+++ b/src/client/components/App/lib/hooks.ts
@@ -13,13 +13,15 @@ import {
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from "react";
 
 export interface CalculateOptions {
-  /** Confirmed-transfer transaction ids — threaded into `getBudgetData`
-   *  so the spent/income aggregation skips internal-movement
-   *  transactions. Not threaded into balance calcs (per Hoie
-   *  2026-06-18: per-account historical balance MUST still include
-   *  transfer effects, since the account's balance really did change).
-   *  Empty / omitted = pre-PR behavior. */
-  confirmedTransferTxIds?: ReadonlySet<string>;
+  /** Membership-test for confirmed-transfer transaction ids — threaded
+   *  into `getBudgetData` so spent/income aggregation skips
+   *  internal-movement transactions. Typed structurally on `has` so
+   *  the standard call site can pass
+   *  `transfers.confirmedTransferByTransactionId` (a Map) directly
+   *  without materializing a parallel Set. Not threaded into balance
+   *  calcs (per Hoie 2026-06-18: per-account historical balance MUST
+   *  still include transfer effects). Omitted = pre-PR behavior. */
+  confirmedTransferIds?: { has(transaction_id: string): boolean };
 }
 
 type CalculateFn = ((data: Data, opts?: CalculateOptions) => void) & {
@@ -59,12 +61,12 @@ export const useData = () => {
         categories,
       } = data;
 
-      const confirmedTransferTxIds = opts?.confirmedTransferTxIds;
+      const confirmedTransferIds = opts?.confirmedTransferIds;
 
       setCalculations((oldCalculations) => {
         const newCalculations = new Calculations(oldCalculations);
 
-        // Balance data intentionally does NOT receive confirmedTransferTxIds:
+        // Balance data intentionally does NOT receive confirmedTransferIds:
         // per-account historical balance is supposed to reflect the actual
         // value held in each account at each point in time. A transfer
         // moves real dollars between accounts, so dropping it would
@@ -84,7 +86,7 @@ export const useData = () => {
           budgets,
           sections,
           categories,
-          confirmedTransferTxIds,
+          confirmedTransferIds,
         );
 
         const capacityData = getCapacityData(budgets, sections, categories);

--- a/src/client/components/FlowChartRow/index.tsx
+++ b/src/client/components/FlowChartRow/index.tsx
@@ -23,16 +23,18 @@ export const FlowChartRow = ({
   onSetOrder,
   height = 150,
 }: FlowChartRowProps) => {
-  const { data, viewDate, transfers } = useAppContext();
-  const { accounts, transactions, investmentTransactions, budgets, sections, categories } = data;
+  const { data, viewDate } = useAppContext();
+  const {
+    accounts,
+    transactions,
+    investmentTransactions,
+    budgets,
+    sections,
+    categories,
+    confirmedTransferByTransactionId,
+  } = data;
   const { configuration } = chart;
   const { account_ids } = configuration;
-
-  // `transfers.confirmedTransferByTransactionId` is already a
-  // Map<transaction_id, ConfirmedTransfer> — its `.has(id)` is exactly
-  // what `getSankeyData` checks. Pass the Map straight through; no
-  // need to materialize a parallel Set (Hoie review 2026-06-19).
-  const confirmedTransferIds = transfers.confirmedTransferByTransactionId;
 
   const {
     onDragStart,
@@ -61,7 +63,7 @@ export const FlowChartRow = ({
         sections,
         categories,
         viewDate,
-        confirmedTransferIds,
+        confirmedTransferByTransactionId,
       ),
     [
       selectedAccounts,
@@ -71,7 +73,7 @@ export const FlowChartRow = ({
       sections,
       categories,
       viewDate,
-      confirmedTransferIds,
+      confirmedTransferByTransactionId,
     ],
   );
 

--- a/src/client/components/FlowChartRow/index.tsx
+++ b/src/client/components/FlowChartRow/index.tsx
@@ -28,15 +28,11 @@ export const FlowChartRow = ({
   const { configuration } = chart;
   const { account_ids } = configuration;
 
-  // Confirmed-transfer txn ids — same shape as the set Utility threads
-  // into `calculate()`. Skipping these here prevents both halves of a
-  // pair from inflating income (destination credit) AND expense
-  // (source debit) by the same dollars on the Sankey.
-  const confirmedTransferTxIds = useMemo(() => {
-    const set = new Set<string>();
-    transfers.confirmedTransferByTransactionId.forEach((_pair, txId) => set.add(txId));
-    return set;
-  }, [transfers.confirmedTransferByTransactionId]);
+  // `transfers.confirmedTransferByTransactionId` is already a
+  // Map<transaction_id, ConfirmedTransfer> — its `.has(id)` is exactly
+  // what `getSankeyData` checks. Pass the Map straight through; no
+  // need to materialize a parallel Set (Hoie review 2026-06-19).
+  const confirmedTransferIds = transfers.confirmedTransferByTransactionId;
 
   const {
     onDragStart,
@@ -65,7 +61,7 @@ export const FlowChartRow = ({
         sections,
         categories,
         viewDate,
-        confirmedTransferTxIds,
+        confirmedTransferIds,
       ),
     [
       selectedAccounts,
@@ -75,7 +71,7 @@ export const FlowChartRow = ({
       sections,
       categories,
       viewDate,
-      confirmedTransferTxIds,
+      confirmedTransferIds,
     ],
   );
 

--- a/src/client/components/FlowChartRow/index.tsx
+++ b/src/client/components/FlowChartRow/index.tsx
@@ -31,7 +31,7 @@ export const FlowChartRow = ({
     budgets,
     sections,
     categories,
-    confirmedTransferByTransactionId,
+    transfers,
   } = data;
   const { configuration } = chart;
   const { account_ids } = configuration;
@@ -63,7 +63,7 @@ export const FlowChartRow = ({
         sections,
         categories,
         viewDate,
-        confirmedTransferByTransactionId,
+        transfers,
       ),
     [
       selectedAccounts,
@@ -73,7 +73,7 @@ export const FlowChartRow = ({
       sections,
       categories,
       viewDate,
-      confirmedTransferByTransactionId,
+      transfers,
     ],
   );
 

--- a/src/client/components/FlowChartRow/index.tsx
+++ b/src/client/components/FlowChartRow/index.tsx
@@ -23,10 +23,20 @@ export const FlowChartRow = ({
   onSetOrder,
   height = 150,
 }: FlowChartRowProps) => {
-  const { data, viewDate } = useAppContext();
+  const { data, viewDate, transfers } = useAppContext();
   const { accounts, transactions, investmentTransactions, budgets, sections, categories } = data;
   const { configuration } = chart;
   const { account_ids } = configuration;
+
+  // Confirmed-transfer txn ids — same shape as the set Utility threads
+  // into `calculate()`. Skipping these here prevents both halves of a
+  // pair from inflating income (destination credit) AND expense
+  // (source debit) by the same dollars on the Sankey.
+  const confirmedTransferTxIds = useMemo(() => {
+    const set = new Set<string>();
+    transfers.confirmedTransferByTransactionId.forEach((_pair, txId) => set.add(txId));
+    return set;
+  }, [transfers.confirmedTransferByTransactionId]);
 
   const {
     onDragStart,
@@ -55,6 +65,7 @@ export const FlowChartRow = ({
         sections,
         categories,
         viewDate,
+        confirmedTransferTxIds,
       ),
     [
       selectedAccounts,
@@ -64,6 +75,7 @@ export const FlowChartRow = ({
       sections,
       categories,
       viewDate,
+      confirmedTransferTxIds,
     ],
   );
 

--- a/src/client/components/FlowChartRow/lib.ts
+++ b/src/client/components/FlowChartRow/lib.ts
@@ -25,6 +25,13 @@ export const getSankeyData = (
   sections: SectionDictionary,
   categories: CategoryDictionary,
   viewDate: ViewDate,
+  // Confirmed-transfer transaction ids — skipped because a transfer is
+  // internal movement between the user's own accounts, not flow in or
+  // out of total wealth. Without this skip the Sankey would inflate
+  // both the income column (destination-side credit) and the expense
+  // column (source-side debit) by the same amount. Defaults to empty
+  // so other callers / tests keep the pre-PR behavior.
+  confirmedTransferTxIds: ReadonlySet<string> = new Set(),
 ): SankeyData => {
   const incomeBudgets = new Map<string, SankeyRow>();
   const incomeSections = new Map<string, SankeyRow>();
@@ -36,6 +43,7 @@ export const getSankeyData = (
 
   const processTransaction = (t: Transaction | InvestmentTransaction) => {
     const isInvestment = t instanceof InvestmentTransaction;
+    if (!isInvestment && confirmedTransferTxIds.has(t.transaction_id)) return;
     const authorized_date = !isInvestment ? t.authorized_date : undefined;
     const transactionDate = new LocalDate(authorized_date || t.date);
     if (!viewDate.has(transactionDate)) return;

--- a/src/client/components/FlowChartRow/lib.ts
+++ b/src/client/components/FlowChartRow/lib.ts
@@ -27,14 +27,15 @@ export const getSankeyData = (
   categories: CategoryDictionary,
   viewDate: ViewDate,
   // All transfer pairs (suggested + confirmed), keyed by pair_id with
-  // a transaction_id pivot. Halves of a CONFIRMED pair are skipped
-  // because a transfer is internal movement between the user's own
-  // accounts, not flow in or out of total wealth. Without this skip
-  // the Sankey would inflate both the income column (destination-side
-  // credit) AND the expense column (source-side debit) by the same
-  // amount. Suggested pairs still aggregate normally. Defaults to an
-  // empty dictionary so callers / tests keep pre-PR behavior.
-  transfers: TransferDictionary = new TransferDictionary(),
+  // a transaction_id pivot. Halves of a CONFIRMED pair are skipped —
+  // a transfer is internal movement between the user's own accounts,
+  // not flow in or out of total wealth. Without this skip the Sankey
+  // would inflate both the income column (destination-side credit)
+  // AND the expense column (source-side debit) by the same amount.
+  // Suggested pairs still aggregate normally. Required (no default):
+  // the caller threads `data.transfers` through, which is itself
+  // defaulted to an empty `TransferDictionary` on `Data`.
+  transfers: TransferDictionary,
 ): SankeyData => {
   const incomeBudgets = new Map<string, SankeyRow>();
   const incomeSections = new Map<string, SankeyRow>();

--- a/src/client/components/FlowChartRow/lib.ts
+++ b/src/client/components/FlowChartRow/lib.ts
@@ -10,7 +10,7 @@ import {
   SectionDictionary,
   Transaction,
   TransactionDictionary,
-  type ConfirmedTransfer,
+  TransferDictionary,
 } from "client";
 
 export interface SankeyData {
@@ -26,14 +26,15 @@ export const getSankeyData = (
   sections: SectionDictionary,
   categories: CategoryDictionary,
   viewDate: ViewDate,
-  // transaction_id → confirmed-transfer pair. Halves of a confirmed
-  // pair are skipped because a transfer is internal movement between
-  // the user's own accounts, not flow in or out of total wealth.
-  // Without this skip the Sankey would inflate both the income column
-  // (destination-side credit) AND the expense column (source-side
-  // debit) by the same amount. Defaults to an empty Map so other
-  // callers / tests keep the pre-PR behavior.
-  confirmedTransferByTransactionId: ReadonlyMap<string, ConfirmedTransfer> = new Map(),
+  // All transfer pairs (suggested + confirmed), keyed by pair_id with
+  // a transaction_id pivot. Halves of a CONFIRMED pair are skipped
+  // because a transfer is internal movement between the user's own
+  // accounts, not flow in or out of total wealth. Without this skip
+  // the Sankey would inflate both the income column (destination-side
+  // credit) AND the expense column (source-side debit) by the same
+  // amount. Suggested pairs still aggregate normally. Defaults to an
+  // empty dictionary so callers / tests keep pre-PR behavior.
+  transfers: TransferDictionary = new TransferDictionary(),
 ): SankeyData => {
   const incomeBudgets = new Map<string, SankeyRow>();
   const incomeSections = new Map<string, SankeyRow>();
@@ -45,7 +46,9 @@ export const getSankeyData = (
 
   const processTransaction = (t: Transaction | InvestmentTransaction) => {
     const isInvestment = t instanceof InvestmentTransaction;
-    if (!isInvestment && confirmedTransferByTransactionId.has(t.transaction_id)) return;
+    if (!isInvestment && transfers.getByTransactionId(t.transaction_id)?.status === "confirmed") {
+      return;
+    }
     const authorized_date = !isInvestment ? t.authorized_date : undefined;
     const transactionDate = new LocalDate(authorized_date || t.date);
     if (!viewDate.has(transactionDate)) return;

--- a/src/client/components/FlowChartRow/lib.ts
+++ b/src/client/components/FlowChartRow/lib.ts
@@ -31,7 +31,7 @@ export const getSankeyData = (
   // both the income column (destination-side credit) and the expense
   // column (source-side debit) by the same amount. Defaults to empty
   // so other callers / tests keep the pre-PR behavior.
-  confirmedTransferTxIds: ReadonlySet<string> = new Set(),
+  confirmedTransferIds: { has(transaction_id: string): boolean } = new Set<string>(),
 ): SankeyData => {
   const incomeBudgets = new Map<string, SankeyRow>();
   const incomeSections = new Map<string, SankeyRow>();
@@ -43,7 +43,7 @@ export const getSankeyData = (
 
   const processTransaction = (t: Transaction | InvestmentTransaction) => {
     const isInvestment = t instanceof InvestmentTransaction;
-    if (!isInvestment && confirmedTransferTxIds.has(t.transaction_id)) return;
+    if (!isInvestment && confirmedTransferIds.has(t.transaction_id)) return;
     const authorized_date = !isInvestment ? t.authorized_date : undefined;
     const transactionDate = new LocalDate(authorized_date || t.date);
     if (!viewDate.has(transactionDate)) return;

--- a/src/client/components/FlowChartRow/lib.ts
+++ b/src/client/components/FlowChartRow/lib.ts
@@ -10,6 +10,7 @@ import {
   SectionDictionary,
   Transaction,
   TransactionDictionary,
+  type ConfirmedTransfer,
 } from "client";
 
 export interface SankeyData {
@@ -25,13 +26,14 @@ export const getSankeyData = (
   sections: SectionDictionary,
   categories: CategoryDictionary,
   viewDate: ViewDate,
-  // Confirmed-transfer transaction ids — skipped because a transfer is
-  // internal movement between the user's own accounts, not flow in or
-  // out of total wealth. Without this skip the Sankey would inflate
-  // both the income column (destination-side credit) and the expense
-  // column (source-side debit) by the same amount. Defaults to empty
-  // so other callers / tests keep the pre-PR behavior.
-  confirmedTransferIds: { has(transaction_id: string): boolean } = new Set<string>(),
+  // transaction_id → confirmed-transfer pair. Halves of a confirmed
+  // pair are skipped because a transfer is internal movement between
+  // the user's own accounts, not flow in or out of total wealth.
+  // Without this skip the Sankey would inflate both the income column
+  // (destination-side credit) AND the expense column (source-side
+  // debit) by the same amount. Defaults to an empty Map so other
+  // callers / tests keep the pre-PR behavior.
+  confirmedTransferByTransactionId: ReadonlyMap<string, ConfirmedTransfer> = new Map(),
 ): SankeyData => {
   const incomeBudgets = new Map<string, SankeyRow>();
   const incomeSections = new Map<string, SankeyRow>();
@@ -43,7 +45,7 @@ export const getSankeyData = (
 
   const processTransaction = (t: Transaction | InvestmentTransaction) => {
     const isInvestment = t instanceof InvestmentTransaction;
-    if (!isInvestment && confirmedTransferIds.has(t.transaction_id)) return;
+    if (!isInvestment && confirmedTransferByTransactionId.has(t.transaction_id)) return;
     const authorized_date = !isInvestment ? t.authorized_date : undefined;
     const transactionDate = new LocalDate(authorized_date || t.date);
     if (!viewDate.has(transactionDate)) return;

--- a/src/client/components/TransactionProperties/index.tsx
+++ b/src/client/components/TransactionProperties/index.tsx
@@ -10,6 +10,7 @@ import {
   TransactionDictionary,
   TransactionLabel,
   useAppContext,
+  useTransfers,
   call,
   indexedDb,
 } from "client";
@@ -29,9 +30,17 @@ interface Props {
 }
 
 export const TransactionProperties = ({ transaction }: Props) => {
-  const { data, setData, calculations, transfers } = useAppContext();
+  const { data, setData, calculations } = useAppContext();
+  const transferActions = useTransfers();
   const { transactionFamilies } = calculations;
-  const { accounts, budgets, sections, categories } = data;
+  const {
+    accounts,
+    budgets,
+    sections,
+    categories,
+    confirmedTransferByTransactionId,
+    suggestedPairByTransactionId,
+  } = data;
 
   const {
     transaction_id,
@@ -279,8 +288,8 @@ export const TransactionProperties = ({ transaction }: Props) => {
       const tDateMs = new LocalDate(t.authorized_date || t.date).getTime();
       if (Math.abs(tDateMs - txDateMs) > PARTNER_DATE_WINDOW_DAYS * ONE_DAY_MS) return;
       // Skip transactions already in a pair (confirmed or suggested).
-      if (transfers.confirmedTransferByTransactionId.has(t.transaction_id)) return;
-      if (transfers.suggestedPairByTransactionId.has(t.transaction_id)) return;
+      if (confirmedTransferByTransactionId.has(t.transaction_id)) return;
+      if (suggestedPairByTransactionId.has(t.transaction_id)) return;
       candidates.push(t);
     });
     candidates.sort((a, b) => {
@@ -289,12 +298,19 @@ export const TransactionProperties = ({ transaction }: Props) => {
       return Math.abs(aDateMs - txDateMs) - Math.abs(bDateMs - txDateMs);
     });
     return candidates;
-  }, [data.transactions, transaction_id, txAmount, txDateMs, transfers]);
+  }, [
+    data.transactions,
+    transaction_id,
+    txAmount,
+    txDateMs,
+    confirmedTransferByTransactionId,
+    suggestedPairByTransactionId,
+  ]);
 
   const onClickPartnerCandidate = async (partnerId: string) => {
     setPendingPartnerId(partnerId);
     try {
-      await transfers.pair(transaction_id, partnerId);
+      await transferActions.pair(transaction_id, partnerId);
       setShowPartnerPicker(false);
     } finally {
       setPendingPartnerId(null);

--- a/src/client/components/TransactionProperties/index.tsx
+++ b/src/client/components/TransactionProperties/index.tsx
@@ -33,14 +33,7 @@ export const TransactionProperties = ({ transaction }: Props) => {
   const { data, setData, calculations } = useAppContext();
   const transferActions = useTransfers();
   const { transactionFamilies } = calculations;
-  const {
-    accounts,
-    budgets,
-    sections,
-    categories,
-    confirmedTransferByTransactionId,
-    suggestedPairByTransactionId,
-  } = data;
+  const { accounts, budgets, sections, categories, transfers } = data;
 
   const {
     transaction_id,
@@ -287,9 +280,8 @@ export const TransactionProperties = ({ transaction }: Props) => {
       // Within ±PARTNER_DATE_WINDOW_DAYS.
       const tDateMs = new LocalDate(t.authorized_date || t.date).getTime();
       if (Math.abs(tDateMs - txDateMs) > PARTNER_DATE_WINDOW_DAYS * ONE_DAY_MS) return;
-      // Skip transactions already in a pair (confirmed or suggested).
-      if (confirmedTransferByTransactionId.has(t.transaction_id)) return;
-      if (suggestedPairByTransactionId.has(t.transaction_id)) return;
+      // Skip transactions already in any pair (confirmed or suggested).
+      if (transfers.getByTransactionId(t.transaction_id)) return;
       candidates.push(t);
     });
     candidates.sort((a, b) => {
@@ -298,14 +290,7 @@ export const TransactionProperties = ({ transaction }: Props) => {
       return Math.abs(aDateMs - txDateMs) - Math.abs(bDateMs - txDateMs);
     });
     return candidates;
-  }, [
-    data.transactions,
-    transaction_id,
-    txAmount,
-    txDateMs,
-    confirmedTransferByTransactionId,
-    suggestedPairByTransactionId,
-  ]);
+  }, [data.transactions, transaction_id, txAmount, txDateMs, transfers]);
 
   const onClickPartnerCandidate = async (partnerId: string) => {
     setPendingPartnerId(partnerId);

--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, ChangeEventHandler, MouseEventHandler, useMemo } f
 import { numberToCommaString, currencyCodeToSymbol, LocalDate } from "common";
 import {
   useAppContext,
+  useTransfers,
   call,
   PATH,
   Transaction,
@@ -22,7 +23,9 @@ interface Props {
 }
 
 const TransactionRow = ({ transaction }: Props) => {
-  const { data, calculations, setData, router, transfers } = useAppContext();
+  const { data, calculations, setData, router } = useAppContext();
+  const transferActions = useTransfers();
+  const { suggestedPairByTransactionId } = data;
   const { transactionFamilies } = calculations;
   const { id, transaction_id, amount, label } = transaction;
   const parentTransaction = data.transactions.get(transaction_id)!;
@@ -102,7 +105,7 @@ const TransactionRow = ({ transaction }: Props) => {
   // transactions, and a split inherits its parent's transaction_id.
   const suggestedPairId = isSplitTransaction
     ? undefined
-    : transfers.suggestedPairByTransactionId.get(transaction_id);
+    : suggestedPairByTransactionId.get(transaction_id);
 
   const onChangeBudgetSelect: ChangeEventHandler<HTMLSelectElement> = async (e) => {
     const { value } = e.target;
@@ -298,8 +301,8 @@ const TransactionRow = ({ transaction }: Props) => {
       <div className="budgetCategoryActions">
         {suggestedPairId ? (
           <TransferControls
-            onConfirm={() => transfers.confirm(suggestedPairId)}
-            onReject={() => transfers.reject(suggestedPairId)}
+            onConfirm={() => transferActions.confirm(suggestedPairId)}
+            onReject={() => transferActions.reject(suggestedPairId)}
           />
         ) : (
           <div className="labelControls">

--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -25,7 +25,7 @@ interface Props {
 const TransactionRow = ({ transaction }: Props) => {
   const { data, calculations, setData, router } = useAppContext();
   const transferActions = useTransfers();
-  const { suggestedPairByTransactionId } = data;
+  const { transfers } = data;
   const { transactionFamilies } = calculations;
   const { id, transaction_id, amount, label } = transaction;
   const parentTransaction = data.transactions.get(transaction_id)!;
@@ -105,7 +105,9 @@ const TransactionRow = ({ transaction }: Props) => {
   // transactions, and a split inherits its parent's transaction_id.
   const suggestedPairId = isSplitTransaction
     ? undefined
-    : suggestedPairByTransactionId.get(transaction_id);
+    : transfers.getByTransactionId(transaction_id)?.status === "suggested"
+      ? transfers.getByTransactionId(transaction_id)?.pair_id
+      : undefined;
 
   const onChangeBudgetSelect: ChangeEventHandler<HTMLSelectElement> = async (e) => {
     const { value } = e.target;

--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -103,11 +103,11 @@ const TransactionRow = ({ transaction }: Props) => {
   // shows Confirm/Reject instead of the budget/category controls (#354). Split
   // rows never carry the affordance — the detection engine pairs whole
   // transactions, and a split inherits its parent's transaction_id.
-  const suggestedPairId = isSplitTransaction
+  const pendingTransferPair = isSplitTransaction
     ? undefined
-    : transfers.getByTransactionId(transaction_id)?.status === "suggested"
-      ? transfers.getByTransactionId(transaction_id)?.pair_id
-      : undefined;
+    : transfers.getByTransactionId(transaction_id);
+  const suggestedPairId =
+    pendingTransferPair?.status === "suggested" ? pendingTransferPair.pair_id : undefined;
 
   const onChangeBudgetSelect: ChangeEventHandler<HTMLSelectElement> = async (e) => {
     const { value } = e.target;

--- a/src/client/components/TransactionsTable/index.tsx
+++ b/src/client/components/TransactionsTable/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export const TransactionsTable = ({ transactions }: Props) => {
   const { data } = useAppContext();
-  const { confirmedTransferByTransactionId } = data;
+  const { transfers } = data;
 
   // Confirmed transfer pairs render as a single bundled row. Walk the
   // list in order, emitting one `TransferRow` for each pair the first
@@ -25,9 +25,12 @@ export const TransactionsTable = ({ transactions }: Props) => {
       // Bundled-pair dedup applies to parent Transaction rows only —
       // SplitTransactions inherit their parent's transaction_id but
       // never participate in a transfer pair (the detection engine
-      // pairs whole transactions).
+      // pairs whole transactions). Only CONFIRMED pairs bundle into
+      // a TransferRow; suggested pairs still render as two
+      // individual TransactionRows with the Confirm/Reject controls.
       if (e instanceof Transaction) {
-        const pair = confirmedTransferByTransactionId.get(e.transaction_id);
+        const lookedUp = transfers.getByTransactionId(e.transaction_id);
+        const pair = lookedUp?.status === "confirmed" ? lookedUp : undefined;
         if (pair) {
           if (renderedPairIds.has(pair.pair_id)) return null;
           renderedPairIds.add(pair.pair_id);

--- a/src/client/components/TransactionsTable/index.tsx
+++ b/src/client/components/TransactionsTable/index.tsx
@@ -9,7 +9,8 @@ interface Props {
 }
 
 export const TransactionsTable = ({ transactions }: Props) => {
-  const { transfers } = useAppContext();
+  const { data } = useAppContext();
+  const { confirmedTransferByTransactionId } = data;
 
   // Confirmed transfer pairs render as a single bundled row. Walk the
   // list in order, emitting one `TransferRow` for each pair the first
@@ -26,7 +27,7 @@ export const TransactionsTable = ({ transactions }: Props) => {
       // never participate in a transfer pair (the detection engine
       // pairs whole transactions).
       if (e instanceof Transaction) {
-        const pair = transfers.confirmedTransferByTransactionId.get(e.transaction_id);
+        const pair = confirmedTransferByTransactionId.get(e.transaction_id);
         if (pair) {
           if (renderedPairIds.has(pair.pair_id)) return null;
           renderedPairIds.add(pair.pair_id);

--- a/src/client/components/TransferProperties/index.tsx
+++ b/src/client/components/TransferProperties/index.tsx
@@ -1,6 +1,6 @@
 import { currencyCodeToSymbol, LocalDate, numberToCommaString } from "common";
 import type { JSONTransaction } from "common";
-import { useAppContext, type ConfirmedTransfer } from "client";
+import { useAppContext, useTransfers, type ConfirmedTransfer } from "client";
 import { InstitutionSpan, TransferArrowIcon } from "client/components";
 import "./index.css";
 
@@ -21,7 +21,8 @@ interface Props {
  * the same as TransactionProperties / ConnectionProperties / etc.
  */
 export const TransferProperties = ({ transfer }: Props) => {
-  const { data, transfers } = useAppContext();
+  const { data } = useAppContext();
+  const transferActions = useTransfers();
   const { accounts } = data;
 
   // Sides are anchored to the SIGN of the amount, not the array index,
@@ -41,7 +42,7 @@ export const TransferProperties = ({ transfer }: Props) => {
   const date = outgoing.authorized_date || outgoing.date;
 
   const onClickUnpair = async () => {
-    await transfers.unpair(transfer.pair_id);
+    await transferActions.unpair(transfer.pair_id);
   };
 
   // Per-side block reusable for both halves of the pair. Each side's

--- a/src/client/components/TransferProperties/index.tsx
+++ b/src/client/components/TransferProperties/index.tsx
@@ -1,12 +1,13 @@
 import { currencyCodeToSymbol, LocalDate, numberToCommaString } from "common";
 import type { JSONTransaction } from "common";
-import { useAppContext, useTransfers, type ConfirmedTransfer } from "client";
+import type { TransferPair } from "server";
+import { useAppContext, useTransfers } from "client";
 import { InstitutionSpan, TransferArrowIcon } from "client/components";
 import "./index.css";
 
 interface Props {
   /** Both transactions in the confirmed pair, in server order. */
-  transfer: ConfirmedTransfer;
+  transfer: TransferPair;
 }
 
 /**

--- a/src/client/lib/hooks/calculation/budgets.test.ts
+++ b/src/client/lib/hooks/calculation/budgets.test.ts
@@ -301,3 +301,104 @@ describe("getCapacityData — hierarchy aggregation", () => {
     expect(cap.get(budgetCapId).children_total).toBe(-MAX_FLOAT);
   });
 });
+
+describe("getBudgetData — confirmed-transfer exclusion", () => {
+  test("transactions in confirmedTransferTxIds are skipped from all budget rollups", () => {
+    const w = makeWorld();
+
+    // Two confirmed-spending transactions, one of which is a transfer half.
+    const { transactions: t1 } = makeTx(w, 250, {
+      budget_id: w.budget.id,
+      category_id: w.category.id,
+      category_confidence: 1,
+    }, { transaction_id: "tx-spend" });
+    const { transactions: t2 } = makeTx(w, 5100, {
+      budget_id: w.budget.id,
+      category_id: w.category.id,
+      category_confidence: 1,
+    }, { transaction_id: "tx-transfer-half" });
+
+    const transactions = new TransactionDictionary();
+    t1.forEach((v, k) => transactions.set(k, v));
+    t2.forEach((v, k) => transactions.set(k, v));
+
+    // Without the set: both transactions count → category total = 5350.
+    const baseline = getBudgetData(
+      transactions,
+      empty.splits,
+      w.accounts,
+      w.budgets,
+      w.sections,
+      w.categories,
+    );
+    expect(baseline.budgetData.get(w.category.id, readDate).sorted_amount).toBe(5350);
+
+    // With tx-transfer-half flagged: only the $250 spend lands.
+    const withTransfer = getBudgetData(
+      transactions,
+      empty.splits,
+      w.accounts,
+      w.budgets,
+      w.sections,
+      w.categories,
+      new Set(["tx-transfer-half"]),
+    );
+    expect(withTransfer.budgetData.get(w.category.id, readDate).sorted_amount).toBe(250);
+    expect(withTransfer.budgetData.get(w.section.id, readDate).sorted_amount).toBe(250);
+    expect(withTransfer.budgetData.get(w.budget.id, readDate).sorted_amount).toBe(250);
+  });
+
+  test("an unsorted transaction in confirmedTransferTxIds is also skipped (unsorted bucket)", () => {
+    const w = makeWorld();
+    // Unsorted transaction — no category_id / confidence — would normally
+    // land in the unsorted bucket. As a transfer half it should not.
+    const { transactions } = makeTx(w, 5100, {
+      budget_id: w.budget.id,
+      category_id: null,
+      category_confidence: null,
+    }, { transaction_id: "tx-transfer-unsorted" });
+
+    const withTransfer = getBudgetData(
+      transactions,
+      empty.splits,
+      w.accounts,
+      w.budgets,
+      w.sections,
+      w.categories,
+      new Set(["tx-transfer-unsorted"]),
+    );
+    // Budget bucket exists only if any transaction landed in it. With the
+    // sole transaction filtered out, the budget id should not be tracked.
+    expect(withTransfer.budgetData.size).toBe(0);
+  });
+
+  test("an empty set behaves exactly like the no-arg call (backward compat)", () => {
+    const w = makeWorld();
+    const { transactions } = makeTx(w, 100, {
+      budget_id: w.budget.id,
+      category_id: w.category.id,
+      category_confidence: 1,
+    });
+
+    const noArg = getBudgetData(
+      transactions,
+      empty.splits,
+      w.accounts,
+      w.budgets,
+      w.sections,
+      w.categories,
+    );
+    const emptySet = getBudgetData(
+      transactions,
+      empty.splits,
+      w.accounts,
+      w.budgets,
+      w.sections,
+      w.categories,
+      new Set(),
+    );
+    expect(emptySet.budgetData.get(w.category.id, readDate).sorted_amount).toBe(
+      noArg.budgetData.get(w.category.id, readDate).sorted_amount,
+    );
+  });
+});

--- a/src/client/lib/hooks/calculation/budgets.test.ts
+++ b/src/client/lib/hooks/calculation/budgets.test.ts
@@ -78,6 +78,7 @@ const makeTx = (
 const empty = {
   transactions: new TransactionDictionary(),
   splits: new SplitTransactionDictionary(),
+  transfers: new TransferDictionary(),
 };
 
 describe("getBudgetData — confidence-gate bucketing", () => {
@@ -90,6 +91,7 @@ describe("getBudgetData — confidence-gate bucketing", () => {
       w.budgets,
       w.sections,
       w.categories,
+      empty.transfers,
     );
     expect(budgetData.size).toBe(0);
   });
@@ -109,6 +111,7 @@ describe("getBudgetData — confidence-gate bucketing", () => {
       w.budgets,
       w.sections,
       w.categories,
+      empty.transfers,
     );
     expect(budgetData.size).toBe(0);
   });
@@ -127,6 +130,7 @@ describe("getBudgetData — confidence-gate bucketing", () => {
       w.budgets,
       w.sections,
       w.categories,
+      empty.transfers,
     );
     expect(budgetData.get(w.category.id, readDate).sorted_amount).toBe(100);
     expect(budgetData.get(w.section.id, readDate).sorted_amount).toBe(100);
@@ -153,6 +157,7 @@ describe("getBudgetData — confidence-gate bucketing", () => {
       w.budgets,
       w.sections,
       w.categories,
+      empty.transfers,
     );
     expect(budgetData.get(w.budget.id, readDate).unsorted_amount).toBe(40);
     expect(budgetData.get(w.budget.id, readDate).number_of_unsorted_items).toBe(1);
@@ -173,6 +178,7 @@ describe("getBudgetData — confidence-gate bucketing", () => {
       w.budgets,
       w.sections,
       w.categories,
+      empty.transfers,
     );
     expect(budgetData.get(w.budget.id, readDate).unsorted_amount).toBe(25);
     expect(budgetData.get(w.category.id, readDate).sorted_amount).toBe(0);
@@ -192,6 +198,7 @@ describe("getBudgetData — confidence-gate bucketing", () => {
       w.budgets,
       w.sections,
       w.categories,
+      empty.transfers,
     );
     expect(budgetData.get(w.budget.id, readDate).unsorted_amount).toBe(10);
     expect(budgetData.get(w.budget.id, readDate).number_of_unsorted_items).toBe(1);
@@ -211,6 +218,7 @@ describe("getBudgetData — confidence-gate bucketing", () => {
       w.budgets,
       w.sections,
       w.categories,
+      empty.transfers,
     );
     expect(budgetData.get(w.budget.id, readDate).unsorted_amount).toBe(70);
   });
@@ -246,6 +254,7 @@ describe("getBudgetData — split transactions", () => {
       w.budgets,
       w.sections,
       w.categories,
+      empty.transfers,
     );
 
     // The parent contributes amount - childrenTotal = 100 - 30 = 70.
@@ -346,6 +355,7 @@ describe("getBudgetData — confirmed-transfer exclusion", () => {
       w.budgets,
       w.sections,
       w.categories,
+      empty.transfers,
     );
     expect(baseline.budgetData.get(w.category.id, readDate).sorted_amount).toBe(5350);
 
@@ -452,6 +462,7 @@ describe("getBudgetData — confirmed-transfer exclusion", () => {
       w.budgets,
       w.sections,
       w.categories,
+      empty.transfers,
     );
     const emptySet = getBudgetData(
       transactions,

--- a/src/client/lib/hooks/calculation/budgets.test.ts
+++ b/src/client/lib/hooks/calculation/budgets.test.ts
@@ -8,7 +8,23 @@ import {
   CategoryDictionary,
   TransactionDictionary,
   SplitTransactionDictionary,
+  TransferDictionary,
 } from "../../models/Data";
+import type { TransferPair } from "server";
+
+// Helper: build a TransferDictionary with the given transaction ids treated
+// as halves of a single CONFIRMED pair. Mirrors what `data.transfers`
+// holds after `fetchTransfers` populates it from `/api/transfers`.
+const makeConfirmedPair = (transaction_ids: string[]): TransferDictionary => {
+  const dict = new TransferDictionary();
+  const pair: TransferPair = {
+    pair_id: "test-pair",
+    status: "confirmed",
+    transactions: transaction_ids.map((id) => ({ transaction_id: id }) as never),
+  };
+  dict.set(pair.pair_id, pair);
+  return dict;
+};
 import { Account } from "../../models/Account";
 import { Budget } from "../../models/Budget";
 import { Section } from "../../models/Section";
@@ -303,7 +319,7 @@ describe("getCapacityData — hierarchy aggregation", () => {
 });
 
 describe("getBudgetData — confirmed-transfer exclusion", () => {
-  test("transactions in confirmedTransferTxIds are skipped from all budget rollups", () => {
+  test("transactions in a confirmed transfer pair are skipped from all budget rollups", () => {
     const w = makeWorld();
 
     // Two confirmed-spending transactions, one of which is a transfer half.
@@ -341,14 +357,14 @@ describe("getBudgetData — confirmed-transfer exclusion", () => {
       w.budgets,
       w.sections,
       w.categories,
-      new Set(["tx-transfer-half"]),
+      makeConfirmedPair(["tx-transfer-half", "tx-transfer-half-2"]),
     );
     expect(withTransfer.budgetData.get(w.category.id, readDate).sorted_amount).toBe(250);
     expect(withTransfer.budgetData.get(w.section.id, readDate).sorted_amount).toBe(250);
     expect(withTransfer.budgetData.get(w.budget.id, readDate).sorted_amount).toBe(250);
   });
 
-  test("an unsorted transaction in confirmedTransferTxIds is also skipped (unsorted bucket)", () => {
+  test("an unsorted transaction in a confirmed pair is also skipped (unsorted bucket)", () => {
     const w = makeWorld();
     // Unsorted transaction — no category_id / confidence — would normally
     // land in the unsorted bucket. As a transfer half it should not.
@@ -365,7 +381,7 @@ describe("getBudgetData — confirmed-transfer exclusion", () => {
       w.budgets,
       w.sections,
       w.categories,
-      new Set(["tx-transfer-unsorted"]),
+      makeConfirmedPair(["tx-transfer-unsorted", "tx-transfer-unsorted-2"]),
     );
     // Budget bucket exists only if any transaction landed in it. With the
     // sole transaction filtered out, the budget id should not be tracked.
@@ -415,13 +431,13 @@ describe("getBudgetData — confirmed-transfer exclusion", () => {
       w.budgets,
       w.sections,
       w.categories,
-      new Set(["tx-transfer-parent"]),
+      makeConfirmedPair(["tx-transfer-parent", "tx-transfer-parent-2"]),
     );
     // No data should land — parent skipped, both splits skipped.
     expect(withTransfer.budgetData.size).toBe(0);
   });
 
-  test("an empty set behaves exactly like the no-arg call (backward compat)", () => {
+  test("an empty TransferDictionary behaves exactly like the no-arg call (backward compat)", () => {
     const w = makeWorld();
     const { transactions } = makeTx(w, 100, {
       budget_id: w.budget.id,
@@ -444,7 +460,7 @@ describe("getBudgetData — confirmed-transfer exclusion", () => {
       w.budgets,
       w.sections,
       w.categories,
-      new Set(),
+      new TransferDictionary(),
     );
     expect(emptySet.budgetData.get(w.category.id, readDate).sorted_amount).toBe(
       noArg.budgetData.get(w.category.id, readDate).sorted_amount,

--- a/src/client/lib/hooks/calculation/budgets.test.ts
+++ b/src/client/lib/hooks/calculation/budgets.test.ts
@@ -372,6 +372,55 @@ describe("getBudgetData — confirmed-transfer exclusion", () => {
     expect(withTransfer.budgetData.size).toBe(0);
   });
 
+  test("splits of a confirmed-transfer parent are also skipped (reviewoie #528 round 1)", () => {
+    const w = makeWorld();
+
+    // Parent transaction is a transfer half (in the set).
+    const { transactions } = makeTx(w, 100, {
+      budget_id: w.budget.id,
+      category_id: w.category.id,
+      category_confidence: 1,
+    }, { transaction_id: "tx-transfer-parent" });
+
+    // Two splits of that parent — they inherit the parent's
+    // transaction_id reference but their own split_transaction_id. If
+    // the guard only checks the synthetic Transaction's id (which is
+    // overridden to split.id by `SplitTransaction.toTransaction()`),
+    // these will leak into Coffee's sorted_amount. The correct shape
+    // is to gate on parent's transaction_id at the split pass.
+    const splitA = new SplitTransaction({
+      split_transaction_id: "split-A",
+      transaction_id: "tx-transfer-parent",
+      account_id: w.account.id,
+      amount: 30,
+      date: DATE,
+      label: { budget_id: w.budget.id, category_id: w.category.id, category_confidence: 1 },
+    });
+    const splitB = new SplitTransaction({
+      split_transaction_id: "split-B",
+      transaction_id: "tx-transfer-parent",
+      account_id: w.account.id,
+      amount: 20,
+      date: DATE,
+      label: { budget_id: w.budget.id, category_id: w.category.id, category_confidence: 1 },
+    });
+    const splits = new SplitTransactionDictionary();
+    splits.set(splitA.id, splitA);
+    splits.set(splitB.id, splitB);
+
+    const withTransfer = getBudgetData(
+      transactions,
+      splits,
+      w.accounts,
+      w.budgets,
+      w.sections,
+      w.categories,
+      new Set(["tx-transfer-parent"]),
+    );
+    // No data should land — parent skipped, both splits skipped.
+    expect(withTransfer.budgetData.size).toBe(0);
+  });
+
   test("an empty set behaves exactly like the no-arg call (backward compat)", () => {
     const w = makeWorld();
     const { transactions } = makeTx(w, 100, {

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -3,9 +3,9 @@ import {
   TransactionFamilies,
   BudgetData,
   CapacityData,
-  ConfirmedTransfer,
   Transaction,
   TransactionDictionary,
+  TransferDictionary,
   SplitTransactionDictionary,
   SectionDictionary,
   CategoryDictionary,
@@ -25,32 +25,37 @@ export const getBudgetData = (
   budgets: BudgetDictionary,
   sections: SectionDictionary,
   categories: CategoryDictionary,
-  // transaction_id → confirmed-transfer pair. Halves of a confirmed
-  // pair are skipped entirely from budget aggregation because a
-  // transfer is internal movement between the user's own accounts,
-  // not real spending or income. The two halves would otherwise
-  // inflate both the spent column on the source-account budget and
-  // the income column on the destination's. Defaults to an empty Map
-  // so existing tests / callers without confirmed transfers keep the
-  // pre-PR behavior. Same shape lives at
-  // `data.confirmedTransferByTransactionId`; the App wires it through.
-  confirmedTransferByTransactionId: ReadonlyMap<string, ConfirmedTransfer> = new Map(),
+  // All transfer pairs (suggested + confirmed) for the user, keyed by
+  // pair_id with a transaction_id pivot. Halves of a CONFIRMED pair
+  // are skipped entirely from budget aggregation — a transfer is
+  // internal movement between the user's own accounts, not real
+  // spending or income. The two halves would otherwise inflate both
+  // the spent column on the source-account budget and the income
+  // column on the destination's. Suggested pairs still aggregate
+  // normally (they're heuristic proposals the user hasn't confirmed).
+  // Defaults to an empty dictionary so existing tests / callers
+  // without transfers keep pre-PR behavior. Same shape lives at
+  // `data.transfers`; the App wires it through.
+  transfers: TransferDictionary = new TransferDictionary(),
 ): GetBudgetDataResult => {
   const budgetData = new BudgetData();
 
   const transactionFamilies = new TransactionFamilies();
 
+  const isConfirmedTransferHalf = (transaction_id: string): boolean =>
+    transfers.getByTransactionId(transaction_id)?.status === "confirmed";
+
   splitTransactions.forEach((splitTransaction) => {
     const { transaction_id } = splitTransaction;
     const transaction = transactions.get(transaction_id);
     if (!transaction) return;
-    if (confirmedTransferByTransactionId.has(transaction_id)) return;
+    if (isConfirmedTransferHalf(transaction_id)) return;
     transactionFamilies.add(transaction_id, splitTransaction);
   });
 
   const processTransaction = (transaction: Transaction) => {
     const { transaction_id, authorized_date, date, account_id, label, amount } = transaction;
-    if (confirmedTransferByTransactionId.has(transaction_id)) return;
+    if (isConfirmedTransferHalf(transaction_id)) return;
     const transactionDate = new LocalDate(authorized_date || date);
     const account = accounts.get(account_id);
     if (!account || account.hide) return;
@@ -157,7 +162,7 @@ export const getBudgetData = (
     // split's own id per `SplitTransaction.toTransaction()` — so the
     // in-`processTransaction` guard on line ~51 would never fire for
     // splits even when their parent is a confirmed transfer).
-    if (confirmedTransferByTransactionId.has(st.transaction_id)) return;
+    if (isConfirmedTransferHalf(st.transaction_id)) return;
     const transaction = st.toTransaction();
     processTransaction(transaction);
   });

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -25,18 +25,17 @@ export const getBudgetData = (
   budgets: BudgetDictionary,
   sections: SectionDictionary,
   categories: CategoryDictionary,
-  // All transfer pairs (suggested + confirmed) for the user, keyed by
-  // pair_id with a transaction_id pivot. Halves of a CONFIRMED pair
-  // are skipped entirely from budget aggregation — a transfer is
-  // internal movement between the user's own accounts, not real
-  // spending or income. The two halves would otherwise inflate both
-  // the spent column on the source-account budget and the income
-  // column on the destination's. Suggested pairs still aggregate
-  // normally (they're heuristic proposals the user hasn't confirmed).
-  // Defaults to an empty dictionary so existing tests / callers
-  // without transfers keep pre-PR behavior. Same shape lives at
-  // `data.transfers`; the App wires it through.
-  transfers: TransferDictionary = new TransferDictionary(),
+  // All transfer pairs (suggested + confirmed), keyed by pair_id with
+  // a transaction_id pivot. Halves of a CONFIRMED pair are skipped
+  // entirely from budget aggregation — a transfer is internal
+  // movement between the user's own accounts, not real spending or
+  // income. The two halves would otherwise inflate both the spent
+  // column on the source-account budget and the income column on the
+  // destination's. Suggested pairs still aggregate normally —
+  // they're heuristic proposals the user hasn't confirmed. Required
+  // (no default): the caller threads `data.transfers` through, which
+  // is itself defaulted to an empty `TransferDictionary` on `Data`.
+  transfers: TransferDictionary,
 ): GetBudgetDataResult => {
   const budgetData = new BudgetData();
 

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -32,7 +32,7 @@ export const getBudgetData = (
   // Defaults to an empty set so existing callers (and tests) keep the
   // pre-PR behavior. See PR #490's TransferRow / TransferProperties
   // for the pair-detection side.
-  confirmedTransferTxIds: ReadonlySet<string> = new Set(),
+  confirmedTransferIds: { has(transaction_id: string): boolean } = new Set<string>(),
 ): GetBudgetDataResult => {
   const budgetData = new BudgetData();
 
@@ -42,13 +42,13 @@ export const getBudgetData = (
     const { transaction_id } = splitTransaction;
     const transaction = transactions.get(transaction_id);
     if (!transaction) return;
-    if (confirmedTransferTxIds.has(transaction_id)) return;
+    if (confirmedTransferIds.has(transaction_id)) return;
     transactionFamilies.add(transaction_id, splitTransaction);
   });
 
   const processTransaction = (transaction: Transaction) => {
     const { transaction_id, authorized_date, date, account_id, label, amount } = transaction;
-    if (confirmedTransferTxIds.has(transaction_id)) return;
+    if (confirmedTransferIds.has(transaction_id)) return;
     const transactionDate = new LocalDate(authorized_date || date);
     const account = accounts.get(account_id);
     if (!account || account.hide) return;
@@ -155,7 +155,7 @@ export const getBudgetData = (
     // split's own id per `SplitTransaction.toTransaction()` — so the
     // in-`processTransaction` guard on line ~51 would never fire for
     // splits even when their parent is a confirmed transfer).
-    if (confirmedTransferTxIds.has(st.transaction_id)) return;
+    if (confirmedTransferIds.has(st.transaction_id)) return;
     const transaction = st.toTransaction();
     processTransaction(transaction);
   });

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -24,6 +24,15 @@ export const getBudgetData = (
   budgets: BudgetDictionary,
   sections: SectionDictionary,
   categories: CategoryDictionary,
+  // Confirmed-transfer transaction ids — skipped entirely from budget
+  // aggregation because a transfer is internal movement between the
+  // user's own accounts, not real spending or income. The two halves
+  // of the pair would otherwise inflate both the spent column on the
+  // source-account budget and the income column on the destination's.
+  // Defaults to an empty set so existing callers (and tests) keep the
+  // pre-PR behavior. See PR #490's TransferRow / TransferProperties
+  // for the pair-detection side.
+  confirmedTransferTxIds: ReadonlySet<string> = new Set(),
 ): GetBudgetDataResult => {
   const budgetData = new BudgetData();
 
@@ -33,11 +42,13 @@ export const getBudgetData = (
     const { transaction_id } = splitTransaction;
     const transaction = transactions.get(transaction_id);
     if (!transaction) return;
+    if (confirmedTransferTxIds.has(transaction_id)) return;
     transactionFamilies.add(transaction_id, splitTransaction);
   });
 
   const processTransaction = (transaction: Transaction) => {
     const { transaction_id, authorized_date, date, account_id, label, amount } = transaction;
+    if (confirmedTransferTxIds.has(transaction_id)) return;
     const transactionDate = new LocalDate(authorized_date || date);
     const account = accounts.get(account_id);
     if (!account || account.hide) return;

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -150,6 +150,12 @@ export const getBudgetData = (
 
   transactions.forEach(processTransaction);
   splitTransactions.forEach((st) => {
+    // Guard at the SPLIT pass on the PARENT's transaction_id, not on
+    // the synthetic Transaction's `transaction_id` (which is the
+    // split's own id per `SplitTransaction.toTransaction()` — so the
+    // in-`processTransaction` guard on line ~51 would never fire for
+    // splits even when their parent is a confirmed transfer).
+    if (confirmedTransferTxIds.has(st.transaction_id)) return;
     const transaction = st.toTransaction();
     processTransaction(transaction);
   });

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -3,6 +3,7 @@ import {
   TransactionFamilies,
   BudgetData,
   CapacityData,
+  ConfirmedTransfer,
   Transaction,
   TransactionDictionary,
   SplitTransactionDictionary,
@@ -24,15 +25,16 @@ export const getBudgetData = (
   budgets: BudgetDictionary,
   sections: SectionDictionary,
   categories: CategoryDictionary,
-  // Confirmed-transfer transaction ids — skipped entirely from budget
-  // aggregation because a transfer is internal movement between the
-  // user's own accounts, not real spending or income. The two halves
-  // of the pair would otherwise inflate both the spent column on the
-  // source-account budget and the income column on the destination's.
-  // Defaults to an empty set so existing callers (and tests) keep the
-  // pre-PR behavior. See PR #490's TransferRow / TransferProperties
-  // for the pair-detection side.
-  confirmedTransferIds: { has(transaction_id: string): boolean } = new Set<string>(),
+  // transaction_id → confirmed-transfer pair. Halves of a confirmed
+  // pair are skipped entirely from budget aggregation because a
+  // transfer is internal movement between the user's own accounts,
+  // not real spending or income. The two halves would otherwise
+  // inflate both the spent column on the source-account budget and
+  // the income column on the destination's. Defaults to an empty Map
+  // so existing tests / callers without confirmed transfers keep the
+  // pre-PR behavior. Same shape lives at
+  // `data.confirmedTransferByTransactionId`; the App wires it through.
+  confirmedTransferByTransactionId: ReadonlyMap<string, ConfirmedTransfer> = new Map(),
 ): GetBudgetDataResult => {
   const budgetData = new BudgetData();
 
@@ -42,13 +44,13 @@ export const getBudgetData = (
     const { transaction_id } = splitTransaction;
     const transaction = transactions.get(transaction_id);
     if (!transaction) return;
-    if (confirmedTransferIds.has(transaction_id)) return;
+    if (confirmedTransferByTransactionId.has(transaction_id)) return;
     transactionFamilies.add(transaction_id, splitTransaction);
   });
 
   const processTransaction = (transaction: Transaction) => {
     const { transaction_id, authorized_date, date, account_id, label, amount } = transaction;
-    if (confirmedTransferIds.has(transaction_id)) return;
+    if (confirmedTransferByTransactionId.has(transaction_id)) return;
     const transactionDate = new LocalDate(authorized_date || date);
     const account = accounts.get(account_id);
     if (!account || account.hide) return;
@@ -155,7 +157,7 @@ export const getBudgetData = (
     // split's own id per `SplitTransaction.toTransaction()` — so the
     // in-`processTransaction` guard on line ~51 would never fire for
     // splits even when their parent is a confirmed transfer).
-    if (confirmedTransferIds.has(st.transaction_id)) return;
+    if (confirmedTransferByTransactionId.has(st.transaction_id)) return;
     const transaction = st.toTransaction();
     processTransaction(transaction);
   });

--- a/src/client/lib/hooks/context.ts
+++ b/src/client/lib/hooks/context.ts
@@ -9,7 +9,15 @@ export enum ScreenType {
   Wide,
 }
 
-type CalculateFn = ((data: Data) => void) & {
+export interface CalculateOptions {
+  /** Confirmed-transfer transaction ids — threaded into `getBudgetData`
+   *  so spent/income aggregation skips internal-movement transactions.
+   *  Balance calc intentionally ignores this (per-account historical
+   *  balance must still include transfers — Hoie 2026-06-18). */
+  confirmedTransferTxIds?: ReadonlySet<string>;
+}
+
+type CalculateFn = ((data: Data, opts?: CalculateOptions) => void) & {
   cache: {
     capacityData: (updater: (current: CapacityData) => CapacityData) => void;
   };

--- a/src/client/lib/hooks/context.ts
+++ b/src/client/lib/hooks/context.ts
@@ -1,7 +1,7 @@
 import { createContext, useContext, Dispatch, SetStateAction } from "react";
 import { MaskedUser } from "server";
 import { Interval, ViewDate } from "common";
-import { ClientRouter, Status, Data, Calculations, CapacityData, Transfers } from "client";
+import { ClientRouter, Status, Data, Calculations, CapacityData } from "client";
 
 export enum ScreenType {
   Narrow,
@@ -9,17 +9,7 @@ export enum ScreenType {
   Wide,
 }
 
-export interface CalculateOptions {
-  /** Membership-test for confirmed-transfer transaction ids — threaded
-   *  into `getBudgetData` so spent/income aggregation skips
-   *  internal-movement transactions. Typed structurally on `has` so a
-   *  Set<id> OR a Map keyed by id both satisfy it. Balance calc
-   *  intentionally ignores this (per-account historical balance must
-   *  still include transfers — Hoie 2026-06-18). */
-  confirmedTransferIds?: { has(transaction_id: string): boolean };
-}
-
-type CalculateFn = ((data: Data, opts?: CalculateOptions) => void) & {
+type CalculateFn = ((data: Data) => void) & {
   cache: {
     capacityData: (updater: (current: CapacityData) => CapacityData) => void;
   };
@@ -39,7 +29,6 @@ export interface ContextType {
   viewDate: ViewDate;
   setViewDate: Dispatch<SetStateAction<ViewDate>>;
   screenType: ScreenType;
-  transfers: Transfers;
 }
 
 export const Context = createContext<ContextType>({} as ContextType);

--- a/src/client/lib/hooks/context.ts
+++ b/src/client/lib/hooks/context.ts
@@ -10,11 +10,13 @@ export enum ScreenType {
 }
 
 export interface CalculateOptions {
-  /** Confirmed-transfer transaction ids — threaded into `getBudgetData`
-   *  so spent/income aggregation skips internal-movement transactions.
-   *  Balance calc intentionally ignores this (per-account historical
-   *  balance must still include transfers — Hoie 2026-06-18). */
-  confirmedTransferTxIds?: ReadonlySet<string>;
+  /** Membership-test for confirmed-transfer transaction ids — threaded
+   *  into `getBudgetData` so spent/income aggregation skips
+   *  internal-movement transactions. Typed structurally on `has` so a
+   *  Set<id> OR a Map keyed by id both satisfy it. Balance calc
+   *  intentionally ignores this (per-account historical balance must
+   *  still include transfers — Hoie 2026-06-18). */
+  confirmedTransferIds?: { has(transaction_id: string): boolean };
 }
 
 type CalculateFn = ((data: Data, opts?: CalculateOptions) => void) & {

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -938,11 +938,27 @@ export const useSync = () => {
         (stage3Transactions?.networkFailed ?? false) ||
         (stage3Snapshots?.networkFailed ?? false);
 
+      console.log("[debug coldPath] coldFetchFailed=", coldFetchFailed,
+        "stage1Budgets=", stage1Budgets.networkFailed,
+        "stage1Transfers=", stage1Transfers.networkFailed,
+        "stage2Transactions=", stage2Transactions.networkFailed,
+        "stage2SplitTxns=", stage2SplitTxns.networkFailed,
+        "stage2Snapshots=", stage2Snapshots.networkFailed,
+        "stage3Transactions=", stage3Transactions?.networkFailed,
+        "stage3Snapshots=", stage3Snapshots?.networkFailed,
+        "finalData.transfers.size=", finalData.transfers.size,
+        "finalData.transactions.size=", finalData.transactions.size,
+      );
+
       if (!coldFetchFailed) {
         indexedDb
           .clearAllData()
-          .then(() => indexedDb.saveAllData(finalData))
-          .catch(console.error);
+          .then(() => {
+            console.log("[debug coldPath] cleared, calling saveAllData");
+            return indexedDb.saveAllData(finalData);
+          })
+          .then(() => console.log("[debug coldPath] saveAllData resolved"))
+          .catch((e) => console.error("[debug coldPath] save chain error:", e));
         writeLastSyncedAt(new Date());
       }
     } catch (err) {

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -18,6 +18,7 @@ import {
   ChartsGetResponse,
   SnapshotsGetResponse,
   SecuritiesGetResponse,
+  TransfersGetResponse,
 } from "server";
 import {
   Account,
@@ -57,6 +58,7 @@ import {
   Holding,
   SecurityDictionary,
   Security,
+  ConfirmedTransfer,
 } from "client";
 
 // Browsers cap concurrent fetches per origin (~6 on HTTP/1.1) and queueing
@@ -344,6 +346,52 @@ const fetchBudgets = async (): Promise<FetchBudgetsResult> => {
   budgets.forEach((e) => result.budgets.set(e.budget_id, new Budget(e)));
   sections.forEach((e) => result.sections.set(e.section_id, new Section(e)));
   categories.forEach((e) => result.categories.set(e.category_id, new Category(e)));
+
+  return result;
+};
+
+interface FetchTransfersResult {
+  suggestedPairByTransactionId: Map<string, string>;
+  confirmedTransferByTransactionId: Map<string, ConfirmedTransfer>;
+  networkFailed: boolean;
+}
+
+/**
+ * Lightweight fetch of all transfer pairs for the user. Lives in
+ * useSync alongside the other model fetches so a cold/warm load
+ * paints with pair state already in place — consumers read the maps
+ * from `data.*`, the calc layer reads them positionally, and mutation
+ * methods (in `useTransfers`) update `data` in-place via `setData`
+ * rather than re-fetching. No IndexedDB caching: pair lists are small
+ * and the maps are pure-derived from the response, so a cold-load
+ * refetch is cheap.
+ */
+const fetchTransfers = async (): Promise<FetchTransfersResult> => {
+  const result: FetchTransfersResult = {
+    suggestedPairByTransactionId: new Map(),
+    confirmedTransferByTransactionId: new Map(),
+    networkFailed: false,
+  };
+
+  const response = await call.get<TransfersGetResponse>("/api/transfers").catch(console.error);
+  if (!response || response.status === "error") {
+    result.networkFailed = true;
+    return result;
+  }
+  if (!response.body) return result;
+
+  for (const pair of response.body) {
+    if (pair.status === "suggested") {
+      for (const tx of pair.transactions) {
+        result.suggestedPairByTransactionId.set(tx.transaction_id, pair.pair_id);
+      }
+    } else if (pair.status === "confirmed") {
+      const entry: ConfirmedTransfer = { pair_id: pair.pair_id, transactions: pair.transactions };
+      for (const tx of pair.transactions) {
+        result.confirmedTransferByTransactionId.set(tx.transaction_id, entry);
+      }
+    }
+  }
 
   return result;
 };
@@ -646,6 +694,7 @@ export const useSync = () => {
           snapshotsResult,
           institutionsResult,
           securitiesResult,
+          transfersResult,
         ] = await Promise.all([
           fetchBudgets(),
           fetchCharts(),
@@ -654,6 +703,7 @@ export const useSync = () => {
           fetchSnapshots(accounts, fullRange, recentSinceMs),
           fetchInstitutions(accounts),
           fetchSecurities(),
+          fetchTransfers(),
         ]);
 
         const refreshed = new Data();
@@ -672,6 +722,8 @@ export const useSync = () => {
         refreshed.accountSnapshots = snapshotsResult.accountSnapshots;
         refreshed.holdingSnapshots = snapshotsResult.holdingSnapshots;
         refreshed.securitySnapshots = snapshotsResult.securitySnapshots;
+        refreshed.suggestedPairByTransactionId = transfersResult.suggestedPairByTransactionId;
+        refreshed.confirmedTransferByTransactionId = transfersResult.confirmedTransferByTransactionId;
         refreshed.status.isInit = true;
         refreshed.status.isLoading = false;
         refreshed.status.isError = false;
@@ -691,7 +743,8 @@ export const useSync = () => {
           transactionsResult.networkFailed ||
           snapshotsResult.networkFailed ||
           institutionsResult.networkFailed ||
-          securitiesResult.networkFailed;
+          securitiesResult.networkFailed ||
+          transfersResult.networkFailed;
 
         if (!warmFetchFailed) {
           indexedDb
@@ -732,6 +785,7 @@ export const useSync = () => {
       const chartsPromise = fetchCharts();
       const institutionsPromise = accountsPromise.then((r) => fetchInstitutions(r.accounts));
       const securitiesPromise = fetchSecurities();
+      const transfersPromise = fetchTransfers();
 
       const [
         { accounts, items },
@@ -739,17 +793,23 @@ export const useSync = () => {
         stage1Charts,
         stage1Institutions,
         stage1Securities,
+        stage1Transfers,
       ] = await Promise.all([
         accountsPromise,
         budgetsPromise,
         chartsPromise,
         institutionsPromise,
         securitiesPromise,
+        transfersPromise,
       ]);
       const { budgets, sections, categories } = stage1Budgets;
       const { charts } = stage1Charts;
       const { institutions } = stage1Institutions;
       const { securities } = stage1Securities;
+      const {
+        suggestedPairByTransactionId,
+        confirmedTransferByTransactionId,
+      } = stage1Transfers;
 
       const stage1 = new Data({
         accounts,
@@ -760,6 +820,8 @@ export const useSync = () => {
         charts,
         institutions,
         securities,
+        suggestedPairByTransactionId,
+        confirmedTransferByTransactionId,
       });
       stage1.status.isInit = true;
       stage1.status.isLoading = true;
@@ -804,6 +866,8 @@ export const useSync = () => {
         charts,
         institutions,
         securities,
+        suggestedPairByTransactionId,
+        confirmedTransferByTransactionId,
         transactions: recentTransactions,
         investmentTransactions: recentInvestmentTransactions,
         splitTransactions,
@@ -839,6 +903,8 @@ export const useSync = () => {
         charts,
         institutions,
         securities,
+        suggestedPairByTransactionId,
+        confirmedTransferByTransactionId,
         transactions: recentTransactions,
         investmentTransactions: recentInvestmentTransactions,
         splitTransactions,
@@ -882,6 +948,7 @@ export const useSync = () => {
         stage1Charts.networkFailed ||
         stage1Institutions.networkFailed ||
         stage1Securities.networkFailed ||
+        stage1Transfers.networkFailed ||
         stage2Transactions.networkFailed ||
         stage2SplitTxns.networkFailed ||
         stage2Snapshots.networkFailed ||

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -382,6 +382,7 @@ const fetchTransfers = async (): Promise<FetchTransfersResult> => {
     result.transfers.set(pair.pair_id, pair);
   }
 
+  console.log("[debug fetchTransfers] populated transfers, size=", result.transfers.size);
   return result;
 };
 

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -58,7 +58,7 @@ import {
   Holding,
   SecurityDictionary,
   Security,
-  ConfirmedTransfer,
+  TransferDictionary,
 } from "client";
 
 // Browsers cap concurrent fetches per origin (~6 on HTTP/1.1) and queueing
@@ -351,25 +351,23 @@ const fetchBudgets = async (): Promise<FetchBudgetsResult> => {
 };
 
 interface FetchTransfersResult {
-  suggestedPairByTransactionId: Map<string, string>;
-  confirmedTransferByTransactionId: Map<string, ConfirmedTransfer>;
+  transfers: TransferDictionary;
   networkFailed: boolean;
 }
 
 /**
  * Lightweight fetch of all transfer pairs for the user. Lives in
  * useSync alongside the other model fetches so a cold/warm load
- * paints with pair state already in place — consumers read the maps
- * from `data.*`, the calc layer reads them positionally, and mutation
- * methods (in `useTransfers`) update `data` in-place via `setData`
- * rather than re-fetching. No IndexedDB caching: pair lists are small
- * and the maps are pure-derived from the response, so a cold-load
- * refetch is cheap.
+ * paints with pair state already in place. Returns a single
+ * TransferDictionary (pair_id → TransferPair) — consumers resolve
+ * transaction_id lookups via `transfers.getByTransactionId(id)` which
+ * is O(1) over the dictionary's internal pivot map. Mutation methods
+ * in `useTransfers` update `data.transfers` in-place via `setData`
+ * (no re-fetch on mutation).
  */
 const fetchTransfers = async (): Promise<FetchTransfersResult> => {
   const result: FetchTransfersResult = {
-    suggestedPairByTransactionId: new Map(),
-    confirmedTransferByTransactionId: new Map(),
+    transfers: new TransferDictionary(),
     networkFailed: false,
   };
 
@@ -381,16 +379,7 @@ const fetchTransfers = async (): Promise<FetchTransfersResult> => {
   if (!response.body) return result;
 
   for (const pair of response.body) {
-    if (pair.status === "suggested") {
-      for (const tx of pair.transactions) {
-        result.suggestedPairByTransactionId.set(tx.transaction_id, pair.pair_id);
-      }
-    } else if (pair.status === "confirmed") {
-      const entry: ConfirmedTransfer = { pair_id: pair.pair_id, transactions: pair.transactions };
-      for (const tx of pair.transactions) {
-        result.confirmedTransferByTransactionId.set(tx.transaction_id, entry);
-      }
-    }
+    result.transfers.set(pair.pair_id, pair);
   }
 
   return result;
@@ -722,8 +711,7 @@ export const useSync = () => {
         refreshed.accountSnapshots = snapshotsResult.accountSnapshots;
         refreshed.holdingSnapshots = snapshotsResult.holdingSnapshots;
         refreshed.securitySnapshots = snapshotsResult.securitySnapshots;
-        refreshed.suggestedPairByTransactionId = transfersResult.suggestedPairByTransactionId;
-        refreshed.confirmedTransferByTransactionId = transfersResult.confirmedTransferByTransactionId;
+        refreshed.transfers = transfersResult.transfers;
         refreshed.status.isInit = true;
         refreshed.status.isLoading = false;
         refreshed.status.isError = false;
@@ -806,10 +794,7 @@ export const useSync = () => {
       const { charts } = stage1Charts;
       const { institutions } = stage1Institutions;
       const { securities } = stage1Securities;
-      const {
-        suggestedPairByTransactionId,
-        confirmedTransferByTransactionId,
-      } = stage1Transfers;
+      const { transfers } = stage1Transfers;
 
       const stage1 = new Data({
         accounts,
@@ -820,8 +805,7 @@ export const useSync = () => {
         charts,
         institutions,
         securities,
-        suggestedPairByTransactionId,
-        confirmedTransferByTransactionId,
+        transfers,
       });
       stage1.status.isInit = true;
       stage1.status.isLoading = true;
@@ -866,8 +850,7 @@ export const useSync = () => {
         charts,
         institutions,
         securities,
-        suggestedPairByTransactionId,
-        confirmedTransferByTransactionId,
+        transfers,
         transactions: recentTransactions,
         investmentTransactions: recentInvestmentTransactions,
         splitTransactions,
@@ -903,8 +886,7 @@ export const useSync = () => {
         charts,
         institutions,
         securities,
-        suggestedPairByTransactionId,
-        confirmedTransferByTransactionId,
+        transfers,
         transactions: recentTransactions,
         investmentTransactions: recentInvestmentTransactions,
         splitTransactions,

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -382,7 +382,6 @@ const fetchTransfers = async (): Promise<FetchTransfersResult> => {
     result.transfers.set(pair.pair_id, pair);
   }
 
-  console.log("[debug fetchTransfers] populated transfers, size=", result.transfers.size);
   return result;
 };
 
@@ -938,27 +937,11 @@ export const useSync = () => {
         (stage3Transactions?.networkFailed ?? false) ||
         (stage3Snapshots?.networkFailed ?? false);
 
-      console.log("[debug coldPath] coldFetchFailed=", coldFetchFailed,
-        "stage1Budgets=", stage1Budgets.networkFailed,
-        "stage1Transfers=", stage1Transfers.networkFailed,
-        "stage2Transactions=", stage2Transactions.networkFailed,
-        "stage2SplitTxns=", stage2SplitTxns.networkFailed,
-        "stage2Snapshots=", stage2Snapshots.networkFailed,
-        "stage3Transactions=", stage3Transactions?.networkFailed,
-        "stage3Snapshots=", stage3Snapshots?.networkFailed,
-        "finalData.transfers.size=", finalData.transfers.size,
-        "finalData.transactions.size=", finalData.transactions.size,
-      );
-
       if (!coldFetchFailed) {
         indexedDb
           .clearAllData()
-          .then(() => {
-            console.log("[debug coldPath] cleared, calling saveAllData");
-            return indexedDb.saveAllData(finalData);
-          })
-          .then(() => console.log("[debug coldPath] saveAllData resolved"))
-          .catch((e) => console.error("[debug coldPath] save chain error:", e));
+          .then(() => indexedDb.saveAllData(finalData))
+          .catch(console.error);
         writeLastSyncedAt(new Date());
       }
     } catch (err) {

--- a/src/client/lib/hooks/transfers.ts
+++ b/src/client/lib/hooks/transfers.ts
@@ -1,17 +1,9 @@
 import { useCallback } from "react";
-import { JSONTransaction } from "common";
-import { call, Data, useAppContext } from "client";
-
-export interface ConfirmedTransfer {
-  pair_id: string;
-  /** Both transactions in the confirmed pair, in the order the server
-   *  returned them (the bundled row renders pair[0] as the "from"
-   *  side, pair[1] as the "to" side). */
-  transactions: JSONTransaction[];
-}
+import type { TransferPair } from "server";
+import { call, Data, TransferDictionary, useAppContext } from "client";
 
 export interface TransferActions {
-  /** Confirm a suggested pair: status becomes "confirmed". */
+  /** Confirm a suggested pair: status flips to "confirmed". */
   confirm: (pair_id: string) => Promise<void>;
   /** Reject a suggested pair: soft-deletes it so the row reverts. */
   reject: (pair_id: string) => Promise<void>;
@@ -28,30 +20,12 @@ export interface TransferActions {
 }
 
 /**
- * Find both transaction_ids that map to a given pair_id in one of the
- * pair maps. Used by mutation methods to update FE state in-place
- * without re-fetching.
- */
-const findPairTxIds = (
-  map: Map<string, unknown>,
-  pair_id: string,
-  matches: (entry: unknown) => boolean,
-): string[] => {
-  const txIds: string[] = [];
-  map.forEach((entry, txId) => {
-    if (matches(entry)) txIds.push(txId);
-    // Stop walking once both halves found — every pair has exactly 2 sides.
-  });
-  return txIds;
-};
-
-/**
  * Transfer-pair actions hook (#354, Phase 3a). Stateless: the pair
- * maps themselves live on `data.suggestedPairByTransactionId` and
- * `data.confirmedTransferByTransactionId`, fetched once by `useSync`
- * alongside transactions / budgets / etc. Mutation methods POST to
- * the server then update `data` in-place via `setData` — no
- * re-fetch, matching the rest of the app's mutation pattern.
+ * dictionary itself lives on `data.transfers`, fetched once by
+ * `useSync` alongside transactions / budgets / etc. Mutation methods
+ * POST to the server then update `data.transfers` in-place via
+ * `setData` — no re-fetch, matching the rest of the app's mutation
+ * pattern.
  */
 export const useTransfers = (): TransferActions => {
   const { setData } = useAppContext();
@@ -61,28 +35,11 @@ export const useTransfers = (): TransferActions => {
       const response = await call.post("/api/transfers/pair", { pair_id });
       if (response.status !== "success") return;
       setData((oldData) => {
-        const txIds = findPairTxIds(
-          oldData.suggestedPairByTransactionId,
-          pair_id,
-          (entry) => entry === pair_id,
-        );
-        // Both halves of the pair are needed to build the ConfirmedTransfer
-        // entry. If only one is in `data.transactions` (rare — partial
-        // sync), the second half goes in as a stub so the maps stay
-        // consistent; the bundled-row renderer will skip the stub side.
-        const transactions: JSONTransaction[] = txIds
-          .map((id) => oldData.transactions.get(id))
-          .filter((t): t is NonNullable<typeof t> => !!t);
-        if (transactions.length < 2) return oldData;
-
-        const entry: ConfirmedTransfer = { pair_id, transactions };
+        const prev = oldData.transfers.get(pair_id);
+        if (!prev) return oldData;
         const newData = new Data(oldData);
-        newData.suggestedPairByTransactionId = new Map(oldData.suggestedPairByTransactionId);
-        newData.confirmedTransferByTransactionId = new Map(oldData.confirmedTransferByTransactionId);
-        for (const id of txIds) {
-          newData.suggestedPairByTransactionId.delete(id);
-          newData.confirmedTransferByTransactionId.set(id, entry);
-        }
+        newData.transfers = new TransferDictionary(oldData.transfers);
+        newData.transfers.set(pair_id, { ...prev, status: "confirmed" });
         return newData;
       });
     },
@@ -94,24 +51,10 @@ export const useTransfers = (): TransferActions => {
       const response = await call.delete(`/api/transfers?id=${encodeURIComponent(pair_id)}`);
       if (response.status !== "success") return;
       setData((oldData) => {
+        if (!oldData.transfers.has(pair_id)) return oldData;
         const newData = new Data(oldData);
-        newData.suggestedPairByTransactionId = new Map(oldData.suggestedPairByTransactionId);
-        newData.confirmedTransferByTransactionId = new Map(oldData.confirmedTransferByTransactionId);
-        // Strip both halves from whichever map they're in. Reject is
-        // semantically used on suggested pairs; unpair (same delete
-        // route) is used on confirmed pairs — both paths land here.
-        const suggestedTxIds = findPairTxIds(
-          newData.suggestedPairByTransactionId,
-          pair_id,
-          (entry) => entry === pair_id,
-        );
-        suggestedTxIds.forEach((id) => newData.suggestedPairByTransactionId.delete(id));
-        const confirmedTxIds = findPairTxIds(
-          newData.confirmedTransferByTransactionId,
-          pair_id,
-          (entry) => (entry as ConfirmedTransfer).pair_id === pair_id,
-        );
-        confirmedTxIds.forEach((id) => newData.confirmedTransferByTransactionId.delete(id));
+        newData.transfers = new TransferDictionary(oldData.transfers);
+        newData.transfers.delete(pair_id);
         return newData;
       });
     },
@@ -131,11 +74,14 @@ export const useTransfers = (): TransferActions => {
         const a = oldData.transactions.get(transaction_id_a);
         const b = oldData.transactions.get(transaction_id_b);
         if (!a || !b) return oldData;
-        const entry: ConfirmedTransfer = { pair_id, transactions: [a, b] };
+        const newPair: TransferPair = {
+          pair_id,
+          status: "confirmed",
+          transactions: [a, b],
+        };
         const newData = new Data(oldData);
-        newData.confirmedTransferByTransactionId = new Map(oldData.confirmedTransferByTransactionId);
-        newData.confirmedTransferByTransactionId.set(transaction_id_a, entry);
-        newData.confirmedTransferByTransactionId.set(transaction_id_b, entry);
+        newData.transfers = new TransferDictionary(oldData.transfers);
+        newData.transfers.set(pair_id, newPair);
         return newData;
       });
     },

--- a/src/client/lib/hooks/transfers.ts
+++ b/src/client/lib/hooks/transfers.ts
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback } from "react";
 import { JSONTransaction } from "common";
-import { MaskedUser, TransferPair, TransfersGetResponse } from "server";
-import { call } from "client";
+import { TransferPair, TransfersGetResponse } from "server";
+import { call, Data, useAppContext } from "client";
 
 export interface ConfirmedTransfer {
   pair_id: string;
@@ -11,22 +11,12 @@ export interface ConfirmedTransfer {
   transactions: JSONTransaction[];
 }
 
-export interface Transfers {
-  /**
-   * transaction_id → pair_id for pairs still awaiting confirmation. A
-   * transaction is present here only while its pair status is "suggested";
-   * once confirmed it moves to `confirmedTransferByTransactionId`.
-   */
-  suggestedPairByTransactionId: Map<string, string>;
-  /**
-   * transaction_id → bundled confirmed-pair info. Used by
-   * `TransactionsTable` to render the two paired transactions as a
-   * single row (deduped on second sighting) and by
-   * `TransactionProperties` to display the transfer chip + the
-   * "mark as non-transfer" affordance. Both transactions in a
-   * confirmed pair point at the SAME ConfirmedTransfer object.
-   */
-  confirmedTransferByTransactionId: Map<string, ConfirmedTransfer>;
+export interface TransferActions {
+  /** Re-fetch /api/transfers and write the derived maps into
+   *  `data.suggestedPairByTransactionId` /
+   *  `data.confirmedTransferByTransactionId`. Called on login (from
+   *  `Utility`) and after every successful mutation below. */
+  refresh: () => Promise<void>;
   /** Confirm a suggested pair: status becomes "confirmed". */
   confirm: (pair_id: string) => Promise<void>;
   /** Reject a suggested pair: soft-deletes it so the row reverts. */
@@ -34,64 +24,67 @@ export interface Transfers {
   /** Unpair a confirmed pair (same delete path as reject, just
    *  semantically named for the "mark as non-transfer" affordance). */
   unpair: (pair_id: string) => Promise<void>;
-  /** Manually pair two transactions as a confirmed transfer. Used by the
-   *  "Mark as Transfer" affordance on a transaction's detail page for
-   *  cases where (a) the user accidentally unpaired and wants to undo
-   *  later, or (b) the detect-transfers heuristic missed the pair. Lands
-   *  directly as `status="confirmed"` — manual pairing is user intent,
-   *  not a suggestion. */
+  /** Manually pair two transactions as a confirmed transfer. Used by
+   *  the "Mark as Transfer" affordance for cases where (a) the user
+   *  accidentally unpaired and wants to undo later, or (b) the
+   *  detect-transfers heuristic missed the pair. Lands directly as
+   *  `status="confirmed"` — manual pairing is user intent, not a
+   *  suggestion. */
   pair: (transaction_id_a: string, transaction_id_b: string) => Promise<void>;
 }
 
-/**
- * Transfer-pair state for the transactions UI (#354, Phase 3a). Kept separate
- * from the heavyweight cold/warm IndexedDB sync because pairs are a small,
- * cheap list refetched on demand after each confirm/reject rather than cached
- * per-month like transactions.
- */
-export const useTransfers = (user: MaskedUser | undefined): Transfers => {
-  const [pairs, setPairs] = useState<TransferPair[]>([]);
-
-  const refresh = useCallback(async () => {
-    const response = await call.get<TransfersGetResponse>("/api/transfers");
-    if (response.status === "success" && response.body) {
-      setPairs(response.body);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!user) {
-      setPairs([]);
-      return;
-    }
-    refresh();
-  }, [user, refresh]);
-
-  const suggestedPairByTransactionId = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const pair of pairs) {
-      if (pair.status !== "suggested") continue;
+const buildMaps = (
+  pairs: TransferPair[],
+): {
+  suggested: Map<string, string>;
+  confirmed: Map<string, ConfirmedTransfer>;
+} => {
+  const suggested = new Map<string, string>();
+  const confirmed = new Map<string, ConfirmedTransfer>();
+  for (const pair of pairs) {
+    if (pair.status === "suggested") {
       for (const transaction of pair.transactions) {
-        map.set(transaction.transaction_id, pair.pair_id);
+        suggested.set(transaction.transaction_id, pair.pair_id);
       }
-    }
-    return map;
-  }, [pairs]);
-
-  const confirmedTransferByTransactionId = useMemo(() => {
-    const map = new Map<string, ConfirmedTransfer>();
-    for (const pair of pairs) {
-      if (pair.status !== "confirmed") continue;
+    } else if (pair.status === "confirmed") {
       const entry: ConfirmedTransfer = {
         pair_id: pair.pair_id,
         transactions: pair.transactions,
       };
       for (const transaction of pair.transactions) {
-        map.set(transaction.transaction_id, entry);
+        confirmed.set(transaction.transaction_id, entry);
       }
     }
-    return map;
-  }, [pairs]);
+  }
+  return { suggested, confirmed };
+};
+
+/**
+ * Transfer-pair actions hook (#354, Phase 3a). Stateless: the maps
+ * themselves live on `data.suggestedPairByTransactionId` and
+ * `data.confirmedTransferByTransactionId` — this hook just provides
+ * memoized callbacks that fetch `/api/transfers` and write the
+ * derived maps back via `setData`. Safe to call from any component;
+ * each call returns fresh memoized callbacks but no internal state.
+ *
+ * Kept separate from the heavyweight cold/warm IndexedDB sync because
+ * pairs are a small, cheap list refetched on demand after each
+ * mutation rather than cached per-month like transactions.
+ */
+export const useTransfers = (): TransferActions => {
+  const { setData } = useAppContext();
+
+  const refresh = useCallback(async () => {
+    const response = await call.get<TransfersGetResponse>("/api/transfers");
+    if (response.status !== "success" || !response.body) return;
+    const { suggested, confirmed } = buildMaps(response.body);
+    setData((oldData) => {
+      const newData = new Data(oldData);
+      newData.suggestedPairByTransactionId = suggested;
+      newData.confirmedTransferByTransactionId = confirmed;
+      return newData;
+    });
+  }, [setData]);
 
   const confirm = useCallback(
     async (pair_id: string) => {
@@ -121,12 +114,5 @@ export const useTransfers = (user: MaskedUser | undefined): Transfers => {
     [refresh],
   );
 
-  return {
-    suggestedPairByTransactionId,
-    confirmedTransferByTransactionId,
-    confirm,
-    reject,
-    unpair: reject,
-    pair,
-  };
+  return { refresh, confirm, reject, unpair: reject, pair };
 };

--- a/src/client/lib/hooks/transfers.ts
+++ b/src/client/lib/hooks/transfers.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import type { TransferPair } from "server";
-import { call, Data, TransferDictionary, useAppContext } from "client";
+import { call, Data, TransferDictionary, indexedDb, StoreName, useAppContext } from "client";
 
 export interface TransferActions {
   /** Confirm a suggested pair: status flips to "confirmed". */
@@ -37,9 +37,15 @@ export const useTransfers = (): TransferActions => {
       setData((oldData) => {
         const prev = oldData.transfers.get(pair_id);
         if (!prev) return oldData;
+        const updatedPair: TransferPair = { ...prev, status: "confirmed" };
+        // IDB mirror: keep the cached pair in sync with React state so
+        // the next warm boot paints with status="confirmed" instead of
+        // the stale "suggested" from the prior cold sync. Fire-and-forget
+        // — never await an IDB write on the latency path.
+        indexedDb.saveTransfer(updatedPair).catch(console.error);
         const newData = new Data(oldData);
         newData.transfers = new TransferDictionary(oldData.transfers);
-        newData.transfers.set(pair_id, { ...prev, status: "confirmed" });
+        newData.transfers.set(pair_id, updatedPair);
         return newData;
       });
     },
@@ -50,6 +56,7 @@ export const useTransfers = (): TransferActions => {
     async (pair_id: string) => {
       const response = await call.delete(`/api/transfers?id=${encodeURIComponent(pair_id)}`);
       if (response.status !== "success") return;
+      indexedDb.remove(StoreName.transfers, pair_id).catch(console.error);
       setData((oldData) => {
         if (!oldData.transfers.has(pair_id)) return oldData;
         const newData = new Data(oldData);
@@ -79,6 +86,7 @@ export const useTransfers = (): TransferActions => {
           status: "confirmed",
           transactions: [a, b],
         };
+        indexedDb.saveTransfer(newPair).catch(console.error);
         const newData = new Data(oldData);
         newData.transfers = new TransferDictionary(oldData.transfers);
         newData.transfers.set(pair_id, newPair);

--- a/src/client/lib/hooks/transfers.ts
+++ b/src/client/lib/hooks/transfers.ts
@@ -56,12 +56,12 @@ export const useTransfers = (): TransferActions => {
     async (pair_id: string) => {
       const response = await call.delete(`/api/transfers?id=${encodeURIComponent(pair_id)}`);
       if (response.status !== "success") return;
-      indexedDb.remove(StoreName.transfers, pair_id).catch(console.error);
       setData((oldData) => {
         if (!oldData.transfers.has(pair_id)) return oldData;
         const newData = new Data(oldData);
         newData.transfers = new TransferDictionary(oldData.transfers);
         newData.transfers.delete(pair_id);
+        indexedDb.remove(StoreName.transfers, pair_id).catch(console.error);
         return newData;
       });
     },

--- a/src/client/lib/hooks/transfers.ts
+++ b/src/client/lib/hooks/transfers.ts
@@ -1,6 +1,5 @@
 import { useCallback } from "react";
 import { JSONTransaction } from "common";
-import { TransferPair, TransfersGetResponse } from "server";
 import { call, Data, useAppContext } from "client";
 
 export interface ConfirmedTransfer {
@@ -12,11 +11,6 @@ export interface ConfirmedTransfer {
 }
 
 export interface TransferActions {
-  /** Re-fetch /api/transfers and write the derived maps into
-   *  `data.suggestedPairByTransactionId` /
-   *  `data.confirmedTransferByTransactionId`. Called on login (from
-   *  `Utility`) and after every successful mutation below. */
-  refresh: () => Promise<void>;
   /** Confirm a suggested pair: status becomes "confirmed". */
   confirm: (pair_id: string) => Promise<void>;
   /** Reject a suggested pair: soft-deletes it so the row reverts. */
@@ -33,86 +27,120 @@ export interface TransferActions {
   pair: (transaction_id_a: string, transaction_id_b: string) => Promise<void>;
 }
 
-const buildMaps = (
-  pairs: TransferPair[],
-): {
-  suggested: Map<string, string>;
-  confirmed: Map<string, ConfirmedTransfer>;
-} => {
-  const suggested = new Map<string, string>();
-  const confirmed = new Map<string, ConfirmedTransfer>();
-  for (const pair of pairs) {
-    if (pair.status === "suggested") {
-      for (const transaction of pair.transactions) {
-        suggested.set(transaction.transaction_id, pair.pair_id);
-      }
-    } else if (pair.status === "confirmed") {
-      const entry: ConfirmedTransfer = {
-        pair_id: pair.pair_id,
-        transactions: pair.transactions,
-      };
-      for (const transaction of pair.transactions) {
-        confirmed.set(transaction.transaction_id, entry);
-      }
-    }
-  }
-  return { suggested, confirmed };
+/**
+ * Find both transaction_ids that map to a given pair_id in one of the
+ * pair maps. Used by mutation methods to update FE state in-place
+ * without re-fetching.
+ */
+const findPairTxIds = (
+  map: Map<string, unknown>,
+  pair_id: string,
+  matches: (entry: unknown) => boolean,
+): string[] => {
+  const txIds: string[] = [];
+  map.forEach((entry, txId) => {
+    if (matches(entry)) txIds.push(txId);
+    // Stop walking once both halves found — every pair has exactly 2 sides.
+  });
+  return txIds;
 };
 
 /**
- * Transfer-pair actions hook (#354, Phase 3a). Stateless: the maps
- * themselves live on `data.suggestedPairByTransactionId` and
- * `data.confirmedTransferByTransactionId` — this hook just provides
- * memoized callbacks that fetch `/api/transfers` and write the
- * derived maps back via `setData`. Safe to call from any component;
- * each call returns fresh memoized callbacks but no internal state.
- *
- * Kept separate from the heavyweight cold/warm IndexedDB sync because
- * pairs are a small, cheap list refetched on demand after each
- * mutation rather than cached per-month like transactions.
+ * Transfer-pair actions hook (#354, Phase 3a). Stateless: the pair
+ * maps themselves live on `data.suggestedPairByTransactionId` and
+ * `data.confirmedTransferByTransactionId`, fetched once by `useSync`
+ * alongside transactions / budgets / etc. Mutation methods POST to
+ * the server then update `data` in-place via `setData` — no
+ * re-fetch, matching the rest of the app's mutation pattern.
  */
 export const useTransfers = (): TransferActions => {
   const { setData } = useAppContext();
 
-  const refresh = useCallback(async () => {
-    const response = await call.get<TransfersGetResponse>("/api/transfers");
-    if (response.status !== "success" || !response.body) return;
-    const { suggested, confirmed } = buildMaps(response.body);
-    setData((oldData) => {
-      const newData = new Data(oldData);
-      newData.suggestedPairByTransactionId = suggested;
-      newData.confirmedTransferByTransactionId = confirmed;
-      return newData;
-    });
-  }, [setData]);
-
   const confirm = useCallback(
     async (pair_id: string) => {
       const response = await call.post("/api/transfers/pair", { pair_id });
-      if (response.status === "success") await refresh();
+      if (response.status !== "success") return;
+      setData((oldData) => {
+        const txIds = findPairTxIds(
+          oldData.suggestedPairByTransactionId,
+          pair_id,
+          (entry) => entry === pair_id,
+        );
+        // Both halves of the pair are needed to build the ConfirmedTransfer
+        // entry. If only one is in `data.transactions` (rare — partial
+        // sync), the second half goes in as a stub so the maps stay
+        // consistent; the bundled-row renderer will skip the stub side.
+        const transactions: JSONTransaction[] = txIds
+          .map((id) => oldData.transactions.get(id))
+          .filter((t): t is NonNullable<typeof t> => !!t);
+        if (transactions.length < 2) return oldData;
+
+        const entry: ConfirmedTransfer = { pair_id, transactions };
+        const newData = new Data(oldData);
+        newData.suggestedPairByTransactionId = new Map(oldData.suggestedPairByTransactionId);
+        newData.confirmedTransferByTransactionId = new Map(oldData.confirmedTransferByTransactionId);
+        for (const id of txIds) {
+          newData.suggestedPairByTransactionId.delete(id);
+          newData.confirmedTransferByTransactionId.set(id, entry);
+        }
+        return newData;
+      });
     },
-    [refresh],
+    [setData],
   );
 
   const reject = useCallback(
     async (pair_id: string) => {
       const response = await call.delete(`/api/transfers?id=${encodeURIComponent(pair_id)}`);
-      if (response.status === "success") await refresh();
+      if (response.status !== "success") return;
+      setData((oldData) => {
+        const newData = new Data(oldData);
+        newData.suggestedPairByTransactionId = new Map(oldData.suggestedPairByTransactionId);
+        newData.confirmedTransferByTransactionId = new Map(oldData.confirmedTransferByTransactionId);
+        // Strip both halves from whichever map they're in. Reject is
+        // semantically used on suggested pairs; unpair (same delete
+        // route) is used on confirmed pairs — both paths land here.
+        const suggestedTxIds = findPairTxIds(
+          newData.suggestedPairByTransactionId,
+          pair_id,
+          (entry) => entry === pair_id,
+        );
+        suggestedTxIds.forEach((id) => newData.suggestedPairByTransactionId.delete(id));
+        const confirmedTxIds = findPairTxIds(
+          newData.confirmedTransferByTransactionId,
+          pair_id,
+          (entry) => (entry as ConfirmedTransfer).pair_id === pair_id,
+        );
+        confirmedTxIds.forEach((id) => newData.confirmedTransferByTransactionId.delete(id));
+        return newData;
+      });
     },
-    [refresh],
+    [setData],
   );
 
   const pair = useCallback(
     async (transaction_id_a: string, transaction_id_b: string) => {
-      const response = await call.post("/api/transfers/pair", {
+      const response = await call.post<{ pair_id: string }>("/api/transfers/pair", {
         transaction_id_a,
         transaction_id_b,
         status: "confirmed",
       });
-      if (response.status === "success") await refresh();
+      if (response.status !== "success" || !response.body) return;
+      const { pair_id } = response.body;
+      setData((oldData) => {
+        const a = oldData.transactions.get(transaction_id_a);
+        const b = oldData.transactions.get(transaction_id_b);
+        if (!a || !b) return oldData;
+        const entry: ConfirmedTransfer = { pair_id, transactions: [a, b] };
+        const newData = new Data(oldData);
+        newData.confirmedTransferByTransactionId = new Map(oldData.confirmedTransferByTransactionId);
+        newData.confirmedTransferByTransactionId.set(transaction_id_a, entry);
+        newData.confirmedTransferByTransactionId.set(transaction_id_b, entry);
+        return newData;
+      });
     },
-    [refresh],
+    [setData],
   );
 
-  return { refresh, confirm, reject, unpair: reject, pair };
+  return { confirm, reject, unpair: reject, pair };
 };

--- a/src/client/lib/indexed-db/accessor.ts
+++ b/src/client/lib/indexed-db/accessor.ts
@@ -1,5 +1,5 @@
 const DB_NAME = "BudgetApp";
-const DB_VERSION = 4;
+const DB_VERSION = 5;
 
 export enum StoreName {
   // primary data
@@ -18,6 +18,11 @@ export enum StoreName {
   accountSnapshots = "accountSnapshots",
   holdingSnapshots = "holdingSnapshots",
   securitySnapshots = "securitySnapshots",
+  // Transfer pairs (suggested + confirmed) keyed by pair_id. Loaded
+  // into `data.transfers` on warm boot, saved on cold-sync settle and
+  // on each mutation so warm paths paint with the most recent pair
+  // state instead of "no pairs until /api/transfers settles".
+  transfers = "transfers",
   // calculations
   balanceData = "balanceData",
   budgetData = "budgetData",

--- a/src/client/lib/indexed-db/service.ts
+++ b/src/client/lib/indexed-db/service.ts
@@ -170,7 +170,9 @@ export const saveSplitTransactions = async (data: SplitTransactionDictionary) =>
 };
 
 export const saveTransfers = async (data: TransferDictionary) => {
+  console.log("[debug saveTransfers] entry, size=", data?.size, "entries=", Array.from(data?.entries() ?? []).length);
   await saveDictionary(StoreName.transfers, data);
+  console.log("[debug saveTransfers] saveDictionary returned");
 };
 
 export const loadTransfers = async (): Promise<TransferDictionary> => {

--- a/src/client/lib/indexed-db/service.ts
+++ b/src/client/lib/indexed-db/service.ts
@@ -170,9 +170,7 @@ export const saveSplitTransactions = async (data: SplitTransactionDictionary) =>
 };
 
 export const saveTransfers = async (data: TransferDictionary) => {
-  console.log("[debug saveTransfers] entry, size=", data?.size, "entries=", Array.from(data?.entries() ?? []).length);
   await saveDictionary(StoreName.transfers, data);
-  console.log("[debug saveTransfers] saveDictionary returned");
 };
 
 export const loadTransfers = async (): Promise<TransferDictionary> => {

--- a/src/client/lib/indexed-db/service.ts
+++ b/src/client/lib/indexed-db/service.ts
@@ -1,4 +1,5 @@
 import { JSONSplitTransaction } from "common";
+import type { TransferPair } from "server";
 import {
   BalanceData,
   AmountByMonth,
@@ -14,6 +15,7 @@ import {
   AccountDictionary,
   Account,
   TransactionDictionary,
+  TransferDictionary,
   Dictionary,
   Transaction,
   InvestmentTransactionDictionary,
@@ -167,6 +169,34 @@ export const saveSplitTransactions = async (data: SplitTransactionDictionary) =>
   await saveDictionary(StoreName.splitTransactions, data);
 };
 
+export const saveTransfers = async (data: TransferDictionary) => {
+  await saveDictionary(StoreName.transfers, data);
+};
+
+export const loadTransfers = async (): Promise<TransferDictionary> => {
+  // TransferPair is a plain interface — no model class to construct.
+  // Feed loaded entries directly into TransferDictionary's constructor,
+  // which rebuilds the pivot (transaction_id → pair) from them.
+  const data = await indexedDbAccessor.load<JSON>(StoreName.transfers);
+  const entries: [string, TransferPair][] = Object.entries(data).map(([pair_id, pair]) => [
+    pair_id,
+    pair as unknown as TransferPair,
+  ]);
+  return new TransferDictionary(entries);
+};
+
+/**
+ * Single-pair save for mutations (confirm / pair). The generic
+ * `save()` below switches on `data.constructor` to pick a StoreName;
+ * TransferPair is an interface with no class, so it needs a dedicated
+ * helper. Use this from `useTransfers` after the optimistic setData
+ * lands so the IDB cache and the React state agree on the next warm
+ * boot.
+ */
+export const saveTransfer = (pair: TransferPair) => {
+  return indexedDbAccessor.save(StoreName.transfers, pair.pair_id, pair);
+};
+
 export const loadSplitTransactions = () => {
   return loadDictionary<SplitTransactionDictionary, SplitTransaction>(
     StoreName.splitTransactions,
@@ -281,6 +311,7 @@ export const saveAllData = async (data: Data) => {
     accountSnapshots,
     holdingSnapshots,
     securitySnapshots,
+    transfers,
   } = data;
 
   await Promise.all([
@@ -299,6 +330,7 @@ export const saveAllData = async (data: Data) => {
     saveAccountSnapshots(accountSnapshots),
     saveHoldingSnapshots(holdingSnapshots),
     saveSecuritySnapshots(securitySnapshots),
+    saveTransfers(transfers),
   ]);
 };
 
@@ -319,6 +351,7 @@ export const loadAllData = async () => {
     accountSnapshots,
     holdingSnapshots,
     securitySnapshots,
+    transfers,
   ] = await Promise.all([
     loadInstitutions(),
     loadAccounts(),
@@ -335,6 +368,7 @@ export const loadAllData = async () => {
     loadAccountSnapshots(),
     loadHoldingSnapshots(),
     loadSecuritySnapshots(),
+    loadTransfers(),
   ]);
 
   return new Data({
@@ -353,6 +387,7 @@ export const loadAllData = async () => {
     accountSnapshots,
     holdingSnapshots,
     securitySnapshots,
+    transfers,
   });
 };
 

--- a/src/client/lib/models/Data.ts
+++ b/src/client/lib/models/Data.ts
@@ -11,7 +11,7 @@ import { Category } from "./Category";
 import { Item } from "./Item";
 import { Chart } from "./Chart";
 import { AccountSnapshot, HoldingSnapshot, SecuritySnapshot } from "./Snapshot";
-import { ConfirmedTransfer } from "../hooks/transfers";
+import type { TransferPair } from "server";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class Dictionary<T = any, S extends Dictionary<T> = any> extends Map<string, T> {
@@ -115,6 +115,53 @@ export class SecuritySnapshotDictionary extends Dictionary<
 
 export class TransactionDictionary extends Dictionary<Transaction, TransactionDictionary> {}
 
+/**
+ * Pair-keyed dictionary of transfers. Keys are pair_id; values are the
+ * server's TransferPair (with status + the two transactions). Maintains
+ * a private `pivot: transaction_id → pair` so consumers can resolve "is
+ * this transaction part of any pair?" in O(1) via getByTransactionId(),
+ * without standing up a parallel map at the Data level. Overrides
+ * `set`/`delete` to keep the pivot in sync with the primary map.
+ *
+ * Suggested and confirmed pairs live in the same dictionary — consumers
+ * filter on `pair.status` at the point of use (matches the suggested-
+ * vs-confirmed category-label pattern already in use elsewhere).
+ */
+export class TransferDictionary extends Map<string, TransferPair> {
+  private pivot = new Map<string, TransferPair>();
+
+  constructor(init?: Iterable<readonly [string, TransferPair]> | null) {
+    super(init as Iterable<readonly [string, TransferPair]> | undefined);
+    // Build the pivot from the entries the base Map constructor just
+    // ingested. The entries went through Map.prototype.set (not our
+    // override), so the pivot wasn't populated incrementally.
+    this.forEach((pair) => {
+      pair.transactions.forEach((t) => this.pivot.set(t.transaction_id, pair));
+    });
+  }
+
+  getByTransactionId = (transaction_id: string): TransferPair | undefined => {
+    return this.pivot.get(transaction_id);
+  };
+
+  override set(pair_id: string, pair: TransferPair): this {
+    const prev = super.get(pair_id);
+    if (prev) {
+      prev.transactions.forEach((t) => this.pivot.delete(t.transaction_id));
+    }
+    pair.transactions.forEach((t) => this.pivot.set(t.transaction_id, pair));
+    return super.set(pair_id, pair);
+  }
+
+  override delete(pair_id: string): boolean {
+    const prev = super.get(pair_id);
+    if (prev) {
+      prev.transactions.forEach((t) => this.pivot.delete(t.transaction_id));
+    }
+    return super.delete(pair_id);
+  }
+}
+
 export const getBudgetClass = (type: BudgetFamilyType): typeof BudgetFamily => {
   return type === "budget" ? Budget : type === "section" ? Section : Category;
 };
@@ -148,18 +195,14 @@ export class Data {
   holdingSnapshots = new HoldingSnapshotDictionary();
   securitySnapshots = new SecuritySnapshotDictionary();
 
-  /** transaction_id → pair_id for pairs the detect-transfers heuristic
-   *  proposed but the user hasn't confirmed yet. Populated by
-   *  `useTransfers().refresh()`. Empty on logout / cold init. */
-  suggestedPairByTransactionId = new Map<string, string>();
-
-  /** transaction_id → bundled confirmed-pair info. Both halves of a
-   *  confirmed pair point at the SAME ConfirmedTransfer object. Read
-   *  by `getBudgetData` / `getSankeyData` to skip transfer halves from
+  /** All transfer pairs (suggested + confirmed), keyed by pair_id.
+   *  Read by `getBudgetData` / `getSankeyData` (filtering to
+   *  `status==="confirmed"`) to skip confirmed-transfer halves from
    *  spent/income aggregation, and by `TransactionsTable` /
-   *  `TransactionProperties` etc. for the bundled-row and "mark as
-   *  non-transfer" UI. Populated by `useTransfers().refresh()`. */
-  confirmedTransferByTransactionId = new Map<string, ConfirmedTransfer>();
+   *  `TransactionProperties` etc. for bundled-row and Confirm/Reject UI.
+   *  Populated by `useSync`'s `fetchTransfers()` on cold/warm load,
+   *  mutated in-place via `useTransfers()` action methods. */
+  transfers = new TransferDictionary();
 
   constructor(init?: Partial<Data>) {
     assign(this, init);

--- a/src/client/lib/models/Data.ts
+++ b/src/client/lib/models/Data.ts
@@ -11,6 +11,7 @@ import { Category } from "./Category";
 import { Item } from "./Item";
 import { Chart } from "./Chart";
 import { AccountSnapshot, HoldingSnapshot, SecuritySnapshot } from "./Snapshot";
+import { ConfirmedTransfer } from "../hooks/transfers";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class Dictionary<T = any, S extends Dictionary<T> = any> extends Map<string, T> {
@@ -146,6 +147,19 @@ export class Data {
   accountSnapshots = new AccountSnapshotDictionary();
   holdingSnapshots = new HoldingSnapshotDictionary();
   securitySnapshots = new SecuritySnapshotDictionary();
+
+  /** transaction_id → pair_id for pairs the detect-transfers heuristic
+   *  proposed but the user hasn't confirmed yet. Populated by
+   *  `useTransfers().refresh()`. Empty on logout / cold init. */
+  suggestedPairByTransactionId = new Map<string, string>();
+
+  /** transaction_id → bundled confirmed-pair info. Both halves of a
+   *  confirmed pair point at the SAME ConfirmedTransfer object. Read
+   *  by `getBudgetData` / `getSankeyData` to skip transfer halves from
+   *  spent/income aggregation, and by `TransactionsTable` /
+   *  `TransactionProperties` etc. for the bundled-row and "mark as
+   *  non-transfer" UI. Populated by `useTransfers().refresh()`. */
+  confirmedTransferByTransactionId = new Map<string, ConfirmedTransfer>();
 
   constructor(init?: Partial<Data>) {
     assign(this, init);

--- a/src/client/lib/models/Data.ts
+++ b/src/client/lib/models/Data.ts
@@ -127,7 +127,7 @@ export class TransactionDictionary extends Dictionary<Transaction, TransactionDi
  * filter on `pair.status` at the point of use (matches the suggested-
  * vs-confirmed category-label pattern already in use elsewhere).
  */
-export class TransferDictionary extends Map<string, TransferPair> {
+export class TransferDictionary extends Dictionary<TransferPair, TransferDictionary> {
   private pivot = new Map<string, TransferPair>();
 
   constructor(init?: Iterable<readonly [string, TransferPair]> | null) {
@@ -144,22 +144,28 @@ export class TransferDictionary extends Map<string, TransferPair> {
     return this.pivot.get(transaction_id);
   };
 
-  override set(pair_id: string, pair: TransferPair): this {
-    const prev = super.get(pair_id);
+  // Dictionary's `set` is an arrow-function field, not a prototype
+  // method, so `super.set` from our own arrow field doesn't resolve
+  // (TS2855). Call `Map.prototype.set` directly — same effect as
+  // bypassing Dictionary's server-side guard, which doesn't apply to
+  // transfers (this is FE-only code).
+  override set = (pair_id: string, pair: TransferPair): this => {
+    const prev = Map.prototype.get.call(this, pair_id) as TransferPair | undefined;
     if (prev) {
       prev.transactions.forEach((t) => this.pivot.delete(t.transaction_id));
     }
     pair.transactions.forEach((t) => this.pivot.set(t.transaction_id, pair));
-    return super.set(pair_id, pair);
-  }
+    Map.prototype.set.call(this, pair_id, pair);
+    return this;
+  };
 
-  override delete(pair_id: string): boolean {
-    const prev = super.get(pair_id);
+  override delete = (pair_id: string): boolean => {
+    const prev = Map.prototype.get.call(this, pair_id) as TransferPair | undefined;
     if (prev) {
       prev.transactions.forEach((t) => this.pivot.delete(t.transaction_id));
     }
-    return super.delete(pair_id);
-  }
+    return Map.prototype.delete.call(this, pair_id);
+  };
 }
 
 export const getBudgetClass = (type: BudgetFamilyType): typeof BudgetFamily => {

--- a/src/client/pages/TransactionDetailPage/index.tsx
+++ b/src/client/pages/TransactionDetailPage/index.tsx
@@ -8,8 +8,8 @@ export type TransactionDetailPageParams = {
 };
 
 export const TransactionDetailPage = () => {
-  const { data, router, transfers } = useAppContext();
-  const { transactions } = data;
+  const { data, router } = useAppContext();
+  const { transactions, confirmedTransferByTransactionId } = data;
 
   const { path, params, transition } = router;
   let id: string;
@@ -25,7 +25,7 @@ export const TransactionDetailPage = () => {
   // entity, not one side of it (Hoie 2026-06-17). Branch on whether the
   // clicked transaction is part of a confirmed pair and render the
   // dedicated `TransferProperties` view if so.
-  const confirmedTransfer = transfers.confirmedTransferByTransactionId.get(transaction.transaction_id);
+  const confirmedTransfer = confirmedTransferByTransactionId.get(transaction.transaction_id);
 
   return (
     <div className="TransactionDetailPage">

--- a/src/client/pages/TransactionDetailPage/index.tsx
+++ b/src/client/pages/TransactionDetailPage/index.tsx
@@ -9,7 +9,7 @@ export type TransactionDetailPageParams = {
 
 export const TransactionDetailPage = () => {
   const { data, router } = useAppContext();
-  const { transactions, confirmedTransferByTransactionId } = data;
+  const { transactions, transfers } = data;
 
   const { path, params, transition } = router;
   let id: string;
@@ -25,7 +25,8 @@ export const TransactionDetailPage = () => {
   // entity, not one side of it (Hoie 2026-06-17). Branch on whether the
   // clicked transaction is part of a confirmed pair and render the
   // dedicated `TransferProperties` view if so.
-  const confirmedTransfer = confirmedTransferByTransactionId.get(transaction.transaction_id);
+  const lookedUp = transfers.getByTransactionId(transaction.transaction_id);
+  const confirmedTransfer = lookedUp?.status === "confirmed" ? lookedUp : undefined;
 
   return (
     <div className="TransactionDetailPage">


### PR DESCRIPTION
Stacks on #490. Rebases to main once #490 merges.

Per Hoie 2026-06-19: confirmed transfers should not count as spending or income in the budget rollups and should not appear as inflow/outflow on the Flow chart Sankey — both halves are internal movement between the user's own accounts. Per-account historical balance INTENTIONALLY still includes them so the chart matches the snapshot baseline of money actually held.

## What changes

| Surface | Confirmed transfers | Reason |
|---|---|---|
| Budget rollups (`getBudgetData`) | **excluded** | Internal movement, not real spending or income — otherwise would inflate both the source-account budget's spent column AND the destination's income column |
| Flow chart Sankey (`getSankeyData`) | **excluded** | Same reason; would double-count by appearing as both an expense (debit side) and income (credit side) |
| Per-account balance history (`getBalanceData`) | **kept** | The account's balance really did change when money left/arrived — dropping transfers would de-sync the chart from the snapshot baseline (Hoie 2026-06-18) |
| Capacity / holdings | n/a | Don't consume transactions |

## How it's wired

- Both `getBudgetData` and `getSankeyData` gain an optional `confirmedTransferTxIds: ReadonlySet<string>` param. Defaults to an empty set so existing callers (and tests) keep pre-PR behavior.
- `CalculateOptions` interface added to both `lib/hooks/context.ts` (the context's contract) and `App/lib/hooks.ts` (the implementation). `calculate(data, opts?)` now takes an optional opts.
- `Utility` derives the set once per `transfers.confirmedTransferByTransactionId` ref change and threads it into the `calculate(data, { confirmedTransferTxIds })` effect.
- `FlowChartRow` derives the same set locally and passes it to `getSankeyData` — the chart computes its own Sankey inside a useMemo rather than reading from `calculations`, so it needs to consume the set directly.
- `getBalanceData` is deliberately NOT changed.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test src/server` — 624 pass, 0 fail
- [x] Sandbox E2E: exclusion verified in a real logged-in browser by running the served `getBudgetData` and `getSankeyData` modules against a synthesized confirmed pair — both drop the pair (amount → 0) once confirmed. See the E2E comment for the harness + results. (The natural click-to-confirm UI path is unreachable read-only: the sandbox has only *suggested* pairs and confirming is a write to the prod-clone, so the calc exclusion was exercised directly instead. `getBalanceData` intentionally unchanged.)
