### PR TITLE
fix(accounts): show live balance, not $0, for past months still loading (#510)

### DIFF
--- a/src/client/components/AccountsDonut/BalanceInfo.tsx
+++ b/src/client/components/AccountsDonut/BalanceInfo.tsx
@@ -1,4 +1,4 @@
-import { DonutData, useAppContext } from "client";
+import { DonutData, getDisplayBalance, useAppContext } from "client";
 import { Changes } from "client/components";
 
 interface Props {
@@ -18,16 +18,21 @@ export const BalanceInfo = ({
   numberOfCredits,
   isShrunk,
 }: Props) => {
-  const { calculations, viewDate } = useAppContext();
+  const { calculations, viewDate, data } = useAppContext();
   const { balanceData } = calculations;
+  const { accounts } = data;
 
-  const viewDateSpan = Math.max(-viewDate.getSpanFrom(new Date()), 0);
+  const today = new Date();
+  const viewDateSpan = Math.max(-viewDate.getSpanFrom(today), 0);
   const previousDate = viewDate.clone().previous().getEndDate();
 
+  // Match the headline total's loading-aware fallback (#510): while history is
+  // still streaming, missing previous-period balances fall back to the live
+  // balance rather than 0, so the "from last <period>" delta doesn't spike.
   const previousAmount = donutData.reduce((a, { id }) => {
-    const balanceHistory = balanceData.get(id);
-    if (!balanceHistory) return a;
-    return a + (balanceHistory.get(previousDate) || 0);
+    const account = accounts.get(id);
+    if (!account) return a;
+    return a + getDisplayBalance(balanceData, account, previousDate, today, data.status.isLoading);
   }, 0);
 
   return (

--- a/src/client/components/AccountsTable/Balance.tsx
+++ b/src/client/components/AccountsTable/Balance.tsx
@@ -1,16 +1,15 @@
 import { AccountSubtype, AccountType } from "plaid";
 import { currencyCodeToSymbol, numberToCommaString } from "common";
-import { Account, getAccountBalance, useAppContext } from "client";
+import { Account, getDisplayBalance, useAppContext } from "client";
 
 interface BalanceProps {
   account: Account;
 }
 
 export const Balance = ({ account }: BalanceProps) => {
-  const { viewDate, calculations } = useAppContext();
+  const { viewDate, calculations, data } = useAppContext();
   const { balanceData } = calculations;
   const { type, subtype, balances } = account;
-  const balanceHistory = balanceData.get(account.id);
   const { available, current, iso_currency_code, unofficial_currency_code } = balances;
 
   const symbol = currencyCodeToSymbol(iso_currency_code || unofficial_currency_code || "USD");
@@ -19,12 +18,12 @@ export const Balance = ({ account }: BalanceProps) => {
   const today = new Date();
   const viewDateDate = viewDate.getEndDate();
   const previousDate = viewDate.clone().previous().getEndDate();
-  // For future dates (e.g. year-end of the current year), fall back to the
-  // current balance rather than 0 so the row shows a meaningful value.
-  // For past dates with no history, show 0 (data was never recorded).
-  const fallback = viewDateDate > today ? getAccountBalance(account) : 0;
-  const dynamicAmount = balanceHistory.get(viewDateDate) ?? fallback;
-  const previousAmount = balanceHistory.get(previousDate) || 0;
+  // Fall back to the live balance for future dates, and for past dates while
+  // the cold-load history is still streaming in — flashing $0 there reports a
+  // bogus net-worth collapse (#510). Once loaded, missing past data → 0 (#428).
+  const isLoading = data.status.isLoading;
+  const dynamicAmount = getDisplayBalance(balanceData, account, viewDateDate, today, isLoading);
+  const previousAmount = getDisplayBalance(balanceData, account, previousDate, today, isLoading);
 
   if (type === AccountType.Credit) {
     const availableString = numberToCommaString(available!);

--- a/src/client/components/BalanceChartRow/index.tsx
+++ b/src/client/components/BalanceChartRow/index.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, KeyboardEvent, MouseEventHandler, SetStateAction } from "react";
 import { AccountType } from "plaid";
 import { numberToCommaString, toTitleCase } from "common";
-import { BalanceChart, getAccountBalance, useAppContext, useReorder } from "client";
+import { BalanceChart, getDisplayBalance, useAppContext, useReorder } from "client";
 import { ChevronDownIcon, ChevronUpIcon, QuestionIcon } from "client/components";
 import { ColumnData, StackData, Stacks } from "./Stacks";
 import "./index.css";
@@ -48,9 +48,9 @@ export const BalanceChartRow = ({
     if (a.hide) return;
     // Use historical balance for the selected view date so that switching
     // to a past month reflects the balance at that time rather than today's
-    // live Plaid balance.
-    const fallback = date > today ? getAccountBalance(a) : 0;
-    const historicalBalance = balanceData.get(a.id, date) ?? fallback;
+    // live Plaid balance. While the cold-load history is still streaming,
+    // fall back to the live balance instead of flashing $0 (#510).
+    const historicalBalance = getDisplayBalance(balanceData, a, date, today, data.status.isLoading);
     const stack = { type: a.type, name: a.custom_name || a.name, amount: historicalBalance };
     if (!configuration.account_ids.includes(a.id)) return;
     // Plaid AccountType: Depository, Investment, Brokerage are assets;

--- a/src/client/lib/hooks/calculation/accounts.test.ts
+++ b/src/client/lib/hooks/calculation/accounts.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import { AccountType, AccountSubtype } from "plaid";
-import { getAccountBalance } from "./accounts";
-import { Account } from "client";
+import { getAccountBalance, getDisplayBalance } from "./accounts";
+import { Account, BalanceData } from "client";
 
 describe("getAccountBalance", () => {
   test("should return current balance for depository accounts", () => {
@@ -60,6 +60,67 @@ describe("getAccountBalance", () => {
     });
     // When values are null/undefined, they become 0
     expect(getAccountBalance(account)).toBe(0);
+  });
+});
+
+// Regression coverage for #510: on a cold load, navigating to a past month
+// rendered every not-yet-streamed account as $0.00 — feeding a bogus
+// net-worth collapse into the Accounts table, the "All Accounts" headline,
+// and the balance charts — before self-healing once the backfill reached
+// that month. getDisplayBalance now distinguishes "history still loading"
+// (fall back to the live balance, like future dates) from "load complete,
+// genuinely no record" (fall back to 0, preserving #428).
+describe("getDisplayBalance (#510 cold-load past-balance flash)", () => {
+  const LIVE = 1000;
+  const RECORDED = 250;
+  const makeAccount = () =>
+    new Account({
+      account_id: "acc1",
+      type: AccountType.Investment,
+      balances: {
+        current: LIVE,
+        available: 0,
+        limit: null,
+        iso_currency_code: "USD",
+        unofficial_currency_code: null,
+      },
+    });
+
+  const today = new Date("2026-06-15");
+  const pastDate = new Date("2026-03-15");
+  const futureDate = new Date("2026-12-15");
+
+  test("returns the recorded balance when one exists, regardless of load state", () => {
+    const account = makeAccount();
+    const balanceData = new BalanceData();
+    balanceData.set(account.id, pastDate, RECORDED);
+    expect(getDisplayBalance(balanceData, account, pastDate, today, true)).toBe(RECORDED);
+    expect(getDisplayBalance(balanceData, account, pastDate, today, false)).toBe(RECORDED);
+  });
+
+  test("a recorded zero is honored (not treated as missing) once loaded", () => {
+    const account = makeAccount();
+    const balanceData = new BalanceData();
+    balanceData.set(account.id, pastDate, 0);
+    expect(getDisplayBalance(balanceData, account, pastDate, today, false)).toBe(0);
+  });
+
+  test("missing past balance falls back to the LIVE balance while history is loading", () => {
+    const account = makeAccount();
+    const balanceData = new BalanceData();
+    expect(getDisplayBalance(balanceData, account, pastDate, today, true)).toBe(LIVE);
+  });
+
+  test("missing past balance falls back to 0 once the load is complete (#428 preserved)", () => {
+    const account = makeAccount();
+    const balanceData = new BalanceData();
+    expect(getDisplayBalance(balanceData, account, pastDate, today, false)).toBe(0);
+  });
+
+  test("missing future balance falls back to the LIVE balance even when not loading", () => {
+    const account = makeAccount();
+    const balanceData = new BalanceData();
+    expect(getDisplayBalance(balanceData, account, futureDate, today, false)).toBe(LIVE);
   });
 });
 

--- a/src/client/lib/hooks/calculation/accounts.ts
+++ b/src/client/lib/hooks/calculation/accounts.ts
@@ -23,6 +23,32 @@ export const getAccountBalance = (account: Account) => {
   return account.balances.current || 0;
 };
 
+/**
+ * Resolve the balance to display for an account at a given view date.
+ *
+ * When `balanceData` has a recorded entry for the date, use it. Otherwise pick
+ * a fallback:
+ *  - Future dates fall back to the live balance (year-end of the current year
+ *    has no recorded snapshot yet, so 0 would be meaningless).
+ *  - While the cold-load backfill is still streaming history in
+ *    (`isHistoryLoading`), a missing past-date entry means "not loaded yet" —
+ *    fall back to the live balance rather than flashing a misleading $0 that
+ *    momentarily reports a near-total net-worth collapse (#510).
+ *  - Once the load is complete, a missing past-date entry genuinely means "no
+ *    record for this month" → 0 (preserves #428's zero-balance behavior).
+ */
+export const getDisplayBalance = (
+  balanceData: BalanceData,
+  account: Account,
+  date: Date,
+  today: Date,
+  isHistoryLoading: boolean,
+): number => {
+  const recorded = balanceData.get(account.id, date);
+  if (recorded !== undefined) return recorded;
+  return date > today || isHistoryLoading ? getAccountBalance(account) : 0;
+};
+
 const getBalanceDataFromTransactions = (
   accounts: AccountDictionary,
   transactions: TransactionDictionary,

--- a/src/client/pages/AccountsPage/index.tsx
+++ b/src/client/pages/AccountsPage/index.tsx
@@ -1,7 +1,14 @@
 import { AccountType } from "plaid";
 import { useEffect, useMemo, useState } from "react";
 import { cap, currencyCodeToSymbol, ViewDate } from "common";
-import { colors, getAccountBalance, ScreenType, useAppContext, useDebounce } from "client";
+import {
+  colors,
+  getAccountBalance,
+  getDisplayBalance,
+  ScreenType,
+  useAppContext,
+  useDebounce,
+} from "client";
 import { AccountsDonut, AccountsTable, DonutData } from "client/components";
 import "./index.css";
 
@@ -50,9 +57,10 @@ export const AccountsPage = () => {
         : endDate;
 
     filteredAccounts.forEach((a, i) => {
-      const balanceHistory = balanceData.get(a.id);
-      const fallback = viewDateDate > today ? getAccountBalance(a) : 0;
-      const value = balanceHistory.get(viewDateDate) || fallback;
+      // While the cold-load history is still streaming, fall back to the live
+      // balance rather than $0 so the headline total doesn't flash a bogus
+      // net-worth collapse (#510).
+      const value = getDisplayBalance(balanceData, a, viewDateDate, today, data.status.isLoading);
       balanceTotal += value;
       const color = colors[i % colors.length];
       const label = a.custom_name || a.name || "Unnamed";
@@ -66,7 +74,7 @@ export const AccountsPage = () => {
     const currencySymbol = currencyCodeToSymbol(currencyCode);
 
     return { donutData, currencySymbol, balanceTotal, totalCredit, numberOfCredits };
-  }, [accounts, balanceData, viewDate]);
+  }, [accounts, balanceData, viewDate, data.status.isLoading]);
 
   const isNarrow = screenType === ScreenType.Narrow;
 


### PR DESCRIPTION
Closes #510.

## Problem

On a cold load (fresh session / cleared IndexedDB), stepping back to a **past month** whose historical snapshots haven't streamed in yet rendered every such account as a zero balance — and fed that same zero into the Accounts-table rows, the "All Accounts" headline total, the donut, and the Dashboard balance charts. The figures looked plausible (not a spinner), so the UI momentarily reported a near-total net-worth collapse before self-healing once the background backfill reached that month. 100% reproducible on the first visit to any not-yet-backfilled past month.

## Root cause

The past-date balance fallback conflated two distinct cases:

1. **Data was genuinely never recorded** for this account/month → zero is reasonable.
2. **Data exists but hasn't loaded into the client yet** → zero is wrong; the value should be the last-known/live balance.

The asymmetry was the tell: for **future** dates the same code already falls back to the live balance (`getAccountBalance`) rather than zero, precisely because zero would be meaningless. A past date during the backfill has exactly the same problem but was unhandled — it silently got zero. This fired at four call sites that all hand-rolled the same `viewDateDate > today ? live : 0` expression.

## Fix

New shared helper `getDisplayBalance(balanceData, account, date, today, isHistoryLoading)`:

- recorded entry exists → use it (a recorded zero is honored, preserving #428);
- otherwise fall back to the live balance for future dates **and** for past dates while the cold-load history is still streaming (`data.status.isLoading`, which is `true` through the staged Stage 1/2 backfill and `false` only once Stage 3 completes);
- once the load is complete, a missing past-date entry genuinely means "no record for this month" → zero.

Applied at every balance-derived surface so they can't drift: the Accounts-table row (`Balance.tsx`), the headline/donut total (`AccountsPage`), the balance-chart rows (`BalanceChartRow`), and the two Changes baselines (`Balance.tsx` previous + `BalanceInfo`). The Changes baselines are made loading-aware too so the per-row / "from last period" deltas don't spike during the same window.

This deliberately does **not** introduce PR #509's `isTransactionHistoryPartial` flag — the existing `data.status.isLoading` already distinguishes "history still streaming" from "load complete", which is exactly the signal this bug needs.

## Tests

- New unit coverage in `accounts.test.ts` for `getDisplayBalance`: recorded value wins regardless of load state; recorded zero is honored once loaded; missing past balance → live while loading / zero once complete (#428 preserved); missing future balance → live. `bun test` on the file: 11 pass / 0 fail.
- `bun run typecheck` clean; eslint clean on all touched files.

## E2E (Playwright, prod-clone, admin, dev server I started this session)

Cold context (empty IndexedDB). Stage-3 (older-month) `/api/snapshots` responses delayed to widen the backfill window, then logged in, opened Accounts, and stepped back 3 months — the exact #510 gesture — sampling the headline total and the count of zero-balance table rows across the delayed window. A/B against this branch vs. the same code with the fix reverted:

| | headline during load | zero-balance rows during load | collapsed? |
|---|---|---|---|
| before (reverted) | **~6% of the live total** | **10** | yes |
| after (this branch) | **~98% of the live total** | **2** (the genuinely-zero accounts, stable across the window) | no |

So the eight investment accounts that previously flashed to zero now hold their live/last-known balance through the load window, the headline no longer collapses, and the two truly-zero accounts still read zero. No JS console errors attributable to the change. Currency magnitudes redacted (prod-clone data); evidence expressed as deltas/percentages per the sandbox-data scrub.
