### PR TITLE
feat(transactions): multi-choice filter + add Transfers option

### DIFF
--- a/src/client/components/TransactionsPageTitle/index.css
+++ b/src/client/components/TransactionsPageTitle/index.css
@@ -103,16 +103,39 @@ div.TransactionsPage > .heading > div.select > div.options > button:last-child {
   padding: 4px 0 10px 0;
 }
 
-div.TransactionsPage > .heading > div.select > div.options > button > span {
+div.TransactionsPage > .heading > div.select > div.options > button {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   padding-left: 10px;
 }
 
-div.TransactionsPage > .heading > div.select > div.options > button > span:not(.checkmark) {
-  padding-left: 30px;
+div.TransactionsPage > .heading > div.select > div.options > button > span.checkbox {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 1px solid #888;
+  border-radius: 2px;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  position: relative;
 }
 
-div.TransactionsPage > .heading > div.select > div.options > button > span.checkmark {
+div.TransactionsPage > .heading > div.select > div.options > button > span.checkbox.checked {
+  background-color: #4a4a4a;
+  border-color: #aaa;
+}
+
+/* Inset ✓ glyph rendered via ::after so the checkbox span itself stays a
+   pure visual element — keeps the option button click target unified. */
+div.TransactionsPage > .heading > div.select > div.options > button > span.checkbox.checked::after {
+  content: "✓";
   position: absolute;
+  top: -2px;
+  left: 1px;
+  font-size: 12px;
+  line-height: 12px;
+  color: #e8e8e8;
 }
 
 div.SearchBar {

--- a/src/client/components/TransactionsPageTitle/index.css
+++ b/src/client/components/TransactionsPageTitle/index.css
@@ -42,6 +42,15 @@ div.TransactionsPage > .heading > button {
   white-space: nowrap;
   display: flex;
   justify-content: space-between;
+  align-items: center;
+  overflow: hidden;
+}
+
+div.TransactionsPage > .heading > button > span:not(.checkmark) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1;
 }
 
 div.TransactionsPage > .heading > button > svg {

--- a/src/client/components/TransactionsPageTitle/index.tsx
+++ b/src/client/components/TransactionsPageTitle/index.tsx
@@ -60,17 +60,12 @@ const VALID_TYPES = Object.keys(TYPE_LABELS) as TransactionsPageType[];
  */
 export const parseTransactionsTypes = (raw: string | null): TransactionsPageType[] => {
   if (!raw) return [];
-  const valid = new Set<string>(VALID_TYPES);
-  const seen = new Set<TransactionsPageType>();
-  const out: TransactionsPageType[] = [];
-  for (const s of raw.split(",").map((p) => p.trim())) {
-    if (!valid.has(s)) continue;
-    const t = s as TransactionsPageType;
-    if (seen.has(t)) continue;
-    seen.add(t);
-    out.push(t);
-  }
-  return out;
+  const present = new Set(raw.split(",").map((p) => p.trim()));
+  // Canonicalize to VALID_TYPES order (matching writeTypes) so a reversed or
+  // duplicated URL param yields the same sort-preference key as the in-app
+  // toggle — `?transactions_type=expenses,deposits` and `deposits,expenses`
+  // must not store divergent sort keys.
+  return VALID_TYPES.filter((v) => present.has(v));
 };
 
 const serializeTransactionsTypes = (types: TransactionsPageType[]): string => types.join(",");

--- a/src/client/components/TransactionsPageTitle/index.tsx
+++ b/src/client/components/TransactionsPageTitle/index.tsx
@@ -55,15 +55,22 @@ const VALID_TYPES = Object.keys(TYPE_LABELS) as TransactionsPageType[];
 /**
  * Parse the `transactions_type` URL param. Stored as a comma-separated
  * list so multiple filters compose in the same param slot. Returns
- * the validated subset (unknown values dropped, keeps order).
+ * the validated, deduplicated subset (unknown values dropped, first
+ * occurrence wins on duplicates, original order preserved).
  */
 export const parseTransactionsTypes = (raw: string | null): TransactionsPageType[] => {
   if (!raw) return [];
   const valid = new Set<string>(VALID_TYPES);
-  return raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s): s is TransactionsPageType => valid.has(s));
+  const seen = new Set<TransactionsPageType>();
+  const out: TransactionsPageType[] = [];
+  for (const s of raw.split(",").map((p) => p.trim())) {
+    if (!valid.has(s)) continue;
+    const t = s as TransactionsPageType;
+    if (seen.has(t)) continue;
+    seen.add(t);
+    out.push(t);
+  }
+  return out;
 };
 
 const serializeTransactionsTypes = (types: TransactionsPageType[]): string => types.join(",");

--- a/src/client/components/TransactionsPageTitle/index.tsx
+++ b/src/client/components/TransactionsPageTitle/index.tsx
@@ -138,9 +138,17 @@ export const TransactionsPageTitle = ({
     writeTypes(VALID_TYPES.filter((v) => set.has(v)));
   };
 
+  // Each row shows a checkbox indicating its current state — multi-choice
+  // semantics so the user can see at a glance which filters are active.
+  // "All Transactions" is the clear-all sentinel; its checkbox reflects
+  // "no other filter selected" (i.e. you're viewing everything).
+  const renderCheckbox = (checked: boolean) => (
+    <span className={"checkbox" + (checked ? " checked" : "")} aria-hidden="true" />
+  );
+
   const allButton = (
     <button key="__all" onClick={onClickAll}>
-      {selectedTypes.length === 0 && <span className="checkmark">✓</span>}
+      {renderCheckbox(selectedTypes.length === 0)}
       <span>All Transactions</span>
     </button>
   );
@@ -149,7 +157,7 @@ export const TransactionsPageTitle = ({
     const isSelected = selectedTypes.includes(t);
     return (
       <button key={t} onClick={() => toggleType(t)}>
-        {isSelected && <span className="checkmark">✓</span>}
+        {renderCheckbox(isSelected)}
         <span>{TYPE_LABELS[t]}</span>
       </button>
     );

--- a/src/client/components/TransactionsPageTitle/index.tsx
+++ b/src/client/components/TransactionsPageTitle/index.tsx
@@ -18,10 +18,15 @@ import { TransactionsHead } from "./TransactionsHead";
 import "./index.css";
 import { SearchBar } from "./SearchBar";
 
-export type TransactionsPageType = "deposits" | "expenses" | "unsorted" | "suggested";
+export type TransactionsPageType =
+  | "deposits"
+  | "expenses"
+  | "unsorted"
+  | "suggested"
+  | "transfers";
 
 interface TransactionsPageFilters {
-  type?: TransactionsPageType;
+  types: TransactionsPageType[];
   account?: Account;
   budget?: Budget;
   section?: Section;
@@ -37,17 +42,36 @@ interface TransactionsPageTitleProps {
   onChangeSearchValue: (v: string) => void;
 }
 
-enum TITLES {
-  all = "All Transactions",
-  unsorted = "Unsorted Transactions",
-  suggested = "Suggested Transactions",
-  deposits = "Deposits",
-  expenses = "Expenses",
-}
+const TYPE_LABELS: Record<TransactionsPageType, string> = {
+  unsorted: "Unsorted Transactions",
+  suggested: "Suggested Transactions",
+  deposits: "Deposits",
+  expenses: "Expenses",
+  transfers: "Transfers",
+};
 
-const typeToTitle = (type?: TransactionsPageType) => {
-  if (type) return TITLES[type];
-  return "All Transactions";
+const VALID_TYPES = Object.keys(TYPE_LABELS) as TransactionsPageType[];
+
+/**
+ * Parse the `transactions_type` URL param. Stored as a comma-separated
+ * list so multiple filters compose in the same param slot. Returns
+ * the validated subset (unknown values dropped, keeps order).
+ */
+export const parseTransactionsTypes = (raw: string | null): TransactionsPageType[] => {
+  if (!raw) return [];
+  const valid = new Set<string>(VALID_TYPES);
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s): s is TransactionsPageType => valid.has(s));
+};
+
+const serializeTransactionsTypes = (types: TransactionsPageType[]): string => types.join(",");
+
+const titleForSelection = (types: TransactionsPageType[]): string => {
+  if (types.length === 0) return "All Transactions";
+  if (types.length === 1) return TYPE_LABELS[types[0]];
+  return types.map((t) => TYPE_LABELS[t]).join(", ");
 };
 
 export type TransactionHeaders = { [k in keyof JSONTransaction]?: boolean } & {
@@ -66,7 +90,7 @@ export const TransactionsPageTitle = ({
   sorter,
   onChangeSearchValue,
 }: TransactionsPageTitleProps) => {
-  const { type: selectedType, account, budget, section, category } = filters;
+  const { types: selectedTypes, account, budget, section, category } = filters;
   const { router, screenType } = useAppContext();
   const { go, path, params } = router;
 
@@ -87,19 +111,39 @@ export const TransactionsPageTitle = ({
     return () => document.removeEventListener("touchstart", handleTouchOutside);
   }, []);
 
-  const options = [...Object.entries(TITLES)].map(([type, title]) => {
-    const isSelected = type === (selectedType || "all");
-    const onClickSelectOption = () => {
-      setIsSelecting(false);
-      const newParams = new URLSearchParams(params);
-      if (type === "all") newParams.delete("transactions_type");
-      else newParams.set("transactions_type", type as TransactionsPageType);
-      go(path, { params: newParams, animate: false });
-    };
+  const writeTypes = (next: TransactionsPageType[]) => {
+    const newParams = new URLSearchParams(params);
+    if (next.length === 0) newParams.delete("transactions_type");
+    else newParams.set("transactions_type", serializeTransactionsTypes(next));
+    go(path, { params: newParams, animate: false });
+  };
+
+  // "All Transactions" is the empty-selection sentinel: clicking it
+  // clears every filter, regardless of which were on. Order of the
+  // menu is fixed (alphabetical-ish by intent: status, sign, kind).
+  const onClickAll = () => writeTypes([]);
+  const toggleType = (t: TransactionsPageType) => {
+    const set = new Set(selectedTypes);
+    if (set.has(t)) set.delete(t);
+    else set.add(t);
+    // Preserve VALID_TYPES order so the URL is canonical regardless
+    // of click sequence.
+    writeTypes(VALID_TYPES.filter((v) => set.has(v)));
+  };
+
+  const allButton = (
+    <button key="__all" onClick={onClickAll}>
+      {selectedTypes.length === 0 && <span className="checkmark">✓</span>}
+      <span>All Transactions</span>
+    </button>
+  );
+
+  const typeButtons = VALID_TYPES.map((t) => {
+    const isSelected = selectedTypes.includes(t);
     return (
-      <button key={title} onClick={onClickSelectOption}>
+      <button key={t} onClick={() => toggleType(t)}>
         {isSelected && <span className="checkmark">✓</span>}
-        <span>{title}</span>
+        <span>{TYPE_LABELS[t]}</span>
       </button>
     );
   });
@@ -147,7 +191,7 @@ export const TransactionsPageTitle = ({
     <>
       <h2 className="heading">
         <button onClick={onClickSelect}>
-          <span>{typeToTitle(selectedType)}</span>
+          <span>{titleForSelection(selectedTypes)}</span>
           <ChevronDownIcon size={15} />
         </button>
         {isSelecting && (
@@ -165,10 +209,13 @@ export const TransactionsPageTitle = ({
               tabIndex={0}
               aria-label="Close transaction type selector"
             >
-              <span>Select&nbsp;transaction&nbsp;type</span>
+              <span>Select&nbsp;transaction&nbsp;types</span>
               <button className="closeButton" aria-hidden="true">✕</button>
             </div>
-            <div className="options">{options}</div>
+            <div className="options">
+              {allButton}
+              {typeButtons}
+            </div>
           </div>
         )}
       </h2>

--- a/src/client/pages/TransactionsPage/index.tsx
+++ b/src/client/pages/TransactionsPage/index.tsx
@@ -22,6 +22,7 @@ import {
   TransactionsPageTitle,
   TransactionsPageType,
   TransactionsTable,
+  parseTransactionsTypes,
 } from "client/components";
 import { useTransactionHit } from "./hooks";
 import "./index.css";
@@ -37,7 +38,11 @@ const isSuggestedLabel = (e: Transaction | SplitTransaction | InvestmentTransact
 };
 
 export type TransactionsPageParams = {
-  transactions_type?: TransactionsPageType;
+  /** Comma-separated list of `TransactionsPageType` values (e.g.
+   *  `expenses,transfers`). Single values stay valid for callers
+   *  that link in with one filter pre-selected (BudgetDetailPage
+   *  uses `transactions_type=unsorted`). */
+  transactions_type?: string;
   budget_id?: string;
   account_id?: string;
   category_id?: string;
@@ -54,6 +59,7 @@ export const TransactionsPage = () => {
     budgets,
     sections,
     categories,
+    transfers,
   } = data;
   const { transactionFamilies } = calculations;
   const { path, params, transition } = router;
@@ -61,19 +67,19 @@ export const TransactionsPage = () => {
 
   const [searchValue, setSearchValue] = useState("");
 
-  let type: TransactionsPageType | undefined;
+  let types: TransactionsPageType[];
   let account_id: string;
   let budget_id: string;
   let section_id: string;
   let category_id: string;
   if (path === PATH.TRANSACTIONS || screenType !== ScreenType.Narrow) {
-    type = (params.get("transactions_type") as TransactionsPageType) || undefined;
+    types = parseTransactionsTypes(params.get("transactions_type"));
     account_id = params.get("account_id") || "";
     budget_id = params.get("budget_id") || "";
     section_id = params.get("section_id") || "";
     category_id = params.get("category_id") || "";
   } else {
-    type = (incomingParams.get("transactions_type") as TransactionsPageType) || undefined;
+    types = parseTransactionsTypes(incomingParams.get("transactions_type"));
     account_id = incomingParams.get("account_id") || "";
     budget_id = incomingParams.get("budget_id") || "";
     section_id = incomingParams.get("section_id") || "";
@@ -89,7 +95,10 @@ export const TransactionsPage = () => {
 
   const hit = useTransactionHit();
 
-  const sortKey = ["transactions", type].filter(Boolean).join("_");
+  // Stable storage key for the sort preferences — distinct per
+  // type-filter combination so e.g. an "expenses" sort doesn't collide
+  // with an "expenses,transfers" sort.
+  const sortKey = ["transactions", ...types].join("_");
 
   const sorter = useSorter<
     Transaction | InvestmentTransaction | SplitTransaction,
@@ -114,6 +123,33 @@ export const TransactionsPage = () => {
       filters.label.category_id = category_id;
     }
 
+    // Multi-choice OR: an entry passes the type filter if it matches
+    // ANY of the selected types (empty selection = no type filter).
+    // Investment transactions never participate in transfer pairs, so
+    // a "transfers"-only selection produces an empty investment list.
+    const matchesAnySelectedType = (
+      e: Transaction | SplitTransaction | InvestmentTransaction,
+    ): boolean => {
+      if (!types.length) return true;
+      return types.some((t) => {
+        if (t === "deposits") return e.amount < 0;
+        if (t === "expenses") return e.amount > 0;
+        if (t === "unsorted") {
+          const c_id = e.label.category_id;
+          const c_conf = e.label.category_confidence;
+          return !(c_id && (c_conf === 1 || c_conf === 0));
+        }
+        if (t === "suggested") return isSuggestedLabel(e);
+        if (t === "transfers") {
+          // Investment transactions can't be in a pair; the detection
+          // engine only pairs Plaid `transactions` rows.
+          if (e instanceof InvestmentTransaction) return false;
+          return !!transfers.getByTransactionId(e.transaction_id);
+        }
+        return false;
+      });
+    };
+
     if (isInvestment) {
       const filtered = investmentTransactions.filter((e) => {
         if (!e.amount) return false;
@@ -122,8 +158,7 @@ export const TransactionsPage = () => {
         const transactionDate = new LocalDate(e.date);
         const within = viewDate.has(transactionDate);
         if (!within) return false;
-        if (type === "deposits" && e.amount > 0) return false;
-        if (type === "expenses" && e.amount < 0) return false;
+        if (!matchesAnySelectedType(e)) return false;
         return isSubset(e, filters);
       });
 
@@ -145,22 +180,14 @@ export const TransactionsPage = () => {
         const transactionDate = new LocalDate(date);
         const within = viewDate.has(transactionDate);
         if (!within) return false;
-        // "unsorted" view includes every transaction that is not
-        // user-confirmed (confidence === 1). That covers genuinely
-        // unlabeled rows AND auto-suggested ones: both buckets stay
-        // visible until the user explicitly confirms a label.
-        if (type === "unsorted") {
-          const c_id = e.label.category_id;
-          const c_conf = e.label.category_confidence;
-          if (c_id && (c_conf === 1 || c_conf === 0)) return false;
-        }
-        // "suggested" view is the narrower slice: rows currently bearing
-        // an unreviewed auto-suggestion (0 < confidence < 1).
-        if (type === "suggested") {
-          if (!isSuggestedLabel(e)) return false;
-        }
-        if (type === "deposits" && e.amount > 0) return false;
-        if (type === "expenses" && e.amount < 0) return false;
+        // Multi-choice OR across selected types. "unsorted" widens to
+        // "not user-confirmed" (covers genuinely unlabeled rows AND
+        // auto-suggested ones — both stay visible until the user
+        // explicitly confirms a label). "suggested" is the narrower
+        // slice (0 < confidence < 1). "transfers" matches any pair
+        // (suggested or confirmed) — the user wants to see transfer
+        // rows in either state.
+        if (!matchesAnySelectedType(e)) return false;
 
         if (!isInvestment && !e.label.budget_id && !section_id && !category_id) {
           const account = accounts.get(e.account_id);
@@ -243,7 +270,8 @@ export const TransactionsPage = () => {
     splitTransactions,
     accounts,
     viewDate,
-    type,
+    types,
+    transfers,
     budgets,
     categories,
     institutions,
@@ -335,7 +363,7 @@ export const TransactionsPage = () => {
   return (
     <div className="TransactionsPage">
       <TransactionsPageTitle
-        filters={{ type, account, budget, section, category }}
+        filters={{ types, account, budget, section, category }}
         sorter={sorter}
         onChangeSearchValue={setSearchValue}
       />

--- a/src/client/pages/TransactionsPage/index.tsx
+++ b/src/client/pages/TransactionsPage/index.tsx
@@ -134,7 +134,15 @@ export const TransactionsPage = () => {
         }
         if (t === "suggested") return isSuggestedLabel(e);
         if (t === "transfers") {
-          return !!transfers.getByTransactionId(e.transaction_id);
+          // Only whole Transactions participate in transfer pairs. A
+          // SplitTransaction inherits its parent's transaction_id, so an
+          // unguarded lookup would resolve the PARENT's pair and leak split
+          // rows into the Transfers view — same guard the render path uses
+          // (TransactionsTable/index.tsx, TransactionRow.tsx).
+          return (
+            e instanceof Transaction &&
+            !!transfers.getByTransactionId(e.transaction_id)
+          );
         }
         return false;
       });

--- a/src/client/pages/TransactionsPage/index.tsx
+++ b/src/client/pages/TransactionsPage/index.tsx
@@ -20,7 +20,6 @@ import {
   InvestmentTransactionHeaders,
   TransactionHeaders,
   TransactionsPageTitle,
-  TransactionsPageType,
   TransactionsTable,
   parseTransactionsTypes,
 } from "client/components";
@@ -67,24 +66,20 @@ export const TransactionsPage = () => {
 
   const [searchValue, setSearchValue] = useState("");
 
-  let types: TransactionsPageType[];
-  let account_id: string;
-  let budget_id: string;
-  let section_id: string;
-  let category_id: string;
-  if (path === PATH.TRANSACTIONS || screenType !== ScreenType.Narrow) {
-    types = parseTransactionsTypes(params.get("transactions_type"));
-    account_id = params.get("account_id") || "";
-    budget_id = params.get("budget_id") || "";
-    section_id = params.get("section_id") || "";
-    category_id = params.get("category_id") || "";
-  } else {
-    types = parseTransactionsTypes(incomingParams.get("transactions_type"));
-    account_id = incomingParams.get("account_id") || "";
-    budget_id = incomingParams.get("budget_id") || "";
-    section_id = incomingParams.get("section_id") || "";
-    category_id = incomingParams.get("category_id") || "";
-  }
+  // Read params from the active path's URLSearchParams — same source
+  // the rest of the page already reads from. Parsing the
+  // `transactions_type` CSV through useMemo keyed on the raw string
+  // (a primitive) so re-renders triggered by unrelated state changes
+  // don't blow the `filteredAndSorted` useMemo's cache via array
+  // reference instability.
+  const activeParams =
+    path === PATH.TRANSACTIONS || screenType !== ScreenType.Narrow ? params : incomingParams;
+  const typesRaw = activeParams.get("transactions_type");
+  const types = useMemo(() => parseTransactionsTypes(typesRaw), [typesRaw]);
+  const account_id = activeParams.get("account_id") || "";
+  const budget_id = activeParams.get("budget_id") || "";
+  const section_id = activeParams.get("section_id") || "";
+  const category_id = activeParams.get("category_id") || "";
 
   const account = accounts.get(account_id);
   const budget = budgets.get(budget_id);
@@ -125,11 +120,9 @@ export const TransactionsPage = () => {
 
     // Multi-choice OR: an entry passes the type filter if it matches
     // ANY of the selected types (empty selection = no type filter).
-    // Investment transactions never participate in transfer pairs, so
-    // a "transfers"-only selection produces an empty investment list.
-    const matchesAnySelectedType = (
-      e: Transaction | SplitTransaction | InvestmentTransaction,
-    ): boolean => {
+    // The label/transfer types apply to regular Transactions /
+    // SplitTransactions; the sign types apply to everything.
+    const matchesAnySelectedType = (e: Transaction | SplitTransaction): boolean => {
       if (!types.length) return true;
       return types.some((t) => {
         if (t === "deposits") return e.amount < 0;
@@ -141,13 +134,23 @@ export const TransactionsPage = () => {
         }
         if (t === "suggested") return isSuggestedLabel(e);
         if (t === "transfers") {
-          // Investment transactions can't be in a pair; the detection
-          // engine only pairs Plaid `transactions` rows.
-          if (e instanceof InvestmentTransaction) return false;
           return !!transfers.getByTransactionId(e.transaction_id);
         }
         return false;
       });
+    };
+
+    // Investment transactions don't carry category labels and don't
+    // participate in transfer pairs, so only the sign filters
+    // (deposits / expenses) are meaningful. Other selected types are
+    // no-ops on the investment branch — same as pre-PR behavior where
+    // the investment branch only checked deposits/expenses and let
+    // every other type fall through as a no-op.
+    const matchesAnySelectedInvestmentType = (e: InvestmentTransaction): boolean => {
+      if (!types.length) return true;
+      const signTypes = types.filter((t) => t === "deposits" || t === "expenses");
+      if (!signTypes.length) return true;
+      return signTypes.some((t) => (t === "deposits" ? e.amount < 0 : e.amount > 0));
     };
 
     if (isInvestment) {
@@ -158,7 +161,7 @@ export const TransactionsPage = () => {
         const transactionDate = new LocalDate(e.date);
         const within = viewDate.has(transactionDate);
         if (!within) return false;
-        if (!matchesAnySelectedType(e)) return false;
+        if (!matchesAnySelectedInvestmentType(e)) return false;
         return isSubset(e, filters);
       });
 


### PR DESCRIPTION
## Summary

The TransactionsPage title selector becomes a multi-choice list (each filter toggles in/out independently) and gains a **Transfers** option.

| Filter | Matches |
|---|---|
| All Transactions | (no selection — clears every filter) |
| Unsorted Transactions | category_confidence !== 1 |
| Suggested Transactions | 0 < category_confidence < 1 |
| Deposits | amount < 0 |
| Expenses | amount > 0 |
| **Transfers** (new) | transaction is in ANY transfer pair (suggested or confirmed) |

Selecting multiple combines with **OR** semantics — `expenses + transfers` shows all expenses plus all transfer rows.

## URL shape

The `transactions_type` URL param is now a comma-separated list:

- `?transactions_type=expenses` — single filter (same as before)
- `?transactions_type=expenses,transfers` — multi-filter
- no param — "All Transactions" (no filter)

Backward-compatible with existing callers (BudgetDetailPage's `transactions_type=unsorted` link still works — a single value is a valid CSV).

## Display

- 0 selected → "All Transactions"
- 1 selected → existing label ("Expenses", "Transfers", …)
- 2+ selected → comma-joined labels

## Notes

- Investment transactions never participate in transfer pairs (the detection engine only pairs Plaid `transactions` rows), so a "transfers"-only selection produces an empty investment list — intentional.
- Sort-preference storage key now derives from the joined types list so e.g. an "expenses" sort doesn't collide with an "expenses,transfers" sort.
- Exports `parseTransactionsTypes(raw)` helper for callers that need to parse the URL param themselves; unknown values are dropped.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test src/server` — 630 / 630 pass
- [ ] Sandbox E2E:
  - Open the transactions title selector — confirm 6 options (All + 5 filters).
  - Click Transfers alone — only transfer rows render (bundled-row for confirmed pairs, individual rows with Confirm/Reject for suggested).
  - Click Expenses + Transfers — confirmed-transfer bundled rows + all positive-amount rows.
  - Click All Transactions — everything cleared.
  - BudgetDetailPage's "Unsorted" link still works as a single-value pre-selection.