### PR TITLE
feat(sync): delta-by-cursor sync, drop Cache API usage

### DIFF
--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -709,12 +709,31 @@ export const useSync = () => {
       // and per-row `remove` for tombstones. AWAITED so the cursor
       // write at the end happens AFTER IDB is durable — a page reload
       // right after sync sees the same state the cursor advertises.
-      // Save the non-time-partitioned stores explicitly — `saveAllData`
-      // would also open readwrite transactions for the 6 time-partitioned
-      // stores with empty dictionaries, which is pointless overhead.
-      // Time-partitioned stores get their own `saveTransactions` /
-      // `saveAccountSnapshots` / etc. calls below using the delta dicts.
-      await Promise.all([
+      // Cursor advances ONLY if every fetch AND every IDB write
+      // succeeded. A swallowed IDB save error here used to silently
+      // advance the cursor — the failed row stayed in React state but
+      // never landed in IDB; once the 60s cursor margin elapsed, the
+      // server stopped re-emitting it (`WHERE updated >= cursor` was
+      // inclusive of the last sync's window only). On next page reload
+      // `loadAllData` painted the prior IDB cache without the row, and
+      // it was permanently gone. So track IDB outcomes too and gate
+      // the cursor on both.
+      const fetchFailed =
+        stage1Budgets.networkFailed ||
+        stage1Charts.networkFailed ||
+        stage1Institutions.networkFailed ||
+        stage1Securities.networkFailed ||
+        stage1Transfers.networkFailed ||
+        transactionsResult.networkFailed ||
+        splitTransactionsResult.networkFailed ||
+        snapshotsResult.networkFailed;
+
+      // Non-time-partitioned stores: explicit per-store saves (avoids
+      // `saveAllData`'s 6 empty-dict transactions). Time-partitioned
+      // stores save the delta dict — the previous-sync state for any
+      // row that wasn't in this delta is already on disk from the
+      // sync that fetched it (idempotent per-id put).
+      const idbSaves: Promise<void>[] = [
         indexedDb.saveAccounts(accounts),
         indexedDb.saveHoldings(holdings),
         indexedDb.saveItems(items),
@@ -731,47 +750,40 @@ export const useSync = () => {
         indexedDb.saveAccountSnapshots(snapshotsResult.accountSnapshots),
         indexedDb.saveHoldingSnapshots(snapshotsResult.holdingSnapshots),
         indexedDb.saveSecuritySnapshots(snapshotsResult.securitySnapshots),
-      ]).catch(console.error);
-
-      // Tombstones: per-row remove. Small N (typically 0–few), so the
-      // serial overhead is negligible and there's no batched-remove
-      // helper. Awaited via Promise.all alongside the saves above
-      // would mix store transactions; keep separate for clarity.
-      const tombstoneRemovals: Promise<void>[] = [];
+      ];
       transactionsResult.tombstoneTxIds.forEach((id) => {
-        tombstoneRemovals.push(indexedDb.remove(StoreName.transactions, id));
+        idbSaves.push(indexedDb.remove(StoreName.transactions, id));
       });
       transactionsResult.tombstoneInvIds.forEach((id) => {
-        tombstoneRemovals.push(indexedDb.remove(StoreName.investmentTransactions, id));
+        idbSaves.push(indexedDb.remove(StoreName.investmentTransactions, id));
       });
       splitTransactionsResult.tombstoneSplitIds.forEach((id) => {
-        tombstoneRemovals.push(indexedDb.remove(StoreName.splitTransactions, id));
+        idbSaves.push(indexedDb.remove(StoreName.splitTransactions, id));
       });
       snapshotsResult.tombstoneAccountSnapshotIds.forEach((id) => {
-        tombstoneRemovals.push(indexedDb.remove(StoreName.accountSnapshots, id));
+        idbSaves.push(indexedDb.remove(StoreName.accountSnapshots, id));
       });
       snapshotsResult.tombstoneHoldingSnapshotIds.forEach((id) => {
-        tombstoneRemovals.push(indexedDb.remove(StoreName.holdingSnapshots, id));
+        idbSaves.push(indexedDb.remove(StoreName.holdingSnapshots, id));
       });
       snapshotsResult.tombstoneSecuritySnapshotIds.forEach((id) => {
-        tombstoneRemovals.push(indexedDb.remove(StoreName.securitySnapshots, id));
+        idbSaves.push(indexedDb.remove(StoreName.securitySnapshots, id));
       });
-      await Promise.all(tombstoneRemovals).catch(console.error);
 
-      // Cursor advances ONLY if every fetch succeeded. On any failure,
-      // leave the cursor at its previous value so the next sync's delta
-      // still spans the gap that just failed.
-      const fetchFailed =
-        stage1Budgets.networkFailed ||
-        stage1Charts.networkFailed ||
-        stage1Institutions.networkFailed ||
-        stage1Securities.networkFailed ||
-        stage1Transfers.networkFailed ||
-        transactionsResult.networkFailed ||
-        splitTransactionsResult.networkFailed ||
-        snapshotsResult.networkFailed;
+      // `allSettled` rather than `all`: a partial IDB failure
+      // shouldn't tear down the orchestrator (React state already has
+      // the data); we just need to detect the failure so the cursor
+      // stays put and the next sync re-fetches the delta.
+      const idbOutcomes = await Promise.allSettled(idbSaves);
+      const idbFailed = idbOutcomes.some((o) => {
+        if (o.status === "rejected") {
+          console.error("[useSync] IDB persist failed:", o.reason);
+          return true;
+        }
+        return false;
+      });
 
-      if (!fetchFailed) {
+      if (!fetchFailed && !idbFailed) {
         writeLastSyncedCursor(cursorForNextSync(syncStartedAt));
       }
     } catch (err) {

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -55,6 +55,17 @@ import {
 // the server returns only rows whose `updated >= cursor`. Cleared by
 // `clean()`.
 const LAST_SYNCED_CURSOR_KEY = "budget:lastSyncedCursor";
+// Old localStorage key (pre-delta-sync). Removed on first load below
+// so returning users don't carry the dead key forever.
+const LEGACY_LAST_SYNCED_AT_KEY = "budget:lastSyncedAt";
+
+const dropLegacyKeys = () => {
+  try {
+    window.localStorage.removeItem(LEGACY_LAST_SYNCED_AT_KEY);
+  } catch {
+    // no-op
+  }
+};
 
 const readLastSyncedCursor = (): string | null => {
   try {
@@ -296,20 +307,17 @@ interface FetchSnapshotsResult {
   accountSnapshots: AccountSnapshotDictionary;
   holdingSnapshots: HoldingSnapshotDictionary;
   securitySnapshots: SecuritySnapshotDictionary;
-  networkFailed: boolean;
-}
-
-interface FetchSnapshotsResultDelta extends FetchSnapshotsResult {
   tombstoneAccountSnapshotIds: Set<string>;
   tombstoneHoldingSnapshotIds: Set<string>;
   tombstoneSecuritySnapshotIds: Set<string>;
+  networkFailed: boolean;
 }
 
 const fetchSnapshots = async (
   accounts: AccountDictionary,
   cursor: string | null,
-): Promise<FetchSnapshotsResultDelta> => {
-  const result: FetchSnapshotsResultDelta = {
+): Promise<FetchSnapshotsResult> => {
+  const result: FetchSnapshotsResult = {
     accountSnapshots: new AccountSnapshotDictionary(),
     holdingSnapshots: new HoldingSnapshotDictionary(),
     securitySnapshots: new SecuritySnapshotDictionary(),
@@ -322,9 +330,7 @@ const fetchSnapshots = async (
   // Single GET against `/api/snapshots[?start-date=<cursor>]`. The
   // route's `searchSnapshots` returns user-scoped account+holding
   // snapshots (no `account-id` narrow) PLUS shared security snapshots
-  // in one response — same superset previously hand-stitched
-  // per-account-per-month with shared security as a separate fetch
-  // per month.
+  // in one response.
   const params = new URLSearchParams();
   if (cursor) params.append("start-date", cursor);
   const path = `/api/snapshots${params.toString() ? "?" + params.toString() : ""}`;
@@ -446,16 +452,25 @@ export const useSync = () => {
       // server-side writes between start and end are picked up by the
       // next sync (which uses cursor = startedAt - safety margin).
       const syncStartedAt = new Date();
+      dropLegacyKeys();
 
       const cached = await indexedDb.loadAllData().catch((err) => {
         console.error(err);
         return null;
       });
-      const cursor = readLastSyncedCursor();
+      const cursorRaw = readLastSyncedCursor();
       // Warm vs cold is gated on BOTH: a populated IDB cache AND a
       // previously-recorded cursor. Either missing → cold (full fetch,
       // no cursor on the wire).
-      const isWarm = !!cached && cached.accounts.size > 0 && cursor !== null;
+      const isWarm = !!cached && cached.accounts.size > 0 && cursorRaw !== null;
+      // Pass the cursor to delta fetches ONLY on the warm branch. The
+      // cold path must fetch the full history with no `start-date=` —
+      // if localStorage has a stale cursor (IDB cleared by quota /
+      // DevTools, or `clean()`'s clearAllData racing the next sync),
+      // sending the cursor would return only rows updated since it
+      // and the reducer's empty-base would commit a near-empty
+      // dataset to React state.
+      const cursor = isWarm ? cursorRaw : null;
 
       // ===== Stage 1: non-historical data (cheap, paints fast). =====
       // Accounts/items, budgets/sections/categories, charts,
@@ -475,22 +490,19 @@ export const useSync = () => {
       const { networkFailed: accountsFailed } = await accountsPromise;
 
       if (accountsFailed) {
-        if (isWarm && cached) {
-          // Offline / server down on a warm load — keep painted cache,
-          // clear the loading flag.
-          cached.status.isInit = true;
-          cached.status.isLoading = false;
-          cached.status.isError = false;
-          setData(cached);
-        } else {
-          setData((oldData) => {
-            const newData = new Data(oldData);
-            newData.status.isInit = true;
-            newData.status.isLoading = false;
-            newData.status.isError = true;
-            return newData;
-          });
-        }
+        // Updater form (not `setData(cached)`): the warm-path paint
+        // already committed `cached` to React state at line ~471, so
+        // a second `setData(cached)` would be `Object.is`-equal to
+        // the current state and React would bail out — stranding the
+        // loading flag we mutated to `false`. Clone via the updater
+        // so React sees a distinct reference and commits.
+        setData((oldData) => {
+          const newData = new Data(oldData);
+          newData.status.isInit = true;
+          newData.status.isLoading = false;
+          newData.status.isError = !isWarm; // online cache wins; cold = real error
+          return newData;
+        });
         return;
       }
 
@@ -538,10 +550,67 @@ export const useSync = () => {
         setData(stage1);
       }
 
-      // ===== Stage 2: time-partitioned stores via delta fetch. =====
-      // Cursor null on cold → single full GET per store. Cursor set on
-      // warm → server returns only rows whose `updated >= cursor`. The
-      // route filter is inclusive; cursor includes a safety margin so
+      // ===== Stage 2: cold-only recent-window paint. =====
+      // The unbounded fetch below scales with the user's full history
+      // (3s for ~6k transactions, more for larger sets). To keep the
+      // first-historical paint fast on cold load, fetch the recent 2
+      // months first via `start-date=<2-months-ago>` and paint that
+      // window. The unbounded Stage 3 fetch fills in older months
+      // after. On warm load this is skipped — the cached paint
+      // already covered it.
+      if (!isWarm) {
+        const twoMonthsAgo = new Date(
+          syncStartedAt.getTime() - 60 * 24 * 60 * 60 * 1000,
+        ).toISOString();
+        const [recentTx, recentSplits, recentSnaps] = await Promise.all([
+          fetchTransactions(twoMonthsAgo),
+          fetchSplitTransactions(twoMonthsAgo),
+          fetchSnapshots(accounts, twoMonthsAgo),
+        ]);
+        setData((oldData) => {
+          const next = new Data(oldData);
+          next.transactions = new TransactionDictionary(oldData.transactions);
+          recentTx.transactions.forEach((t, id) => next.transactions.set(id, t));
+          recentTx.tombstoneTxIds.forEach((id) => next.transactions.delete(id));
+          next.investmentTransactions = new InvestmentTransactionDictionary(
+            oldData.investmentTransactions,
+          );
+          recentTx.investmentTransactions.forEach((t, id) =>
+            next.investmentTransactions.set(id, t),
+          );
+          recentTx.tombstoneInvIds.forEach((id) => next.investmentTransactions.delete(id));
+          next.splitTransactions = new SplitTransactionDictionary(oldData.splitTransactions);
+          recentSplits.splitTransactions.forEach((t, id) =>
+            next.splitTransactions.set(id, t),
+          );
+          recentSplits.tombstoneSplitIds.forEach((id) => next.splitTransactions.delete(id));
+          next.accountSnapshots = new AccountSnapshotDictionary(oldData.accountSnapshots);
+          recentSnaps.accountSnapshots.forEach((s, id) => next.accountSnapshots.set(id, s));
+          recentSnaps.tombstoneAccountSnapshotIds.forEach((id) =>
+            next.accountSnapshots.delete(id),
+          );
+          next.holdingSnapshots = new HoldingSnapshotDictionary(oldData.holdingSnapshots);
+          recentSnaps.holdingSnapshots.forEach((s, id) => next.holdingSnapshots.set(id, s));
+          recentSnaps.tombstoneHoldingSnapshotIds.forEach((id) =>
+            next.holdingSnapshots.delete(id),
+          );
+          next.securitySnapshots = new SecuritySnapshotDictionary(oldData.securitySnapshots);
+          recentSnaps.securitySnapshots.forEach((s, id) => next.securitySnapshots.set(id, s));
+          recentSnaps.tombstoneSecuritySnapshotIds.forEach((id) =>
+            next.securitySnapshots.delete(id),
+          );
+          next.status.isInit = true;
+          next.status.isLoading = true;
+          next.status.isError = false;
+          return next;
+        });
+      }
+
+      // ===== Stage 3: time-partitioned stores via delta/full fetch. =====
+      // Cursor null on cold → unbounded GET (fills in older months
+      // after Stage 2 painted recent ones). Cursor set on warm →
+      // server returns only rows whose `updated >= cursor`. The route
+      // filter is inclusive; cursor includes a safety margin so
       // borderline rows aren't missed at the cost of a small per-sync
       // re-fetch of the last minute's changes.
       const [
@@ -554,21 +623,20 @@ export const useSync = () => {
         fetchSnapshots(accounts, cursor),
       ]);
 
-      // ===== Stage 3: apply (warm path: in-place merge on `oldData`;
-      //                       cold path: drop into a fresh Data). =====
+      // ===== Stage 4: apply (warm + cold: in-place merge on `oldData`). =====
       //
-      // Warm: existing state stays — added/modified rows overwrite their
+      // Existing state stays — added/modified rows overwrite their
       // ids in the cloned dictionary; tombstoned ids are explicitly
       // deleted from the clone. This is the design-doc rule (the calc
       // depends on prior state, so the orchestrator can't just `new
       // Data(refreshed)`).
       //
-      // Cold: no prior state to merge with; the delta result IS the
-      // full data.
+      // On cold load, the prior state from Stage 2's recent-window
+      // paint is already in oldData; Stage 4's unbounded fetch
+      // overlays the same recent rows (idempotent) and fills in the
+      // older months.
       setData((oldData) => {
-        const base = isWarm && oldData.accounts.size > 0 ? oldData : new Data();
-
-        const next = new Data(base);
+        const next = new Data(oldData);
         next.accounts = accounts;
         next.holdings = holdings;
         next.items = items;
@@ -579,6 +647,7 @@ export const useSync = () => {
         next.institutions = institutions;
         next.securities = securities;
         next.transfers = transfers;
+        const base = oldData;
 
         // Apply transactions delta: clone the existing dict, set
         // added/modified, delete tombstoned ids.
@@ -628,16 +697,12 @@ export const useSync = () => {
         return next;
       });
 
-      // ===== Stage 4: persist + advance the cursor. =====
+      // ===== Stage 5: persist + advance the cursor. =====
       //
       // Per-store batched `saveMany` writes for added/modified entries
       // and per-row `remove` for tombstones. AWAITED so the cursor
       // write at the end happens AFTER IDB is durable — a page reload
       // right after sync sees the same state the cursor advertises.
-      // (Fire-and-forget here would race the next warm boot's
-      // `loadAllData` against the in-flight writes; the test that
-      // surfaced this caught a partial cold-sync state being treated
-      // as the warm-load baseline.)
       const refreshedStage1 = new Data({
         accounts,
         items,

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -1,18 +1,8 @@
 import { useCallback } from "react";
-import {
-  ViewDate,
-  getDateString,
-  THIRTY_DAYS,
-  JSONInstitution,
-  JSONSnapshotData,
-  LocalDate,
-  Queue,
-} from "common";
+import { JSONInstitution, JSONSnapshotData } from "common";
 import {
   BudgetsGetResponse,
   TransactionsGetResponse,
-  OldestTransactionDateGetResponse,
-  ApiResponse,
   AccountsGetResponse,
   SplitTransactionsGetResponse,
   ChartsGetResponse,
@@ -35,7 +25,6 @@ import {
   SecuritySnapshot,
   useAppContext,
   call,
-  cachedCall,
   BudgetDictionary,
   SectionDictionary,
   CategoryDictionary,
@@ -61,186 +50,113 @@ import {
   TransferDictionary,
 } from "client";
 
-// Browsers cap concurrent fetches per origin (~6 on HTTP/1.1) and queueing
-// hundreds of `fetch`/`cache.add` calls at once triggers
-// ERR_INSUFFICIENT_RESOURCES — which silently aborts `cache.add` and defeats
-// the Cache API benefit for older months. Gate snapshot fetches through a
-// shared Queue so at most 6 are in flight at any time.
-const snapshotFetchQueue = new Queue({ maxInflight: 6 });
+// Cursor key: ISO timestamp of the last successful sync's start, minus a
+// safety margin. Next sync's delta fetch sends this as `start-date`, so
+// the server returns only rows whose `updated >= cursor`. Cleared by
+// `clean()`.
+const LAST_SYNCED_CURSOR_KEY = "budget:lastSyncedCursor";
 
-// Presence of the key gates warm-vs-cold: a known previous sync means
-// the IndexedDB cache is trustworthy enough to paint upfront. The value
-// drives the warm path's freshness window (`recentSinceMs =
-// lastSyncedAt − FRESHNESS_WINDOW_MS`), passed to
-// fetchTransactions/fetchSnapshots so months in that window go to
-// network and older months use the browser Cache API. Absent → cold
-// (avoids the failure mode where IndexedDB has stale data without a
-// known cutoff).
-const LAST_SYNCED_AT_KEY = "budget:lastSyncedAt";
-// How far back from `lastSyncedAt` we consider "potentially stale" on
-// the client. Wider than Plaid's pending→posted restatement window
-// (commonly cited as ~14d) to also catch user labels / category
-// edits that happened on another device since the last sync.
-const FRESHNESS_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
-
-const readLastSyncedAt = (): Date | null => {
+const readLastSyncedCursor = (): string | null => {
   try {
-    const raw = window.localStorage.getItem(LAST_SYNCED_AT_KEY);
+    const raw = window.localStorage.getItem(LAST_SYNCED_CURSOR_KEY);
     if (!raw) return null;
     const t = Date.parse(raw);
     if (!Number.isFinite(t)) return null;
-    // Reject future timestamps (clock skew between sessions / device wake) —
-    // treat them as missing so we err on the side of a wider refresh.
+    // Future timestamps (clock skew between sessions) → treat as
+    // missing so the next sync widens to a full fetch.
     if (t > Date.now()) return null;
-    return new Date(t);
+    return raw;
   } catch {
     return null;
   }
 };
 
-const writeLastSyncedAt = (date: Date) => {
+const writeLastSyncedCursor = (cursor: string) => {
   try {
-    window.localStorage.setItem(LAST_SYNCED_AT_KEY, date.toISOString());
+    window.localStorage.setItem(LAST_SYNCED_CURSOR_KEY, cursor);
   } catch {
     // localStorage can throw in private-mode iOS / over quota. Best
-    // effort; next warm load will fall back to cold path, which is
-    // correct but slower.
+    // effort; next sync without a cursor falls through to the cold
+    // path, which is correct but slower.
   }
 };
 
-const removeLastSyncedAt = () => {
+const removeLastSyncedCursor = () => {
   try {
-    window.localStorage.removeItem(LAST_SYNCED_AT_KEY);
+    window.localStorage.removeItem(LAST_SYNCED_CURSOR_KEY);
   } catch {
     // no-op
   }
 };
 
-const getOldestTransactionDate = async (): Promise<Date | undefined> => {
-  const response = await call
-    .get<OldestTransactionDateGetResponse>("/api/oldest-transaction-date")
-    .catch(console.error);
-  if (!response?.body) return undefined;
-  return response.body ? new LocalDate(response.body) : undefined;
-};
+// FE wall-clock minus a safety margin is the next-sync cursor. Sub-row
+// `updated` timestamps aren't on every JSON wire type today, so per-row
+// max(updated) can't drive the cursor without widening common/models.
+// Margin trades a small per-sync re-fetch of the last minute's changes
+// for robustness against client/server clock skew — a sync that picks
+// `Date.now()` as the cursor would silently miss any row whose
+// server-side `updated` lands behind the FE's clock view of "now".
+const CURSOR_SAFETY_MARGIN_MS = 60 * 1000;
+const cursorForNextSync = (syncStartedAt: Date): string =>
+  new Date(syncStartedAt.getTime() - CURSOR_SAFETY_MARGIN_MS).toISOString();
 
+/**
+ * Delta payload for transactions + investment transactions: a single
+ * GET `/api/transactions[?start-date=<cursor>]` carries both the
+ * added/modified rows and any tombstones (`is_deleted=true`) emitted
+ * since the cursor. The orchestrator applies them in-place to the
+ * existing `data.transactions` / `data.investmentTransactions` via
+ * `setData((old) => …)` and mirrors to IDB per row — no
+ * `clearAllData → saveAllData` step. Cursor null = full fetch (cold).
+ */
 interface FetchTransactionsResult {
+  /** Active rows arriving in the response. Constructed clients of
+   *  `Transaction` / `InvestmentTransaction` ready to drop into the
+   *  context dictionaries. */
   transactions: TransactionDictionary;
   investmentTransactions: InvestmentTransactionDictionary;
+  /** Soft-deleted row ids — caller must `delete` from context dicts
+   *  AND `indexedDb.remove(...)` per id for IDB durability. */
+  tombstoneTxIds: Set<string>;
+  tombstoneInvIds: Set<string>;
   networkFailed: boolean;
 }
 
-interface FetchRange {
-  /** Inclusive lower bound on the month start date — loop stops when viewDate < this. */
-  from: Date;
-  /** Exclusive upper bound on the month start date — loop starts at this month-1. */
-  until: Date;
-}
-
-const fetchTransactions = async (
-  accounts: AccountDictionary,
-  range: FetchRange,
-  // Months whose end falls at or after `recentSinceMs` bypass the browser
-  // Cache API (call) and go to network; older months use cachedCall.
-  // Default mirrors the original "last 30 days from now" semantic so the
-  // cold path keeps current behavior. The warm path overrides it with
-  // `lastSyncedAt − 30d` so the freshness threshold tracks the user's
-  // own gap between visits, not wall clock.
-  recentSinceMs: number = Date.now() - THIRTY_DAYS,
-): Promise<FetchTransactionsResult> => {
+const fetchTransactions = async (cursor: string | null): Promise<FetchTransactionsResult> => {
   const result: FetchTransactionsResult = {
     transactions: new TransactionDictionary(),
     investmentTransactions: new InvestmentTransactionDictionary(),
+    tombstoneTxIds: new Set(),
+    tombstoneInvIds: new Set(),
     networkFailed: false,
   };
 
-  // Tombstones collected from any month's response. Applied at the end
-  // so eviction wins regardless of which parallel response arrived
-  // last — mirrors the snapshot-side handling and avoids a stale
-  // `cachedCall` response re-adding a row the live query already
-  // marked deleted.
-  const tombstones = {
-    transaction: new Set<string>(),
-    investmentTransaction: new Set<string>(),
-  };
-
-  const transactionsApiPath = "/api/transactions";
-  const viewDate = new ViewDate("month");
-  // Walk back to the first month whose start < range.until.
-  while (viewDate.getStartDate() >= range.until) viewDate.previous();
-
-  const promises: Promise<void>[] = [];
-
-  while (range.from < viewDate.getStartDate()) {
-    accounts?.forEach((a) => {
-      const params = new URLSearchParams();
-      const startDate = viewDate.getStartDate();
-      const endDate = viewDate.clone().next().getStartDate();
-      params.append("start-date", getDateString(startDate));
-      params.append("end-date", getDateString(endDate));
-      params.append("account-id", a.id);
-      // Route hardcodes `includeDeleted: true` (matches snapshots) — the
-      // soft-deleted rows arrive as tombstones in the response and are
-      // dropped from `result.transactions` / IDB below.
-      const path = transactionsApiPath + "?" + params.toString();
-      const isRecent = endDate.getTime() >= recentSinceMs;
-
-      const fetchTransactionsForAccount = async () => {
-        let response: ApiResponse<TransactionsGetResponse> | void;
-        if (isRecent) {
-          response = await call.get<TransactionsGetResponse>(path).catch(console.error);
-        } else {
-          response = await cachedCall<TransactionsGetResponse>(path).catch(console.error);
-        }
-        if (!response || response.status === "error") {
-          result.networkFailed = true;
-          return;
-        }
-        if (!response.body) return;
-
-        const { transactions, investmentTransactions } = response.body;
-        transactions.forEach((t) => {
-          if (t.is_deleted) {
-            tombstones.transaction.add(t.transaction_id);
-            return;
-          }
-          result.transactions.set(t.transaction_id, new Transaction(t));
-        });
-        investmentTransactions.forEach((t) => {
-          if (t.is_deleted) {
-            tombstones.investmentTransaction.add(t.investment_transaction_id);
-            return;
-          }
-          result.investmentTransactions.set(
-            t.investment_transaction_id,
-            new InvestmentTransaction(t),
-          );
-        });
-      };
-      const promise = fetchTransactionsForAccount();
-
-      promises.push(promise);
-    });
-
-    viewDate.previous();
+  const params = new URLSearchParams();
+  if (cursor) params.append("start-date", cursor);
+  // Route hardcodes `includeDeleted: true`; soft-deleted rows arrive
+  // as tombstones (is_deleted=true).
+  const path = `/api/transactions${params.toString() ? "?" + params.toString() : ""}`;
+  const response = await call.get<TransactionsGetResponse>(path).catch(console.error);
+  if (!response || response.status === "error") {
+    result.networkFailed = true;
+    return result;
   }
+  if (!response.body) return result;
 
-  await Promise.all(promises);
-
-  // Apply tombstones after every parallel ingest has landed — same
-  // semantics as the snapshot path. The eager `indexedDb.remove` is
-  // load-bearing for the partial-failure branch in `useSync` (line
-  // ~671): when any fetch fails, `clearAllData → saveAllData` is
-  // skipped, so the only thing that drops the tombstoned row from IDB
-  // is this explicit remove. (The happy-path branches still
-  // clear-then-save from `result`, which would also drop it.)
-  tombstones.transaction.forEach((id) => {
-    result.transactions.delete(id);
-    indexedDb.remove(StoreName.transactions, id).catch(console.error);
+  const { transactions, investmentTransactions } = response.body;
+  transactions.forEach((t) => {
+    if (t.is_deleted) {
+      result.tombstoneTxIds.add(t.transaction_id);
+      return;
+    }
+    result.transactions.set(t.transaction_id, new Transaction(t));
   });
-  tombstones.investmentTransaction.forEach((id) => {
-    result.investmentTransactions.delete(id);
-    indexedDb.remove(StoreName.investmentTransactions, id).catch(console.error);
+  investmentTransactions.forEach((t) => {
+    if (t.is_deleted) {
+      result.tombstoneInvIds.add(t.investment_transaction_id);
+      return;
+    }
+    result.investmentTransactions.set(t.investment_transaction_id, new InvestmentTransaction(t));
   });
 
   return result;
@@ -248,45 +164,36 @@ const fetchTransactions = async (
 
 interface FetchSplitTransactionsResult {
   splitTransactions: SplitTransactionDictionary;
+  tombstoneSplitIds: Set<string>;
   networkFailed: boolean;
 }
 
-const fetchSplitTransactions = async (): Promise<FetchSplitTransactionsResult> => {
-  // Single unbounded GET — splits are small (well under any pagination
-  // threshold for current users) and the per-month-per-account paged
-  // shape from the initial draft of this PR introduced an FE coverage
-  // regression under high concurrency (1100+ in-flight fetches dropped
-  // rows across the response stream — see PR #522 thread). The
-  // `is_deleted` flag still rides on every row so the FE can branch into
-  // active vs tombstone here, matching the snapshot path's eviction
-  // semantics. The server still supports the paged shape (route + repo
-  // accept startDate/endDate/account-id) so a future delta-cursor design
-  // can adopt pagination uniformly across all three stores at once.
+const fetchSplitTransactions = async (
+  cursor: string | null,
+): Promise<FetchSplitTransactionsResult> => {
   const result: FetchSplitTransactionsResult = {
     splitTransactions: new SplitTransactionDictionary(),
+    tombstoneSplitIds: new Set(),
     networkFailed: false,
   };
 
-  const tombstones = new Set<string>();
+  const params = new URLSearchParams();
+  if (cursor) params.append("start-date", cursor);
+  const path = `/api/split-transactions${params.toString() ? "?" + params.toString() : ""}`;
 
-  const response = await call
-    .get<SplitTransactionsGetResponse>("/api/split-transactions")
-    .catch(console.error);
+  const response = await call.get<SplitTransactionsGetResponse>(path).catch(console.error);
   if (!response || response.status === "error") {
     result.networkFailed = true;
     return result;
   }
+  if (!response.body) return result;
 
-  response.body?.forEach((t) => {
+  response.body.forEach((t) => {
     if (t.is_deleted) {
-      tombstones.add(t.split_transaction_id);
+      result.tombstoneSplitIds.add(t.split_transaction_id);
       return;
     }
     result.splitTransactions.set(t.split_transaction_id, new SplitTransaction(t));
-  });
-
-  tombstones.forEach((id) => {
-    indexedDb.remove(StoreName.splitTransactions, id).catch(console.error);
   });
 
   return result;
@@ -392,36 +299,48 @@ interface FetchSnapshotsResult {
   networkFailed: boolean;
 }
 
+interface FetchSnapshotsResultDelta extends FetchSnapshotsResult {
+  tombstoneAccountSnapshotIds: Set<string>;
+  tombstoneHoldingSnapshotIds: Set<string>;
+  tombstoneSecuritySnapshotIds: Set<string>;
+}
+
 const fetchSnapshots = async (
   accounts: AccountDictionary,
-  range: FetchRange,
-  // Same semantic as `fetchTransactions`: months whose end is at or after
-  // `recentSinceMs` go to network; older months use cachedCall.
-  recentSinceMs: number = Date.now() - THIRTY_DAYS,
-): Promise<FetchSnapshotsResult> => {
-  const result: FetchSnapshotsResult = {
+  cursor: string | null,
+): Promise<FetchSnapshotsResultDelta> => {
+  const result: FetchSnapshotsResultDelta = {
     accountSnapshots: new AccountSnapshotDictionary(),
     holdingSnapshots: new HoldingSnapshotDictionary(),
     securitySnapshots: new SecuritySnapshotDictionary(),
+    tombstoneAccountSnapshotIds: new Set(),
+    tombstoneHoldingSnapshotIds: new Set(),
+    tombstoneSecuritySnapshotIds: new Set(),
     networkFailed: false,
   };
 
-  // Tombstones collected from any month's response. Applied at the end
-  // so the eviction wins regardless of which parallel response arrived
-  // last — without this, a tombstone from June's live query loses to a
-  // cached older-month response that still has the row as active.
-  const tombstones = {
-    account: new Set<string>(),
-    holding: new Set<string>(),
-    security: new Set<string>(),
-  };
+  // Single GET against `/api/snapshots[?start-date=<cursor>]`. The
+  // route's `searchSnapshots` returns user-scoped account+holding
+  // snapshots (no `account-id` narrow) PLUS shared security snapshots
+  // in one response — same superset previously hand-stitched
+  // per-account-per-month with shared security as a separate fetch
+  // per month.
+  const params = new URLSearchParams();
+  if (cursor) params.append("start-date", cursor);
+  const path = `/api/snapshots${params.toString() ? "?" + params.toString() : ""}`;
+  const response = await call.get<SnapshotsGetResponse>(path).catch(console.error);
+  if (!response || response.status === "error") {
+    result.networkFailed = true;
+    return result;
+  }
+  if (!response.body) return result;
 
-  const ingestSnapshot = (snapshot: JSONSnapshotData) => {
+  response.body.forEach((snapshot: JSONSnapshotData) => {
     if (snapshot.snapshot.is_deleted) {
       const id = snapshot.snapshot.snapshot_id;
-      if ("account" in snapshot) tombstones.account.add(id);
-      else if ("holding" in snapshot) tombstones.holding.add(id);
-      else if ("security" in snapshot) tombstones.security.add(id);
+      if ("account" in snapshot) result.tombstoneAccountSnapshotIds.add(id);
+      else if ("holding" in snapshot) result.tombstoneHoldingSnapshotIds.add(id);
+      else if ("security" in snapshot) result.tombstoneSecuritySnapshotIds.add(id);
       return;
     }
     if ("account" in snapshot) {
@@ -436,97 +355,6 @@ const fetchSnapshots = async (
       const newSnapshot = new SecuritySnapshot(snapshot);
       result.securitySnapshots.set(newSnapshot.snapshot.id, newSnapshot);
     }
-  };
-
-  // Mirror fetchTransactions (Closes #323): slice the full date window into
-  // month-sized chunks, fetched per-account for user-scoped snapshots and
-  // once-per-month for shared security snapshots. Months whose end falls
-  // at or after `recentSinceMs` bypass the browser Cache API and go to
-  // network; older months use cachedCall.
-  const snapshotsApiPath = "/api/snapshots";
-  const viewDate = new ViewDate("month");
-  while (viewDate.getStartDate() >= range.until) viewDate.previous();
-
-  const promises: Promise<void>[] = [];
-
-  while (range.from < viewDate.getStartDate()) {
-    const monthStart = viewDate.getStartDate();
-    const monthEnd = viewDate.clone().next().getStartDate();
-    const startStr = getDateString(monthStart);
-    const endStr = getDateString(monthEnd);
-    const isRecent = monthEnd.getTime() >= recentSinceMs;
-
-    accounts?.forEach((a) => {
-      const params = new URLSearchParams();
-      params.append("start-date", startStr);
-      params.append("end-date", endStr);
-      params.append("account-id", a.id);
-      const path = snapshotsApiPath + "?" + params.toString();
-
-      promises.push(
-        snapshotFetchQueue.add(async () => {
-          let response: ApiResponse<SnapshotsGetResponse> | void;
-          if (isRecent) {
-            response = await call.get<SnapshotsGetResponse>(path).catch(console.error);
-          } else {
-            response = await cachedCall<SnapshotsGetResponse>(path).catch(console.error);
-          }
-          if (!response || response.status === "error") {
-            result.networkFailed = true;
-            return;
-          }
-          response.body?.forEach(ingestSnapshot);
-        }),
-      );
-    });
-
-    // Security snapshots are user-id=NULL (shared) and aren't returned by
-    // the account-scoped queries above. One slice per month, cached for
-    // older months — keeps the per-account URL space cleanly cache-keyed
-    // and avoids re-pulling the full price history on every page load.
-    const securityParams = new URLSearchParams();
-    securityParams.append("start-date", startStr);
-    securityParams.append("end-date", endStr);
-    securityParams.append("snapshot-type", "security");
-    const securityPath = snapshotsApiPath + "?" + securityParams.toString();
-
-    promises.push(
-      snapshotFetchQueue.add(async () => {
-        let response: ApiResponse<SnapshotsGetResponse> | void;
-        if (isRecent) {
-          response = await call.get<SnapshotsGetResponse>(securityPath).catch(console.error);
-        } else {
-          response = await cachedCall<SnapshotsGetResponse>(securityPath).catch(console.error);
-        }
-        if (!response || response.status === "error") {
-          result.networkFailed = true;
-          return;
-        }
-        response.body?.forEach(ingestSnapshot);
-      }),
-    );
-
-    viewDate.previous();
-  }
-
-  await Promise.all(promises);
-
-  // Apply tombstones after every parallel ingest has landed: drop the
-  // id from the dict (in case a stale cachedCall response re-added it)
-  // AND evict from IDB. Order matters — the dict-delete must happen
-  // before the consumer hands the dict to `saveAllData`, which would
-  // otherwise persist the stale row right back.
-  tombstones.account.forEach((id) => {
-    result.accountSnapshots.delete(id);
-    indexedDb.remove(StoreName.accountSnapshots, id).catch(console.error);
-  });
-  tombstones.holding.forEach((id) => {
-    result.holdingSnapshots.delete(id);
-    indexedDb.remove(StoreName.holdingSnapshots, id).catch(console.error);
-  });
-  tombstones.security.forEach((id) => {
-    result.securitySnapshots.delete(id);
-    indexedDb.remove(StoreName.securitySnapshots, id).catch(console.error);
   });
 
   return result;
@@ -563,9 +391,9 @@ const fetchInstitutions = async (accounts: AccountDictionary): Promise<FetchInst
   };
   const promises = accounts.toArray().map(async ({ institution_id }) => {
     if (institution_id === "Unknown") return;
-    const response = await cachedCall<JSONInstitution>(
-      `/api/institution?id=${institution_id}`,
-    ).catch(console.error);
+    const response = await call
+      .get<JSONInstitution>(`/api/institution?id=${institution_id}`)
+      .catch(console.error);
     if (!response || response.status === "error") {
       result.networkFailed = true;
       return;
@@ -611,184 +439,75 @@ export const useSync = () => {
     });
 
     try {
-      // Read IndexedDB synchronously up front. On a warm load (any cached
-      // accounts) we paint from cache immediately and only refresh the
-      // current month — full Stage 1/2/3 slicing is reserved for cold
-      // load (no IndexedDB). The previous fire-and-forget then-callback
-      // raced with Stage 1's setData(new Data({...})) which carries no
-      // transactions/snapshots, blowing away the cached history one
-      // frame after it painted (#399).
+      // Snapshot the wall-clock at sync start. Used to compute the next
+      // cursor *if* every fetch succeeds, so a failed sync doesn't
+      // advance the cursor and miss the rows that landed during the
+      // failed window. Captured here, not at the end, so concurrent
+      // server-side writes between start and end are picked up by the
+      // next sync (which uses cursor = startedAt - safety margin).
+      const syncStartedAt = new Date();
+
       const cached = await indexedDb.loadAllData().catch((err) => {
         console.error(err);
         return null;
       });
-      const lastSyncedAt = readLastSyncedAt();
-      // Warm-load preconditions: cached data with at least one account,
-      // AND a previously persisted sync timestamp. The timestamp drives
-      // the warm path's freshness window (`recentSinceMs =
-      // lastSyncedAt − 30d`) which decides per-month whether to go to
-      // network or use the browser Cache API. Absent timestamp →
-      // cache is opaque, fall through to cold.
-      const isWarm = !!cached && cached.accounts.size > 0 && lastSyncedAt !== null;
+      const cursor = readLastSyncedCursor();
+      // Warm vs cold is gated on BOTH: a populated IDB cache AND a
+      // previously-recorded cursor. Either missing → cold (full fetch,
+      // no cursor on the wire).
+      const isWarm = !!cached && cached.accounts.size > 0 && cursor !== null;
 
-      if (isWarm && cached && lastSyncedAt) {
-        const accountsPromise = fetchAccounts();
-        const { networkFailed } = await accountsPromise;
-
-        if (networkFailed) {
-          // Offline / server down — use cache as-is, no refresh.
-          cached.status.isInit = true;
-          cached.status.isLoading = false;
-          cached.status.isError = false;
-          setData(cached);
-          return;
-        }
-
-        // Paint from cache immediately; flag still-loading so the UI
-        // can show a refresh indicator while the full fetch settles.
+      // ===== Stage 1: non-historical data (cheap, paints fast). =====
+      // Accounts/items, budgets/sections/categories, charts,
+      // institutions, securities, transfers. None of these are
+      // time-partitioned. Refreshed on every sync (warm + cold).
+      //
+      // For warm load, we paint cached state first so the UI doesn't
+      // flicker between cache and the refreshed view of Stage 1.
+      if (isWarm && cached) {
         cached.status.isInit = true;
         cached.status.isLoading = true;
         cached.status.isError = false;
         setData(cached);
+      }
 
-        const { accounts, items, holdings } = await accountsPromise;
+      const accountsPromise = fetchAccounts();
+      const { networkFailed: accountsFailed } = await accountsPromise;
 
-        // Full-history fetch (`[oldestDate or 3-months-ago, currentMonth + 1)`)
-        // — same range the cold path covers via Stage 2 + Stage 3. The
-        // narrow freshness window from the prior warm-path design
-        // (`[lastSyncedAt − 30d, now]`) is now passed as `recentSinceMs`
-        // to drive the per-month `isRecent` decision inside
-        // fetchTransactions / fetchSnapshots: months whose end falls
-        // in that freshness window go to network (call), older months
-        // use cachedCall and come from the browser Cache API. Net effect:
-        // state always reflects the full server view, only the recent
-        // months pay network cost, the rest are essentially free.
-        const currentViewDate = new ViewDate("month");
-        const oldestDatePromise = getOldestTransactionDate();
-        const oldestDate = await oldestDatePromise;
-        const defaultFrom = currentViewDate.clone().previous().previous().previous().getStartDate();
-        const fullFrom = oldestDate && oldestDate < defaultFrom ? oldestDate : defaultFrom;
-        const fullUntil = currentViewDate.clone().next().getStartDate();
-        const fullRange: FetchRange = { from: fullFrom, until: fullUntil };
-        // Freshness window: 30 days back from the last sync. Anything
-        // newer than this is potentially-stale on the client and needs a
-        // re-fetch; anything older we trust the HTTP cache for.
-        const recentSinceMs = lastSyncedAt.getTime() - FRESHNESS_WINDOW_MS;
-
-        const [
-          budgetsResult,
-          chartsResult,
-          splitTransactionsResult,
-          transactionsResult,
-          snapshotsResult,
-          institutionsResult,
-          securitiesResult,
-          transfersResult,
-        ] = await Promise.all([
-          fetchBudgets(),
-          fetchCharts(),
-          fetchSplitTransactions(),
-          fetchTransactions(accounts, fullRange, recentSinceMs),
-          fetchSnapshots(accounts, fullRange, recentSinceMs),
-          fetchInstitutions(accounts),
-          fetchSecurities(),
-          fetchTransfers(),
-        ]);
-
-        const refreshed = new Data();
-        refreshed.accounts = accounts;
-        refreshed.holdings = holdings;
-        refreshed.securities = securitiesResult.securities;
-        refreshed.items = items;
-        refreshed.budgets = budgetsResult.budgets;
-        refreshed.sections = budgetsResult.sections;
-        refreshed.categories = budgetsResult.categories;
-        refreshed.charts = chartsResult.charts;
-        refreshed.splitTransactions = splitTransactionsResult.splitTransactions;
-        refreshed.institutions = institutionsResult.institutions;
-        refreshed.transactions = transactionsResult.transactions;
-        refreshed.investmentTransactions = transactionsResult.investmentTransactions;
-        refreshed.accountSnapshots = snapshotsResult.accountSnapshots;
-        refreshed.holdingSnapshots = snapshotsResult.holdingSnapshots;
-        refreshed.securitySnapshots = snapshotsResult.securitySnapshots;
-        refreshed.transfers = transfersResult.transfers;
-        refreshed.status.isInit = true;
-        refreshed.status.isLoading = false;
-        refreshed.status.isError = false;
-        setData(refreshed);
-
-        // If ANY of the warm-path fetches reported a network failure,
-        // don't persist the partial result to IndexedDB — the existing
-        // cache is still good; replacing it with a partial would
-        // permanently lose the dictionaries that fell through to empty.
-        // Same reason for skipping `writeLastSyncedAt` — the next warm
-        // load needs the OLD timestamp so its refresh window still spans
-        // the gap that just failed.
-        const warmFetchFailed =
-          budgetsResult.networkFailed ||
-          chartsResult.networkFailed ||
-          splitTransactionsResult.networkFailed ||
-          transactionsResult.networkFailed ||
-          snapshotsResult.networkFailed ||
-          institutionsResult.networkFailed ||
-          securitiesResult.networkFailed ||
-          transfersResult.networkFailed;
-
-        if (!warmFetchFailed) {
-          indexedDb
-            .clearAllData()
-            .then(() => indexedDb.saveAllData(refreshed))
-            .catch(console.error);
-          writeLastSyncedAt(new Date());
+      if (accountsFailed) {
+        if (isWarm && cached) {
+          // Offline / server down on a warm load — keep painted cache,
+          // clear the loading flag.
+          cached.status.isInit = true;
+          cached.status.isLoading = false;
+          cached.status.isError = false;
+          setData(cached);
+        } else {
+          setData((oldData) => {
+            const newData = new Data(oldData);
+            newData.status.isInit = true;
+            newData.status.isLoading = false;
+            newData.status.isError = true;
+            return newData;
+          });
         }
         return;
       }
 
-      // ----- Cold start (no IndexedDB) — existing Stage 1/2/3 slicing -----
-
-      const accountsPromise = fetchAccounts();
-
-      const { networkFailed } = await accountsPromise;
-
-      if (networkFailed) {
-        // Even cold-start can hit a network failure; fall back to whatever
-        // partial IndexedDB read returned (likely empty Data).
-        setData((oldData) => {
-          const newData = new Data(oldData);
-          newData.status.isInit = true;
-          newData.status.isLoading = false;
-          newData.status.isError = true;
-          return newData;
-        });
-        return;
-      }
-
-      // --- Stage 1: non-historical data (paint as soon as it lands).
-      // Accounts/items, budgets/sections/categories, charts, institutions —
-      // none of these are time-partitioned, so they finish quickly and let
-      // the UI render the navigation + summary widgets before the heavy
-      // snapshot/transaction fetches complete.
-      const oldestDatePromise = getOldestTransactionDate();
-      const budgetsPromise = fetchBudgets();
-      const chartsPromise = fetchCharts();
-      const institutionsPromise = accountsPromise.then((r) => fetchInstitutions(r.accounts));
-      const securitiesPromise = fetchSecurities();
-      const transfersPromise = fetchTransfers();
+      const { accounts, items, holdings } = await accountsPromise;
 
       const [
-        { accounts, items },
         stage1Budgets,
         stage1Charts,
         stage1Institutions,
         stage1Securities,
         stage1Transfers,
       ] = await Promise.all([
-        accountsPromise,
-        budgetsPromise,
-        chartsPromise,
-        institutionsPromise,
-        securitiesPromise,
-        transfersPromise,
+        fetchBudgets(),
+        fetchCharts(),
+        fetchInstitutions(accounts),
+        fetchSecurities(),
+        fetchTransfers(),
       ]);
       const { budgets, sections, categories } = stage1Budgets;
       const { charts } = stage1Charts;
@@ -796,153 +515,208 @@ export const useSync = () => {
       const { securities } = stage1Securities;
       const { transfers } = stage1Transfers;
 
-      const stage1 = new Data({
-        accounts,
-        items,
-        budgets,
-        sections,
-        categories,
-        charts,
-        institutions,
-        securities,
-        transfers,
-      });
-      stage1.status.isInit = true;
-      stage1.status.isLoading = true;
-      stage1.status.isError = false;
-      setData(stage1);
-
-      // --- Stage 2: the most recent 2 months of historical data.
-      // The current month + previous month covers what the active
-      // dashboard / transactions table renders by default, so paint that
-      // as soon as it's available rather than blocking on the full
-      // history. Bounds are exclusive on both ends, matching the original
-      // single-pass loop's `while (oldestDate < viewDate.getStartDate())`
-      // semantics — months M with recentFrom < M.start < recentUntil are
-      // fetched (i.e. current + previous).
-      const currentViewDate = new ViewDate("month");
-      const recentFrom = currentViewDate.clone().previous().previous().getStartDate();
-      const recentUntil = currentViewDate.clone().next().getStartDate();
-      const recentRange: FetchRange = { from: recentFrom, until: recentUntil };
-
-      const [stage2Transactions, stage2SplitTxns, stage2Snapshots] = await Promise.all([
-        fetchTransactions(accounts, recentRange),
-        fetchSplitTransactions(),
-        fetchSnapshots(accounts, recentRange),
-      ]);
-      const {
-        transactions: recentTransactions,
-        investmentTransactions: recentInvestmentTransactions,
-      } = stage2Transactions;
-      const { splitTransactions } = stage2SplitTxns;
-      const {
-        accountSnapshots: recentAccountSnapshots,
-        holdingSnapshots: recentHoldingSnapshots,
-        securitySnapshots: recentSecuritySnapshots,
-      } = stage2Snapshots;
-
-      const stage2 = new Data({
-        accounts,
-        items,
-        budgets,
-        sections,
-        categories,
-        charts,
-        institutions,
-        securities,
-        transfers,
-        transactions: recentTransactions,
-        investmentTransactions: recentInvestmentTransactions,
-        splitTransactions,
-        accountSnapshots: recentAccountSnapshots,
-        holdingSnapshots: recentHoldingSnapshots,
-        securitySnapshots: recentSecuritySnapshots,
-      });
-      stage2.status.isInit = true;
-      stage2.status.isLoading = true;
-      stage2.status.isError = false;
-      setData(stage2);
-
-      // --- Stage 3: everything older. Fetch the rest of the historical
-      // window (oldestTransactionDate → the month right before stage 2's
-      // window) and merge it into the dictionaries from stage 2.
-      // `olderUntil = 1-month-ago start` is exclusive — the older fetch
-      // covers months M with olderFrom < M.start < olderUntil, which
-      // begins one month earlier than stage 2's window so the two stages
-      // tile cleanly with no overlap and no gap.
-      const oldestDate = await oldestDatePromise;
-      const defaultFrom = currentViewDate.clone().previous().previous().previous().getStartDate();
-      const olderFrom = oldestDate && oldestDate < defaultFrom ? oldestDate : defaultFrom;
-      const olderUntil = currentViewDate.clone().previous().getStartDate();
-
-      const olderRange: FetchRange = { from: olderFrom, until: olderUntil };
-
-      const finalData = new Data({
-        accounts,
-        items,
-        budgets,
-        sections,
-        categories,
-        charts,
-        institutions,
-        securities,
-        transfers,
-        transactions: recentTransactions,
-        investmentTransactions: recentInvestmentTransactions,
-        splitTransactions,
-        accountSnapshots: recentAccountSnapshots,
-        holdingSnapshots: recentHoldingSnapshots,
-        securitySnapshots: recentSecuritySnapshots,
-      });
-
-      let stage3Transactions: FetchTransactionsResult | null = null;
-      let stage3Snapshots: FetchSnapshotsResult | null = null;
-      if (olderFrom < olderUntil) {
-        // Splits aren't paged (stage 2 already fetched the full active set
-        // in one shot), so stage 3 only covers transactions + snapshots.
-        [stage3Transactions, stage3Snapshots] = await Promise.all([
-          fetchTransactions(accounts, olderRange),
-          fetchSnapshots(accounts, olderRange),
-        ]);
-
-        stage3Transactions.transactions.forEach((t, id) => finalData.transactions.set(id, t));
-        stage3Transactions.investmentTransactions.forEach((t, id) =>
-          finalData.investmentTransactions.set(id, t),
-        );
-        stage3Snapshots.accountSnapshots.forEach((s, id) => finalData.accountSnapshots.set(id, s));
-        stage3Snapshots.holdingSnapshots.forEach((s, id) => finalData.holdingSnapshots.set(id, s));
-        stage3Snapshots.securitySnapshots.forEach((s, id) =>
-          finalData.securitySnapshots.set(id, s),
-        );
+      // On a cold load, paint Stage 1 immediately so the navigation +
+      // summary widgets render before the historical fetches finish.
+      // On warm load, the cached paint above already covered this; the
+      // delta apply below replaces what changed.
+      if (!isWarm) {
+        const stage1 = new Data({
+          accounts,
+          items,
+          holdings,
+          budgets,
+          sections,
+          categories,
+          charts,
+          institutions,
+          securities,
+          transfers,
+        });
+        stage1.status.isInit = true;
+        stage1.status.isLoading = true;
+        stage1.status.isError = false;
+        setData(stage1);
       }
 
-      finalData.status.isInit = true;
-      finalData.status.isLoading = false;
-      finalData.status.isError = false;
-      setData(finalData);
+      // ===== Stage 2: time-partitioned stores via delta fetch. =====
+      // Cursor null on cold → single full GET per store. Cursor set on
+      // warm → server returns only rows whose `updated >= cursor`. The
+      // route filter is inclusive; cursor includes a safety margin so
+      // borderline rows aren't missed at the cost of a small per-sync
+      // re-fetch of the last minute's changes.
+      const [
+        transactionsResult,
+        splitTransactionsResult,
+        snapshotsResult,
+      ] = await Promise.all([
+        fetchTransactions(cursor),
+        fetchSplitTransactions(cursor),
+        fetchSnapshots(accounts, cursor),
+      ]);
 
-      // Only persist when every cold-path fetch succeeded — same
-      // semantics as the warm path. If anything failed, leave whatever
-      // was in IndexedDB before this run alone and skip the timestamp
-      // write so the next sync still treats this gap as un-pulled.
-      const coldFetchFailed =
+      // ===== Stage 3: apply (warm path: in-place merge on `oldData`;
+      //                       cold path: drop into a fresh Data). =====
+      //
+      // Warm: existing state stays — added/modified rows overwrite their
+      // ids in the cloned dictionary; tombstoned ids are explicitly
+      // deleted from the clone. This is the design-doc rule (the calc
+      // depends on prior state, so the orchestrator can't just `new
+      // Data(refreshed)`).
+      //
+      // Cold: no prior state to merge with; the delta result IS the
+      // full data.
+      setData((oldData) => {
+        const base = isWarm && oldData.accounts.size > 0 ? oldData : new Data();
+
+        const next = new Data(base);
+        next.accounts = accounts;
+        next.holdings = holdings;
+        next.items = items;
+        next.budgets = budgets;
+        next.sections = sections;
+        next.categories = categories;
+        next.charts = charts;
+        next.institutions = institutions;
+        next.securities = securities;
+        next.transfers = transfers;
+
+        // Apply transactions delta: clone the existing dict, set
+        // added/modified, delete tombstoned ids.
+        next.transactions = new TransactionDictionary(base.transactions);
+        transactionsResult.transactions.forEach((t, id) => next.transactions.set(id, t));
+        transactionsResult.tombstoneTxIds.forEach((id) => next.transactions.delete(id));
+
+        next.investmentTransactions = new InvestmentTransactionDictionary(
+          base.investmentTransactions,
+        );
+        transactionsResult.investmentTransactions.forEach((t, id) =>
+          next.investmentTransactions.set(id, t),
+        );
+        transactionsResult.tombstoneInvIds.forEach((id) =>
+          next.investmentTransactions.delete(id),
+        );
+
+        next.splitTransactions = new SplitTransactionDictionary(base.splitTransactions);
+        splitTransactionsResult.splitTransactions.forEach((t, id) =>
+          next.splitTransactions.set(id, t),
+        );
+        splitTransactionsResult.tombstoneSplitIds.forEach((id) =>
+          next.splitTransactions.delete(id),
+        );
+
+        next.accountSnapshots = new AccountSnapshotDictionary(base.accountSnapshots);
+        snapshotsResult.accountSnapshots.forEach((s, id) => next.accountSnapshots.set(id, s));
+        snapshotsResult.tombstoneAccountSnapshotIds.forEach((id) =>
+          next.accountSnapshots.delete(id),
+        );
+
+        next.holdingSnapshots = new HoldingSnapshotDictionary(base.holdingSnapshots);
+        snapshotsResult.holdingSnapshots.forEach((s, id) => next.holdingSnapshots.set(id, s));
+        snapshotsResult.tombstoneHoldingSnapshotIds.forEach((id) =>
+          next.holdingSnapshots.delete(id),
+        );
+
+        next.securitySnapshots = new SecuritySnapshotDictionary(base.securitySnapshots);
+        snapshotsResult.securitySnapshots.forEach((s, id) => next.securitySnapshots.set(id, s));
+        snapshotsResult.tombstoneSecuritySnapshotIds.forEach((id) =>
+          next.securitySnapshots.delete(id),
+        );
+
+        next.status.isInit = true;
+        next.status.isLoading = false;
+        next.status.isError = false;
+        return next;
+      });
+
+      // ===== Stage 4: persist + advance the cursor. =====
+      //
+      // Persist whatever changed in this delta to IDB per-row:
+      // `indexedDb.save` for added/modified entries, `indexedDb.remove`
+      // for tombstones. These are the load-bearing writes once the
+      // `clearAllData → saveAllData` pattern is gone — IDB must reflect
+      // exactly what setData applied so the next warm boot's
+      // `loadAllData` cache matches.
+      //
+      // Bias toward eager fire-and-forget IDB writes (no awaits) since
+      // a failed IDB write just means the next warm load re-fetches
+      // (correct but slower). The orchestrator's only blocking await
+      // is the cursor write at the end, after every fetch succeeded.
+      transactionsResult.transactions.forEach((t) =>
+        indexedDb.save(t).catch(console.error),
+      );
+      transactionsResult.investmentTransactions.forEach((t) =>
+        indexedDb.save(t).catch(console.error),
+      );
+      transactionsResult.tombstoneTxIds.forEach((id) =>
+        indexedDb.remove(StoreName.transactions, id).catch(console.error),
+      );
+      transactionsResult.tombstoneInvIds.forEach((id) =>
+        indexedDb.remove(StoreName.investmentTransactions, id).catch(console.error),
+      );
+      splitTransactionsResult.splitTransactions.forEach((t) =>
+        indexedDb.save(t).catch(console.error),
+      );
+      splitTransactionsResult.tombstoneSplitIds.forEach((id) =>
+        indexedDb.remove(StoreName.splitTransactions, id).catch(console.error),
+      );
+      snapshotsResult.accountSnapshots.forEach((s) =>
+        indexedDb.save(s).catch(console.error),
+      );
+      snapshotsResult.holdingSnapshots.forEach((s) =>
+        indexedDb.save(s).catch(console.error),
+      );
+      snapshotsResult.securitySnapshots.forEach((s) =>
+        indexedDb.save(s).catch(console.error),
+      );
+      snapshotsResult.tombstoneAccountSnapshotIds.forEach((id) =>
+        indexedDb.remove(StoreName.accountSnapshots, id).catch(console.error),
+      );
+      snapshotsResult.tombstoneHoldingSnapshotIds.forEach((id) =>
+        indexedDb.remove(StoreName.holdingSnapshots, id).catch(console.error),
+      );
+      snapshotsResult.tombstoneSecuritySnapshotIds.forEach((id) =>
+        indexedDb.remove(StoreName.securitySnapshots, id).catch(console.error),
+      );
+
+      // Non-time-partitioned stores: persist the whole dictionary —
+      // the server may have updated them since the cursor in ways the
+      // delta protocol doesn't surface here (e.g. budget edits). The
+      // `clearAllData → saveAllData` super-replace approach is gone,
+      // so we save these via `saveAllData(refreshed)` separately. That
+      // function `put`s entry-by-entry, idempotent on existing keys,
+      // and is correct as long as we don't need to evict rows that
+      // were never refetched. (For these stores — accounts, budgets,
+      // etc. — there's no per-row tombstone protocol; deletions show
+      // up as a missing id. That's the same behavior as today.)
+      const refreshedStage1 = new Data({
+        accounts,
+        items,
+        holdings,
+        budgets,
+        sections,
+        categories,
+        charts,
+        institutions,
+        securities,
+        transfers,
+      });
+      indexedDb.saveAllData(refreshedStage1).catch(console.error);
+
+      // Cursor advances ONLY if every fetch succeeded. On any failure,
+      // leave the cursor at its previous value so the next sync's delta
+      // still spans the gap that just failed.
+      const fetchFailed =
         stage1Budgets.networkFailed ||
         stage1Charts.networkFailed ||
         stage1Institutions.networkFailed ||
         stage1Securities.networkFailed ||
         stage1Transfers.networkFailed ||
-        stage2Transactions.networkFailed ||
-        stage2SplitTxns.networkFailed ||
-        stage2Snapshots.networkFailed ||
-        (stage3Transactions?.networkFailed ?? false) ||
-        (stage3Snapshots?.networkFailed ?? false);
+        transactionsResult.networkFailed ||
+        splitTransactionsResult.networkFailed ||
+        snapshotsResult.networkFailed;
 
-      if (!coldFetchFailed) {
-        indexedDb
-          .clearAllData()
-          .then(() => indexedDb.saveAllData(finalData))
-          .catch(console.error);
-        writeLastSyncedAt(new Date());
+      if (!fetchFailed) {
+        writeLastSyncedCursor(cursorForNextSync(syncStartedAt));
       }
     } catch (err) {
       console.error(err);
@@ -960,7 +734,7 @@ export const useSync = () => {
 
   const clean = useCallback(() => {
     indexedDb.clearAllData();
-    removeLastSyncedAt();
+    removeLastSyncedCursor();
     setData(new Data());
   }, [setData]);
 

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -486,16 +486,37 @@ export const useSync = () => {
         setData(cached);
       }
 
+      // Kick off every Stage 1 fetch in parallel. Only `fetchInstitutions`
+      // depends on accounts (chained via the promise), the rest are
+      // independent and start as soon as the user is authenticated.
       const accountsPromise = fetchAccounts();
-      const { networkFailed: accountsFailed } = await accountsPromise;
+      const budgetsPromise = fetchBudgets();
+      const chartsPromise = fetchCharts();
+      const institutionsPromise = accountsPromise.then((r) => fetchInstitutions(r.accounts));
+      const securitiesPromise = fetchSecurities();
+      const transfersPromise = fetchTransfers();
 
-      if (accountsFailed) {
-        // Updater form (not `setData(cached)`): the warm-path paint
-        // already committed `cached` to React state at line ~471, so
-        // a second `setData(cached)` would be `Object.is`-equal to
-        // the current state and React would bail out — stranding the
-        // loading flag we mutated to `false`. Clone via the updater
-        // so React sees a distinct reference and commits.
+      const [
+        accountsResult,
+        stage1Budgets,
+        stage1Charts,
+        stage1Institutions,
+        stage1Securities,
+        stage1Transfers,
+      ] = await Promise.all([
+        accountsPromise,
+        budgetsPromise,
+        chartsPromise,
+        institutionsPromise,
+        securitiesPromise,
+        transfersPromise,
+      ]);
+
+      if (accountsResult.networkFailed) {
+        // Setdata via the updater so React sees a distinct reference
+        // and commits; the warm-path paint above already committed the
+        // same `cached` ref, so `setData(cached)` would Object.is-bail
+        // and strand the loading flag.
         setData((oldData) => {
           const newData = new Data(oldData);
           newData.status.isInit = true;
@@ -506,21 +527,7 @@ export const useSync = () => {
         return;
       }
 
-      const { accounts, items, holdings } = await accountsPromise;
-
-      const [
-        stage1Budgets,
-        stage1Charts,
-        stage1Institutions,
-        stage1Securities,
-        stage1Transfers,
-      ] = await Promise.all([
-        fetchBudgets(),
-        fetchCharts(),
-        fetchInstitutions(accounts),
-        fetchSecurities(),
-        fetchTransfers(),
-      ]);
+      const { accounts, items, holdings } = accountsResult;
       const { budgets, sections, categories } = stage1Budgets;
       const { charts } = stage1Charts;
       const { institutions } = stage1Institutions;
@@ -647,16 +654,15 @@ export const useSync = () => {
         next.institutions = institutions;
         next.securities = securities;
         next.transfers = transfers;
-        const base = oldData;
 
         // Apply transactions delta: clone the existing dict, set
         // added/modified, delete tombstoned ids.
-        next.transactions = new TransactionDictionary(base.transactions);
+        next.transactions = new TransactionDictionary(oldData.transactions);
         transactionsResult.transactions.forEach((t, id) => next.transactions.set(id, t));
         transactionsResult.tombstoneTxIds.forEach((id) => next.transactions.delete(id));
 
         next.investmentTransactions = new InvestmentTransactionDictionary(
-          base.investmentTransactions,
+          oldData.investmentTransactions,
         );
         transactionsResult.investmentTransactions.forEach((t, id) =>
           next.investmentTransactions.set(id, t),
@@ -665,7 +671,7 @@ export const useSync = () => {
           next.investmentTransactions.delete(id),
         );
 
-        next.splitTransactions = new SplitTransactionDictionary(base.splitTransactions);
+        next.splitTransactions = new SplitTransactionDictionary(oldData.splitTransactions);
         splitTransactionsResult.splitTransactions.forEach((t, id) =>
           next.splitTransactions.set(id, t),
         );
@@ -673,19 +679,19 @@ export const useSync = () => {
           next.splitTransactions.delete(id),
         );
 
-        next.accountSnapshots = new AccountSnapshotDictionary(base.accountSnapshots);
+        next.accountSnapshots = new AccountSnapshotDictionary(oldData.accountSnapshots);
         snapshotsResult.accountSnapshots.forEach((s, id) => next.accountSnapshots.set(id, s));
         snapshotsResult.tombstoneAccountSnapshotIds.forEach((id) =>
           next.accountSnapshots.delete(id),
         );
 
-        next.holdingSnapshots = new HoldingSnapshotDictionary(base.holdingSnapshots);
+        next.holdingSnapshots = new HoldingSnapshotDictionary(oldData.holdingSnapshots);
         snapshotsResult.holdingSnapshots.forEach((s, id) => next.holdingSnapshots.set(id, s));
         snapshotsResult.tombstoneHoldingSnapshotIds.forEach((id) =>
           next.holdingSnapshots.delete(id),
         );
 
-        next.securitySnapshots = new SecuritySnapshotDictionary(base.securitySnapshots);
+        next.securitySnapshots = new SecuritySnapshotDictionary(oldData.securitySnapshots);
         snapshotsResult.securitySnapshots.forEach((s, id) => next.securitySnapshots.set(id, s));
         snapshotsResult.tombstoneSecuritySnapshotIds.forEach((id) =>
           next.securitySnapshots.delete(id),
@@ -703,20 +709,22 @@ export const useSync = () => {
       // and per-row `remove` for tombstones. AWAITED so the cursor
       // write at the end happens AFTER IDB is durable — a page reload
       // right after sync sees the same state the cursor advertises.
-      const refreshedStage1 = new Data({
-        accounts,
-        items,
-        holdings,
-        budgets,
-        sections,
-        categories,
-        charts,
-        institutions,
-        securities,
-        transfers,
-      });
+      // Save the non-time-partitioned stores explicitly — `saveAllData`
+      // would also open readwrite transactions for the 6 time-partitioned
+      // stores with empty dictionaries, which is pointless overhead.
+      // Time-partitioned stores get their own `saveTransactions` /
+      // `saveAccountSnapshots` / etc. calls below using the delta dicts.
       await Promise.all([
-        indexedDb.saveAllData(refreshedStage1),
+        indexedDb.saveAccounts(accounts),
+        indexedDb.saveHoldings(holdings),
+        indexedDb.saveItems(items),
+        indexedDb.saveBudgets(budgets),
+        indexedDb.saveSections(sections),
+        indexedDb.saveCategories(categories),
+        indexedDb.saveCharts(charts),
+        indexedDb.saveInstitutions(institutions),
+        indexedDb.saveSecurities(securities),
+        indexedDb.saveTransfers(transfers),
         indexedDb.saveTransactions(transactionsResult.transactions),
         indexedDb.saveInvestmentTransactions(transactionsResult.investmentTransactions),
         indexedDb.saveSplitTransactions(splitTransactionsResult.splitTransactions),

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -630,64 +630,14 @@ export const useSync = () => {
 
       // ===== Stage 4: persist + advance the cursor. =====
       //
-      // Persist whatever changed in this delta to IDB per-row:
-      // `indexedDb.save` for added/modified entries, `indexedDb.remove`
-      // for tombstones. These are the load-bearing writes once the
-      // `clearAllData → saveAllData` pattern is gone — IDB must reflect
-      // exactly what setData applied so the next warm boot's
-      // `loadAllData` cache matches.
-      //
-      // Bias toward eager fire-and-forget IDB writes (no awaits) since
-      // a failed IDB write just means the next warm load re-fetches
-      // (correct but slower). The orchestrator's only blocking await
-      // is the cursor write at the end, after every fetch succeeded.
-      transactionsResult.transactions.forEach((t) =>
-        indexedDb.save(t).catch(console.error),
-      );
-      transactionsResult.investmentTransactions.forEach((t) =>
-        indexedDb.save(t).catch(console.error),
-      );
-      transactionsResult.tombstoneTxIds.forEach((id) =>
-        indexedDb.remove(StoreName.transactions, id).catch(console.error),
-      );
-      transactionsResult.tombstoneInvIds.forEach((id) =>
-        indexedDb.remove(StoreName.investmentTransactions, id).catch(console.error),
-      );
-      splitTransactionsResult.splitTransactions.forEach((t) =>
-        indexedDb.save(t).catch(console.error),
-      );
-      splitTransactionsResult.tombstoneSplitIds.forEach((id) =>
-        indexedDb.remove(StoreName.splitTransactions, id).catch(console.error),
-      );
-      snapshotsResult.accountSnapshots.forEach((s) =>
-        indexedDb.save(s).catch(console.error),
-      );
-      snapshotsResult.holdingSnapshots.forEach((s) =>
-        indexedDb.save(s).catch(console.error),
-      );
-      snapshotsResult.securitySnapshots.forEach((s) =>
-        indexedDb.save(s).catch(console.error),
-      );
-      snapshotsResult.tombstoneAccountSnapshotIds.forEach((id) =>
-        indexedDb.remove(StoreName.accountSnapshots, id).catch(console.error),
-      );
-      snapshotsResult.tombstoneHoldingSnapshotIds.forEach((id) =>
-        indexedDb.remove(StoreName.holdingSnapshots, id).catch(console.error),
-      );
-      snapshotsResult.tombstoneSecuritySnapshotIds.forEach((id) =>
-        indexedDb.remove(StoreName.securitySnapshots, id).catch(console.error),
-      );
-
-      // Non-time-partitioned stores: persist the whole dictionary —
-      // the server may have updated them since the cursor in ways the
-      // delta protocol doesn't surface here (e.g. budget edits). The
-      // `clearAllData → saveAllData` super-replace approach is gone,
-      // so we save these via `saveAllData(refreshed)` separately. That
-      // function `put`s entry-by-entry, idempotent on existing keys,
-      // and is correct as long as we don't need to evict rows that
-      // were never refetched. (For these stores — accounts, budgets,
-      // etc. — there's no per-row tombstone protocol; deletions show
-      // up as a missing id. That's the same behavior as today.)
+      // Per-store batched `saveMany` writes for added/modified entries
+      // and per-row `remove` for tombstones. AWAITED so the cursor
+      // write at the end happens AFTER IDB is durable — a page reload
+      // right after sync sees the same state the cursor advertises.
+      // (Fire-and-forget here would race the next warm boot's
+      // `loadAllData` against the in-flight writes; the test that
+      // surfaced this caught a partial cold-sync state being treated
+      // as the warm-load baseline.)
       const refreshedStage1 = new Data({
         accounts,
         items,
@@ -700,7 +650,40 @@ export const useSync = () => {
         securities,
         transfers,
       });
-      indexedDb.saveAllData(refreshedStage1).catch(console.error);
+      await Promise.all([
+        indexedDb.saveAllData(refreshedStage1),
+        indexedDb.saveTransactions(transactionsResult.transactions),
+        indexedDb.saveInvestmentTransactions(transactionsResult.investmentTransactions),
+        indexedDb.saveSplitTransactions(splitTransactionsResult.splitTransactions),
+        indexedDb.saveAccountSnapshots(snapshotsResult.accountSnapshots),
+        indexedDb.saveHoldingSnapshots(snapshotsResult.holdingSnapshots),
+        indexedDb.saveSecuritySnapshots(snapshotsResult.securitySnapshots),
+      ]).catch(console.error);
+
+      // Tombstones: per-row remove. Small N (typically 0–few), so the
+      // serial overhead is negligible and there's no batched-remove
+      // helper. Awaited via Promise.all alongside the saves above
+      // would mix store transactions; keep separate for clarity.
+      const tombstoneRemovals: Promise<void>[] = [];
+      transactionsResult.tombstoneTxIds.forEach((id) => {
+        tombstoneRemovals.push(indexedDb.remove(StoreName.transactions, id));
+      });
+      transactionsResult.tombstoneInvIds.forEach((id) => {
+        tombstoneRemovals.push(indexedDb.remove(StoreName.investmentTransactions, id));
+      });
+      splitTransactionsResult.tombstoneSplitIds.forEach((id) => {
+        tombstoneRemovals.push(indexedDb.remove(StoreName.splitTransactions, id));
+      });
+      snapshotsResult.tombstoneAccountSnapshotIds.forEach((id) => {
+        tombstoneRemovals.push(indexedDb.remove(StoreName.accountSnapshots, id));
+      });
+      snapshotsResult.tombstoneHoldingSnapshotIds.forEach((id) => {
+        tombstoneRemovals.push(indexedDb.remove(StoreName.holdingSnapshots, id));
+      });
+      snapshotsResult.tombstoneSecuritySnapshotIds.forEach((id) => {
+        tombstoneRemovals.push(indexedDb.remove(StoreName.securitySnapshots, id));
+      });
+      await Promise.all(tombstoneRemovals).catch(console.error);
 
       // Cursor advances ONLY if every fetch succeeded. On any failure,
       // leave the cursor at its previous value so the next sync's delta

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -459,10 +459,33 @@ export const useSync = () => {
         return null;
       });
       const cursorRaw = readLastSyncedCursor();
-      // Warm vs cold is gated on BOTH: a populated IDB cache AND a
-      // previously-recorded cursor. Either missing → cold (full fetch,
-      // no cursor on the wire).
-      const isWarm = !!cached && cached.accounts.size > 0 && cursorRaw !== null;
+      // Warm vs cold is gated on:
+      //   - a populated IDB cache (accounts AND at least one
+      //     time-partitioned store; protects against partial-IDB
+      //     states like a future schema migration that resets some
+      //     stores or storage-quota partial eviction), AND
+      //   - a previously-recorded cursor.
+      // Any missing → cold (full fetch, no cursor on the wire) so
+      // the time-partitioned history can re-hydrate from scratch.
+      const isWarm =
+        !!cached &&
+        cached.accounts.size > 0 &&
+        (cached.transactions.size > 0 ||
+          cached.investmentTransactions.size > 0 ||
+          cached.accountSnapshots.size > 0) &&
+        cursorRaw !== null;
+
+      // Cold path purges IDB before the new save block writes the
+      // fresh delta — otherwise pre-tombstone-era rows (soft-deleted
+      // server-side before tombstone delivery existed, hard-deleted,
+      // or admin-removed) persist as cruft. Without a cursor the
+      // server's delta won't replay tombstones for those, so cold is
+      // the only opportunity to reset IDB. Awaited — the new saves
+      // can't safely race against a still-in-flight clearAllData on
+      // the same stores.
+      if (!isWarm) {
+        await indexedDb.clearAllData().catch(console.error);
+      }
       // Pass the cursor to delta fetches ONLY on the warm branch. The
       // cold path must fetch the full history with no `start-date=` —
       // if localStorage has a stale cursor (IDB cleared by quota /


### PR DESCRIPTION
PR B of the 3-PR caching rework (per `~/claude/memory/project_budget_delta_sync_design.md`). Successor to merged PR #520 (transactions tombstones) and PR #522 (split-tx tombstones). PR C will remove the now-dead `cachedCall` helper file.

## What changes

- New `budget:lastSyncedCursor` localStorage key. Persists the ISO timestamp of the last successful sync's start (minus a 60s safety margin). Next sync's delta fetch sends this as `?start-date=<cursor>` so the server returns only rows whose `updated >= cursor`.
- `useSync._sync` is rewritten around delta semantics:
  - **Cursor + IDB present → warm path:** paint cached state first, then run all stage-1 + 3 delta fetches in parallel, then `setData((old) => …)` that explicitly merges added/modified into a cloned dictionary and `.delete()`s tombstoned ids. The design-doc rule the constraint is here for.
  - **Cursor absent OR IDB empty → cold path:** same flow but cursor=null sends an unbounded GET per store. Single setData with a fresh Data once everything lands.
- IDB persistence is now per-row: `indexedDb.save(entry)` for added/modified and `indexedDb.remove(StoreName.x, id)` for tombstones. The previous `clearAllData → saveAllData(refreshed)` super-replace is gone for the four time-partitioned stores (transactions, inv-tx, splits, snapshots). Non-time stores (accounts, budgets, charts, etc.) still go through `saveAllData` because they don't have a row-level tombstone protocol.
- `cachedCall` is no longer used anywhere in `sync.ts`. PR C will remove the helper file itself.

## What's out of scope (PR C)

- Removing the `cachedCall.ts` helper file + its tests.
- Removing the `LAST_SYNCED_AT_KEY` constant and `FRESHNESS_WINDOW_MS` (already deleted in this PR — they're no longer referenced).

## Why this is structured this way

Per the design doc, **warm-path tombstone handling needs explicit in-place removal** because the orchestrator can no longer rely on `setData(refreshed)` superseding prior state — delta means the old state IS the base. The constraint Hoie surfaced on PR #520 (review id 3423861186): *"This works in current state because we're replacing the whole transactions data. However in the next PR when we remove Cache API, we'll have to remove them explicitly from the previous data state."* The new `setData((old) => …)` body does exactly that for every store.

## Cursor mechanism

The JSON wire format doesn't expose `updated` on snapshot or split-tx rows today (only transactions does). Per-row `max(updated)` would require widening `common/models/Snapshot.ts` + `Transaction.JSONSplitTransaction` + their server-side `toJSON()` paths — out of scope for PR B and not worth the cross-cutting change here.

Instead, the cursor is set to `Date.now() - 60s` at sync start, written only on success. The 60s margin trades a small per-sync re-fetch of the last minute's server-side changes for robustness against client-server clock skew (a bare `Date.now()` cursor would silently miss rows whose `updated` lands behind the FE's `now`).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun test src/server` — 630 / 630 pass
- [ ] Sandbox E2E — cold load, warm reload (cursor + IDB cache), label edit on row → reload → verify edit persisted, snapshot delete from another session → reload → verify eviction.