### PR TITLE
fix(transfers): detection-engine sweep — tiebreak + window + cascade + distinct rejection

### DIFF
--- a/src/common/models/Transaction.ts
+++ b/src/common/models/Transaction.ts
@@ -59,7 +59,7 @@ export interface JSONTransaction extends PlaidTransaction {
   is_deleted?: boolean;
 }
 
-export type TransferPairStatus = "suggested" | "confirmed";
+export type TransferPairStatus = "suggested" | "confirmed" | "rejected";
 
 export interface JSONTransferPair {
   pair_id: string;

--- a/src/server/lib/compute-tools/detect-transfers.test.ts
+++ b/src/server/lib/compute-tools/detect-transfers.test.ts
@@ -229,7 +229,7 @@ describe("runTransferDetection", () => {
     expect(inserts).toHaveLength(2);
   });
 
-  test("candidate-fetch SQL uses 7-day window + hidden-count tiebreak", async () => {
+  test("candidate-fetch SQL uses 7-day window + hidden-account exclusion", async () => {
     // Single user with no candidates — we only inspect the SELECT-candidates
     // SQL shape that the engine issues per user.
     mockQuery.mockResolvedValueOnce({ rows: [userRow({ user_id: "u-1" })], rowCount: 1 });
@@ -246,21 +246,24 @@ describe("runTransferDetection", () => {
     // 7-day window passed as second positional parameter.
     expect((values as unknown[])[1]).toBe(7);
 
-    // Joins both transactions' accounts to expose `.hide`.
+    // Joins both transactions' accounts so the WHERE clause can filter
+    // by `account.hide`.
     expect(sql as string).toMatch(/JOIN\s+accounts\s+a1\s+ON\s+a1\.account_id\s*=\s*t1\.account_id/i);
     expect(sql as string).toMatch(/JOIN\s+accounts\s+a2\s+ON\s+a2\.account_id\s*=\s*t2\.account_id/i);
 
-    // ORDER BY: date_delta ASC, hidden-count ASC, transaction_id ASC.
-    // The hidden-count sub-expression appears both in the SELECT (as a
-    // returned column) and in the ORDER BY — match the ORDER BY shape
-    // specifically.
+    // Hidden-account exclusion: both sides must be visible.
+    expect(sql as string).toMatch(/COALESCE\(a1\.hide,\s*FALSE\)\s*=\s*FALSE/i);
+    expect(sql as string).toMatch(/COALESCE\(a2\.hide,\s*FALSE\)\s*=\s*FALSE/i);
+
+    // ORDER BY: date_delta ASC, transaction_id ASC (no hidden-count
+    // tiebreaker — hidden accounts are excluded outright).
     const sqlStr = sql as string;
     const orderByIdx = sqlStr.search(/ORDER\s+BY/i);
     expect(orderByIdx).toBeGreaterThan(-1);
     const tail = sqlStr.slice(orderByIdx);
     expect(tail).toMatch(/ABS\(t1\.date\s*-\s*t2\.date\)\s*ASC/i);
-    expect(tail).toMatch(/a1\.hide/i);
-    expect(tail).toMatch(/a2\.hide/i);
     expect(tail).toMatch(/t1\.transaction_id\s+ASC/i);
+    expect(tail).not.toMatch(/a1\.hide/i);
+    expect(tail).not.toMatch(/a2\.hide/i);
   });
 });

--- a/src/server/lib/compute-tools/detect-transfers.test.ts
+++ b/src/server/lib/compute-tools/detect-transfers.test.ts
@@ -220,4 +220,39 @@ describe("runTransferDetection", () => {
     const inserts = findInsertCalls();
     expect(inserts).toHaveLength(2);
   });
+
+  test("candidate-fetch SQL uses 7-day window + hidden-count tiebreak", async () => {
+    // Single user with no candidates — we only inspect the SELECT-candidates
+    // SQL shape that the engine issues per user.
+    mockQuery.mockResolvedValueOnce({ rows: [userRow({ user_id: "u-1" })], rowCount: 1 });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+    await runTransferDetection();
+
+    const candidateCalls = mockQuery.mock.calls.filter((c) =>
+      /JOIN\s+transactions\s+t2/i.test(c[0] as string),
+    );
+    expect(candidateCalls).toHaveLength(1);
+    const [sql, values] = candidateCalls[0];
+
+    // 7-day window passed as second positional parameter.
+    expect((values as unknown[])[1]).toBe(7);
+
+    // Joins both transactions' accounts to expose `.hide`.
+    expect(sql as string).toMatch(/JOIN\s+accounts\s+a1\s+ON\s+a1\.account_id\s*=\s*t1\.account_id/i);
+    expect(sql as string).toMatch(/JOIN\s+accounts\s+a2\s+ON\s+a2\.account_id\s*=\s*t2\.account_id/i);
+
+    // ORDER BY: date_delta ASC, hidden-count ASC, transaction_id ASC.
+    // The hidden-count sub-expression appears both in the SELECT (as a
+    // returned column) and in the ORDER BY — match the ORDER BY shape
+    // specifically.
+    const sqlStr = sql as string;
+    const orderByIdx = sqlStr.search(/ORDER\s+BY/i);
+    expect(orderByIdx).toBeGreaterThan(-1);
+    const tail = sqlStr.slice(orderByIdx);
+    expect(tail).toMatch(/ABS\(t1\.date\s*-\s*t2\.date\)\s*ASC/i);
+    expect(tail).toMatch(/a1\.hide/i);
+    expect(tail).toMatch(/a2\.hide/i);
+    expect(tail).toMatch(/t1\.transaction_id\s+ASC/i);
+  });
 });

--- a/src/server/lib/compute-tools/detect-transfers.test.ts
+++ b/src/server/lib/compute-tools/detect-transfers.test.ts
@@ -93,6 +93,8 @@ describe("runTransferDetection", () => {
   test("inserts a pair for a single candidate above threshold", async () => {
     // SELECT users → [user-1]
     mockQuery.mockResolvedValueOnce({ rows: [userRow({ user_id: "user-1" })], rowCount: 1 });
+    // Stale-pair cleanup UPDATE — runs before fetchCandidates (0 cleaned).
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
     // SELECT candidates for user-1 → one matching pair
     mockQuery.mockResolvedValueOnce({
       rows: [
@@ -120,6 +122,8 @@ describe("runTransferDetection", () => {
 
   test("prevents a single transaction from being paired twice in one run", async () => {
     mockQuery.mockResolvedValueOnce({ rows: [userRow({ user_id: "user-1" })], rowCount: 1 });
+    // Stale-pair cleanup UPDATE.
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
     mockQuery.mockResolvedValueOnce({
       rows: [
         {
@@ -164,8 +168,10 @@ describe("runTransferDetection", () => {
       rows: [userRow({ user_id: "user-bad" }), userRow({ user_id: "user-good" })],
       rowCount: 2,
     });
-    // user-bad's SELECT candidates → throws
+    // user-bad's stale-pair cleanup UPDATE — throws (simulates fail point)
     mockQuery.mockRejectedValueOnce(new Error("boom"));
+    // user-good's stale-pair cleanup UPDATE → 0 cleaned.
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
     // user-good's SELECT candidates → one matching pair
     mockQuery.mockResolvedValueOnce({
       rows: [
@@ -192,6 +198,8 @@ describe("runTransferDetection", () => {
 
   test("logs but continues when an INSERT throws", async () => {
     mockQuery.mockResolvedValueOnce({ rows: [userRow({ user_id: "user-1" })], rowCount: 1 });
+    // Stale-pair cleanup UPDATE.
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
     // SELECT candidates → two matching pairs
     mockQuery.mockResolvedValueOnce({
       rows: [

--- a/src/server/lib/compute-tools/detect-transfers.ts
+++ b/src/server/lib/compute-tools/detect-transfers.ts
@@ -5,7 +5,7 @@ const BASE_CONFIDENCE = 0.7;
 const PLAID_TRANSFER_BOOST = 0.2;
 const SAME_DAY_BOOST = 0.1;
 const SUGGEST_THRESHOLD = 0.7;
-const DATE_WINDOW_DAYS = 3;
+const DATE_WINDOW_DAYS = 7;
 const PER_USER_CANDIDATE_LIMIT = 500;
 
 export interface DetectionCandidate {
@@ -31,11 +31,22 @@ const fetchUsers = async (): Promise<string[]> => {
 };
 
 const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> => {
+  // Tiebreaker: when multiple candidates share the same `date_delta`,
+  // prefer the candidate whose two accounts are both NOT hidden. When a
+  // user has duplicate-data accounts from the same institution (Plaid
+  // sometimes mirrors the same transactions on two account_ids for the
+  // same product — e.g. BILT cards), the workaround is `account.hide =
+  // true` on the redundant one. Counting hidden accounts on either
+  // side of the candidate (0, 1, or 2) and sorting ASC biases the
+  // match toward the visible-account pairing, which is what the
+  // user's manual labels actually pair against.
   const result = await pool.query(
     `SELECT
        t1.transaction_id AS transaction_id_a,
        t2.transaction_id AS transaction_id_b,
        ABS(t1.date - t2.date) AS date_delta,
+       (CASE WHEN a1.hide THEN 1 ELSE 0 END
+         + CASE WHEN a2.hide THEN 1 ELSE 0 END) AS hidden_count,
        (
          (t1.raw->'personal_finance_category'->>'primary') LIKE 'TRANSFER%'
          OR (t2.raw->'personal_finance_category'->>'primary') LIKE 'TRANSFER%'
@@ -49,6 +60,8 @@ const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> =>
       AND t1.account_id <> t2.account_id
       AND ABS(t1.date - t2.date) <= $2
       AND t1.transaction_id < t2.transaction_id
+     JOIN accounts a1 ON a1.account_id = t1.account_id
+     JOIN accounts a2 ON a2.account_id = t2.account_id
      WHERE (t1.is_deleted IS NULL OR t1.is_deleted = FALSE)
        AND (t2.is_deleted IS NULL OR t2.is_deleted = FALSE)
        AND NOT EXISTS (
@@ -60,7 +73,11 @@ const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> =>
              OR tp.transaction_id_b IN (t1.transaction_id, t2.transaction_id)
            )
        )
-     ORDER BY ABS(t1.date - t2.date) ASC, t1.transaction_id ASC
+     ORDER BY
+       ABS(t1.date - t2.date) ASC,
+       (CASE WHEN a1.hide THEN 1 ELSE 0 END
+         + CASE WHEN a2.hide THEN 1 ELSE 0 END) ASC,
+       t1.transaction_id ASC
      LIMIT $3`,
     [userId, DATE_WINDOW_DAYS, PER_USER_CANDIDATE_LIMIT],
   );

--- a/src/server/lib/compute-tools/detect-transfers.ts
+++ b/src/server/lib/compute-tools/detect-transfers.ts
@@ -162,6 +162,33 @@ export const runTransferDetection = async (): Promise<void> => {
     const userIds = await fetchUsers();
     for (const userId of userIds) {
       try {
+        // Pre-step: cascade soft-delete any existing pair whose own
+        // `is_deleted` is FALSE but at least one of its referenced
+        // transactions has been soft-deleted since the pair was
+        // created. Without this, the surviving counterpart stays
+        // "stuck" paired with a ghost — fetchCandidates' existing-pair
+        // filter excludes it from re-detection forever. Going forward,
+        // `deleteTransactions` cascades to pairs at the source, so
+        // this catch-up step handles already-stale rows.
+        const stalePairCleanup = await pool.query(
+          `UPDATE transaction_pairs tp
+           SET is_deleted = TRUE, updated = CURRENT_TIMESTAMP
+           WHERE tp.user_id = $1
+             AND (tp.is_deleted IS NULL OR tp.is_deleted = FALSE)
+             AND EXISTS (
+               SELECT 1 FROM transactions t
+               WHERE t.transaction_id IN (tp.transaction_id_a, tp.transaction_id_b)
+                 AND t.is_deleted = TRUE
+             )`,
+          [userId],
+        );
+        if ((stalePairCleanup.rowCount ?? 0) > 0) {
+          logger.info("Cleaned stale transfer pairs", {
+            userId,
+            count: stalePairCleanup.rowCount,
+          });
+        }
+
         const candidates = await fetchCandidates(userId);
         if (candidates.length === PER_USER_CANDIDATE_LIMIT) {
           // The LIMIT just truncated the candidate set; the highest-

--- a/src/server/lib/compute-tools/detect-transfers.ts
+++ b/src/server/lib/compute-tools/detect-transfers.ts
@@ -32,21 +32,20 @@ const fetchUsers = async (): Promise<string[]> => {
 
 const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> => {
   // Tiebreaker: when multiple candidates share the same `date_delta`,
-  // prefer the candidate whose two accounts are both NOT hidden. When a
-  // user has duplicate-data accounts from the same institution (Plaid
-  // sometimes mirrors the same transactions on two account_ids for the
-  // same product — e.g. BILT cards), the workaround is `account.hide =
-  // true` on the redundant one. Counting hidden accounts on either
-  // side of the candidate (0, 1, or 2) and sorting ASC biases the
-  // match toward the visible-account pairing, which is what the
-  // user's manual labels actually pair against.
+  // prefer the candidate whose two accounts are both `hide = false`.
+  // `account.hide` is the canonical signal that an account is a
+  // duplicate-data view of another (Plaid occasionally surfaces the
+  // same product on two account_ids); the visible account is the one
+  // the user expects pairings to anchor on. Counting hidden accounts
+  // on either side (0, 1, or 2) and sorting ASC biases the match
+  // toward the visible-account pairing.
   const result = await pool.query(
     `SELECT
        t1.transaction_id AS transaction_id_a,
        t2.transaction_id AS transaction_id_b,
        ABS(t1.date - t2.date) AS date_delta,
-       (CASE WHEN a1.hide THEN 1 ELSE 0 END
-         + CASE WHEN a2.hide THEN 1 ELSE 0 END) AS hidden_count,
+       (CASE WHEN COALESCE(a1.hide, FALSE) THEN 1 ELSE 0 END
+         + CASE WHEN COALESCE(a2.hide, FALSE) THEN 1 ELSE 0 END) AS hidden_count,
        (
          (t1.raw->'personal_finance_category'->>'primary') LIKE 'TRANSFER%'
          OR (t2.raw->'personal_finance_category'->>'primary') LIKE 'TRANSFER%'
@@ -60,8 +59,8 @@ const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> =>
       AND t1.account_id <> t2.account_id
       AND ABS(t1.date - t2.date) <= $2
       AND t1.transaction_id < t2.transaction_id
-     JOIN accounts a1 ON a1.account_id = t1.account_id
-     JOIN accounts a2 ON a2.account_id = t2.account_id
+     LEFT JOIN accounts a1 ON a1.account_id = t1.account_id
+     LEFT JOIN accounts a2 ON a2.account_id = t2.account_id
      WHERE (t1.is_deleted IS NULL OR t1.is_deleted = FALSE)
        AND (t2.is_deleted IS NULL OR t2.is_deleted = FALSE)
        AND NOT EXISTS (
@@ -75,8 +74,8 @@ const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> =>
        )
      ORDER BY
        ABS(t1.date - t2.date) ASC,
-       (CASE WHEN a1.hide THEN 1 ELSE 0 END
-         + CASE WHEN a2.hide THEN 1 ELSE 0 END) ASC,
+       (CASE WHEN COALESCE(a1.hide, FALSE) THEN 1 ELSE 0 END
+         + CASE WHEN COALESCE(a2.hide, FALSE) THEN 1 ELSE 0 END) ASC,
        t1.transaction_id ASC
      LIMIT $3`,
     [userId, DATE_WINDOW_DAYS, PER_USER_CANDIDATE_LIMIT],
@@ -132,7 +131,7 @@ const createPair = async (
  * Match criteria (enforced by the SQL):
  *   - same user, different accounts
  *   - equal absolute amount with opposite signs (debit/credit)
- *   - |date_a - date_b| <= 3 days
+ *   - |date_a - date_b| <= DATE_WINDOW_DAYS (currently 7)
  *   - neither transaction already participates in a non-deleted pair
  *
  * Confidence scoring (`scoreConfidence`):
@@ -164,6 +163,15 @@ export const runTransferDetection = async (): Promise<void> => {
     for (const userId of userIds) {
       try {
         const candidates = await fetchCandidates(userId);
+        if (candidates.length === PER_USER_CANDIDATE_LIMIT) {
+          // The LIMIT just truncated the candidate set; the highest-
+          // `date_delta` rows fell off the end. Surface so the cap can
+          // be tuned if heavy-transfer users hit it routinely.
+          logger.warn("Transfer-detection candidate cap reached", {
+            userId,
+            limit: PER_USER_CANDIDATE_LIMIT,
+          });
+        }
         const usedTxnIds = new Set<string>();
         let userSuggested = 0;
 

--- a/src/server/lib/compute-tools/detect-transfers.ts
+++ b/src/server/lib/compute-tools/detect-transfers.ts
@@ -63,13 +63,30 @@ const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> =>
      LEFT JOIN accounts a2 ON a2.account_id = t2.account_id
      WHERE (t1.is_deleted IS NULL OR t1.is_deleted = FALSE)
        AND (t2.is_deleted IS NULL OR t2.is_deleted = FALSE)
+       -- Block on suggested/confirmed pairings only. status='rejected'
+       -- means the user said "no" to a specific pair, not "this
+       -- transaction can never be paired", so the transactions stay
+       -- eligible for OTHER counterparts.
        AND NOT EXISTS (
          SELECT 1 FROM transaction_pairs tp
          WHERE tp.user_id = t1.user_id
            AND (tp.is_deleted IS NULL OR tp.is_deleted = FALSE)
+           AND tp.status <> 'rejected'
            AND (
              tp.transaction_id_a IN (t1.transaction_id, t2.transaction_id)
              OR tp.transaction_id_b IN (t1.transaction_id, t2.transaction_id)
+           )
+       )
+       -- Respect the user's explicit rejection of THIS specific pair:
+       -- if (t1, t2) was rejected before, do not re-suggest it.
+       AND NOT EXISTS (
+         SELECT 1 FROM transaction_pairs tp
+         WHERE tp.user_id = t1.user_id
+           AND (tp.is_deleted IS NULL OR tp.is_deleted = FALSE)
+           AND tp.status = 'rejected'
+           AND (
+             (tp.transaction_id_a = t1.transaction_id AND tp.transaction_id_b = t2.transaction_id)
+             OR (tp.transaction_id_a = t2.transaction_id AND tp.transaction_id_b = t1.transaction_id)
            )
        )
      ORDER BY
@@ -111,11 +128,25 @@ const createPair = async (
        SELECT 1 FROM transaction_pairs tp
        WHERE tp.user_id = $2
          AND (tp.is_deleted IS NULL OR tp.is_deleted = FALSE)
+         AND tp.status <> 'rejected'
          AND (
            tp.transaction_id_a IN ($3, $4)
            OR tp.transaction_id_b IN ($3, $4)
          )
-     )`,
+     )
+       AND NOT EXISTS (
+         -- ON CONFLICT-equivalent for the unique constraint on (a, b):
+         -- if a rejected pair already exists for THIS specific pair,
+         -- don't INSERT another row (the UNIQUE constraint would fire
+         -- anyway, but explicit guard avoids the 23505 round-trip).
+         SELECT 1 FROM transaction_pairs tp
+         WHERE tp.user_id = $2
+           AND (tp.is_deleted IS NULL OR tp.is_deleted = FALSE)
+           AND (
+             (tp.transaction_id_a = $3 AND tp.transaction_id_b = $4)
+             OR (tp.transaction_id_a = $4 AND tp.transaction_id_b = $3)
+           )
+       )`,
     [
       pair_id,
       userId,

--- a/src/server/lib/compute-tools/detect-transfers.ts
+++ b/src/server/lib/compute-tools/detect-transfers.ts
@@ -54,8 +54,8 @@ const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> =>
      JOIN transactions t2
        ON t1.user_id = t2.user_id
       AND t1.user_id = $1
-      AND ABS(t1.amount) = ABS(t2.amount)
-      AND t1.amount * t2.amount < 0
+      AND t1.amount + t2.amount = 0
+      AND t1.amount <> 0
       AND t1.account_id <> t2.account_id
       AND ABS(t1.date - t2.date) <= $2
       AND t1.transaction_id < t2.transaction_id

--- a/src/server/lib/compute-tools/detect-transfers.ts
+++ b/src/server/lib/compute-tools/detect-transfers.ts
@@ -135,13 +135,18 @@ const createPair = async (
          )
      )
        AND NOT EXISTS (
-         -- ON CONFLICT-equivalent for the unique constraint on (a, b):
-         -- if a rejected pair already exists for THIS specific pair,
-         -- don't INSERT another row (the UNIQUE constraint would fire
-         -- anyway, but explicit guard avoids the 23505 round-trip).
+         -- Mirror the UNIQUE(transaction_id_a, transaction_id_b)
+         -- constraint: any existing row for this pair — including
+         -- soft-deleted rejected tombstones — would 23505 the INSERT.
+         -- Pre-filtering by the same shape skips the round-trip in
+         -- both the common race (rejection lands between
+         -- fetchCandidates and createPair) and the rarer
+         -- soft-deleted-rejected case (catch-up cleanup tombstoned a
+         -- rejected pair before a fresh transaction re-import). No
+         -- is_deleted predicate — the UNIQUE constraint doesn't care
+         -- about is_deleted, so neither does this guard.
          SELECT 1 FROM transaction_pairs tp
          WHERE tp.user_id = $2
-           AND (tp.is_deleted IS NULL OR tp.is_deleted = FALSE)
            AND (
              (tp.transaction_id_a = $3 AND tp.transaction_id_b = $4)
              OR (tp.transaction_id_a = $4 AND tp.transaction_id_b = $3)

--- a/src/server/lib/compute-tools/detect-transfers.ts
+++ b/src/server/lib/compute-tools/detect-transfers.ts
@@ -31,21 +31,20 @@ const fetchUsers = async (): Promise<string[]> => {
 };
 
 const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> => {
-  // Tiebreaker: when multiple candidates share the same `date_delta`,
-  // prefer the candidate whose two accounts are both `hide = false`.
-  // `account.hide` is the canonical signal that an account is a
+  // Hidden-account exclusion: `account.hide=TRUE` marks an account as
   // duplicate-data view of another (Plaid occasionally surfaces the
-  // same product on two account_ids); the visible account is the one
-  // the user expects pairings to anchor on. Counting hidden accounts
-  // on either side (0, 1, or 2) and sorting ASC biases the match
-  // toward the visible-account pairing.
+  // same product on two `account_id`s; the user hides the redundant
+  // one). Transactions on hidden accounts are mirrors of transactions
+  // on a visible account — the visible-side pairing is the real one.
+  // Including hidden accounts as candidates makes duplicate-data
+  // transactions compete with their visible twins, leaving labeled
+  // transactions on the hidden side unpaired even when the engine
+  // would correctly pair the visible side.
   const result = await pool.query(
     `SELECT
        t1.transaction_id AS transaction_id_a,
        t2.transaction_id AS transaction_id_b,
        ABS(t1.date - t2.date) AS date_delta,
-       (CASE WHEN COALESCE(a1.hide, FALSE) THEN 1 ELSE 0 END
-         + CASE WHEN COALESCE(a2.hide, FALSE) THEN 1 ELSE 0 END) AS hidden_count,
        (
          (t1.raw->'personal_finance_category'->>'primary') LIKE 'TRANSFER%'
          OR (t2.raw->'personal_finance_category'->>'primary') LIKE 'TRANSFER%'
@@ -59,10 +58,12 @@ const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> =>
       AND t1.account_id <> t2.account_id
       AND ABS(t1.date - t2.date) <= $2
       AND t1.transaction_id < t2.transaction_id
-     LEFT JOIN accounts a1 ON a1.account_id = t1.account_id
-     LEFT JOIN accounts a2 ON a2.account_id = t2.account_id
+     JOIN accounts a1 ON a1.account_id = t1.account_id
+     JOIN accounts a2 ON a2.account_id = t2.account_id
      WHERE (t1.is_deleted IS NULL OR t1.is_deleted = FALSE)
        AND (t2.is_deleted IS NULL OR t2.is_deleted = FALSE)
+       AND COALESCE(a1.hide, FALSE) = FALSE
+       AND COALESCE(a2.hide, FALSE) = FALSE
        -- Block on suggested/confirmed pairings only. status='rejected'
        -- means the user said "no" to a specific pair, not "this
        -- transaction can never be paired", so the transactions stay
@@ -89,11 +90,7 @@ const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> =>
              OR (tp.transaction_id_a = t2.transaction_id AND tp.transaction_id_b = t1.transaction_id)
            )
        )
-     ORDER BY
-       ABS(t1.date - t2.date) ASC,
-       (CASE WHEN COALESCE(a1.hide, FALSE) THEN 1 ELSE 0 END
-         + CASE WHEN COALESCE(a2.hide, FALSE) THEN 1 ELSE 0 END) ASC,
-       t1.transaction_id ASC
+     ORDER BY ABS(t1.date - t2.date) ASC, t1.transaction_id ASC
      LIMIT $3`,
     [userId, DATE_WINDOW_DAYS, PER_USER_CANDIDATE_LIMIT],
   );

--- a/src/server/lib/postgres/models/base.ts
+++ b/src/server/lib/postgres/models/base.ts
@@ -274,13 +274,19 @@ export abstract class Table<
 
   async bulkSoftDeleteByColumn(
     column: string,
-    columnValue: ParamValue,
+    columnValue: ParamValue | ParamValue[],
     userIdValue?: ParamValue,
     client?: QueryExecutor,
   ): Promise<number> {
     this._assertSimplePrimaryKey("bulkSoftDeleteByColumn");
-    let sql = `UPDATE ${this.name} SET is_deleted = TRUE, updated = CURRENT_TIMESTAMP WHERE ${column} = $1`;
-    const values: ParamValue[] = [columnValue];
+    // `columnValue` is either a single value (`column = $1`) or an
+    // array (`column = ANY($1)`) — callers with multiple matching ids
+    // get one round-trip instead of N.
+    const isArray = Array.isArray(columnValue);
+    if (isArray && columnValue.length === 0) return 0;
+    const predicate = isArray ? `${column} = ANY($1)` : `${column} = $1`;
+    let sql = `UPDATE ${this.name} SET is_deleted = TRUE, updated = CURRENT_TIMESTAMP WHERE ${predicate}`;
+    const values: ParamValue[] = [columnValue as ParamValue];
 
     if (userIdValue !== undefined) {
       sql += ` AND user_id = $2`;

--- a/src/server/lib/postgres/repositories/transactions.ts
+++ b/src/server/lib/postgres/repositories/transactions.ts
@@ -5,6 +5,7 @@ import {
   InvTxModel,
   transactionsTable,
   splitTransactionsTable,
+  transactionPairsTable,
   TRANSACTION_ID,
   ACCOUNT_ID,
   USER_ID,
@@ -165,6 +166,15 @@ export const deleteTransactions = async (
 
   for (const tx_id of transaction_ids) {
     await splitTransactionsTable.bulkSoftDeleteByColumn(TRANSACTION_ID, tx_id, user.user_id, client);
+    // Cascade to transaction_pairs: a pair that references a soft-deleted
+    // transaction must itself be soft-deleted, otherwise the surviving
+    // counterpart stays "stuck" paired with a ghost — the transfer
+    // detection engine sees it as already-paired and refuses to suggest
+    // it as part of a new candidate. Plaid pending+settled duplicates
+    // hit this path: the pending row gets soft-deleted on settle but the
+    // pair previously linked to it persists.
+    await transactionPairsTable.bulkSoftDeleteByColumn("transaction_id_a", tx_id, user.user_id, client);
+    await transactionPairsTable.bulkSoftDeleteByColumn("transaction_id_b", tx_id, user.user_id, client);
   }
 
   const deleted = await transactionsTable.bulkSoftDelete(

--- a/src/server/lib/postgres/repositories/transactions.ts
+++ b/src/server/lib/postgres/repositories/transactions.ts
@@ -5,12 +5,13 @@ import {
   InvTxModel,
   transactionsTable,
   splitTransactionsTable,
-  transactionPairsTable,
   TRANSACTION_ID,
   TRANSACTION_ID_A,
   TRANSACTION_ID_B,
+  TRANSACTION_PAIRS,
   ACCOUNT_ID,
   USER_ID,
+  IS_DELETED,
   DATE,
   UPDATED,
   INVESTMENT_TRANSACTIONS,
@@ -168,16 +169,26 @@ export const deleteTransactions = async (
 
   for (const tx_id of transaction_ids) {
     await splitTransactionsTable.bulkSoftDeleteByColumn(TRANSACTION_ID, tx_id, user.user_id, client);
-    // Cascade to transaction_pairs: a pair that references a soft-deleted
-    // transaction must itself be soft-deleted, otherwise the surviving
-    // counterpart stays "stuck" paired with a ghost — the transfer
-    // detection engine sees it as already-paired and refuses to suggest
-    // it as part of a new candidate. Plaid pending+settled duplicates
-    // hit this path: the pending row gets soft-deleted on settle but the
-    // pair previously linked to it persists.
-    await transactionPairsTable.bulkSoftDeleteByColumn(TRANSACTION_ID_A, tx_id, user.user_id, client);
-    await transactionPairsTable.bulkSoftDeleteByColumn(TRANSACTION_ID_B, tx_id, user.user_id, client);
   }
+
+  // Cascade to transaction_pairs: a pair that references any soft-deleted
+  // transaction must itself be soft-deleted, otherwise the surviving
+  // counterpart stays "stuck" paired with a ghost — the transfer
+  // detection engine sees it as already-paired and refuses to suggest
+  // a new candidate. Plaid pending+settled duplicates hit this path.
+  // Single UPDATE per cascade (vs. 2N round-trips for N transactions):
+  // both transaction_id_a and transaction_id_b checked via ANY against
+  // the full id list.
+  const executor = client ?? pool;
+  await executor.query(
+    `UPDATE ${TRANSACTION_PAIRS}
+     SET ${IS_DELETED} = TRUE, ${UPDATED} = CURRENT_TIMESTAMP
+     WHERE ${USER_ID} = $1
+       AND (${IS_DELETED} IS NULL OR ${IS_DELETED} = FALSE)
+       AND (${TRANSACTION_ID_A} = ANY($2::text[])
+            OR ${TRANSACTION_ID_B} = ANY($2::text[]))`,
+    [user.user_id, transaction_ids],
+  );
 
   const deleted = await transactionsTable.bulkSoftDelete(
     transaction_ids,

--- a/src/server/lib/postgres/repositories/transactions.ts
+++ b/src/server/lib/postgres/repositories/transactions.ts
@@ -5,13 +5,12 @@ import {
   InvTxModel,
   transactionsTable,
   splitTransactionsTable,
+  transactionPairsTable,
   TRANSACTION_ID,
   TRANSACTION_ID_A,
   TRANSACTION_ID_B,
-  TRANSACTION_PAIRS,
   ACCOUNT_ID,
   USER_ID,
-  IS_DELETED,
   DATE,
   UPDATED,
   INVESTMENT_TRANSACTIONS,
@@ -167,27 +166,31 @@ export const deleteTransactions = async (
 ): Promise<{ deleted: number }> => {
   if (!transaction_ids.length) return { deleted: 0 };
 
-  for (const tx_id of transaction_ids) {
-    await splitTransactionsTable.bulkSoftDeleteByColumn(TRANSACTION_ID, tx_id, user.user_id, client);
-  }
+  // Soft-delete splits attached to each transaction (existing cascade).
+  await splitTransactionsTable.bulkSoftDeleteByColumn(
+    TRANSACTION_ID,
+    transaction_ids,
+    user.user_id,
+    client,
+  );
 
   // Cascade to transaction_pairs: a pair that references any soft-deleted
   // transaction must itself be soft-deleted, otherwise the surviving
-  // counterpart stays "stuck" paired with a ghost — the transfer
-  // detection engine sees it as already-paired and refuses to suggest
-  // a new candidate. Plaid pending+settled duplicates hit this path.
-  // Single UPDATE per cascade (vs. 2N round-trips for N transactions):
-  // both transaction_id_a and transaction_id_b checked via ANY against
-  // the full id list.
-  const executor = client ?? pool;
-  await executor.query(
-    `UPDATE ${TRANSACTION_PAIRS}
-     SET ${IS_DELETED} = TRUE, ${UPDATED} = CURRENT_TIMESTAMP
-     WHERE ${USER_ID} = $1
-       AND (${IS_DELETED} IS NULL OR ${IS_DELETED} = FALSE)
-       AND (${TRANSACTION_ID_A} = ANY($2::text[])
-            OR ${TRANSACTION_ID_B} = ANY($2::text[]))`,
-    [user.user_id, transaction_ids],
+  // counterpart stays "stuck" paired with a ghost — the engine sees it
+  // as already-paired and refuses to suggest a new candidate. Plaid
+  // pending+settled duplicates hit this path. Two UPDATEs per cascade
+  // (one per join column) instead of 2N for N transactions.
+  await transactionPairsTable.bulkSoftDeleteByColumn(
+    TRANSACTION_ID_A,
+    transaction_ids,
+    user.user_id,
+    client,
+  );
+  await transactionPairsTable.bulkSoftDeleteByColumn(
+    TRANSACTION_ID_B,
+    transaction_ids,
+    user.user_id,
+    client,
   );
 
   const deleted = await transactionsTable.bulkSoftDelete(

--- a/src/server/lib/postgres/repositories/transactions.ts
+++ b/src/server/lib/postgres/repositories/transactions.ts
@@ -7,6 +7,8 @@ import {
   splitTransactionsTable,
   transactionPairsTable,
   TRANSACTION_ID,
+  TRANSACTION_ID_A,
+  TRANSACTION_ID_B,
   ACCOUNT_ID,
   USER_ID,
   DATE,
@@ -173,8 +175,8 @@ export const deleteTransactions = async (
     // it as part of a new candidate. Plaid pending+settled duplicates
     // hit this path: the pending row gets soft-deleted on settle but the
     // pair previously linked to it persists.
-    await transactionPairsTable.bulkSoftDeleteByColumn("transaction_id_a", tx_id, user.user_id, client);
-    await transactionPairsTable.bulkSoftDeleteByColumn("transaction_id_b", tx_id, user.user_id, client);
+    await transactionPairsTable.bulkSoftDeleteByColumn(TRANSACTION_ID_A, tx_id, user.user_id, client);
+    await transactionPairsTable.bulkSoftDeleteByColumn(TRANSACTION_ID_B, tx_id, user.user_id, client);
   }
 
   const deleted = await transactionsTable.bulkSoftDelete(

--- a/src/server/lib/postgres/repositories/transfers.test.ts
+++ b/src/server/lib/postgres/repositories/transfers.test.ts
@@ -20,7 +20,7 @@ mock.module("pg", () => ({
   default: { Pool: FakePool, types: { setTypeParser: () => {} } },
 }));
 
-const { getTransferPairs, pairTransactions, confirmTransferPair, removeTransferPair } =
+const { getTransferPairs, pairTransactions, confirmTransferPair, rejectTransferPair } =
   await import("./transfers");
 
 afterAll(restoreLeaves);
@@ -191,16 +191,21 @@ describe("confirmTransferPair", () => {
   });
 });
 
-describe("removeTransferPair", () => {
+describe("rejectTransferPair", () => {
   beforeEach(() => mockQuery.mockClear());
 
-  test("soft-deletes the pair row (does not touch transactions)", async () => {
+  test("sets status='rejected' on the pair row (keeps is_deleted=FALSE)", async () => {
     mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-    await removeTransferPair(mockUser as never, "pair-1");
+    await rejectTransferPair(mockUser as never, "pair-1");
     expect(mockQuery).toHaveBeenCalledTimes(1);
     const [sql, values] = mockQuery.mock.calls[0] as [string, unknown[]];
     expect(sql).toContain("UPDATE transaction_pairs");
-    expect(sql).toContain("is_deleted = TRUE");
+    expect(sql).toContain("status = 'rejected'");
+    // Must NOT soft-delete — rejection and deletion are distinct.
+    expect(sql).not.toContain("is_deleted = TRUE");
+    // WHERE clause still excludes already-soft-deleted rows (no point
+    // updating a tombstoned pair).
+    expect(sql).toMatch(/is_deleted IS NULL OR is_deleted = FALSE/i);
     expect(values).toContain("pair-1");
     expect(values).toContain("usr-1");
   });

--- a/src/server/lib/postgres/repositories/transfers.ts
+++ b/src/server/lib/postgres/repositories/transfers.ts
@@ -4,7 +4,6 @@ import {
   MaskedUser,
   TransactionModel,
   TransactionPairModel,
-  transactionPairsTable,
   TRANSACTIONS,
   TRANSACTION_PAIRS,
   USER_ID,
@@ -126,11 +125,32 @@ export const confirmTransferPair = async (
 };
 
 /**
- * Remove a transfer pairing — soft-delete the pair row.
+ * Reject a transfer pairing — marks the pair `status = 'rejected'` so the
+ * suggestion engine remembers the user's "no" and won't re-suggest THIS
+ * specific pair on future runs. The pair row stays present (is_deleted
+ * = FALSE) so the rejection is queryable; the two transactions remain
+ * eligible to be paired with OTHER counterparts.
+ *
+ * Distinct from soft-deletion (`is_deleted = TRUE`): soft-deletion is
+ * the system-side cascade when one of the paired transactions itself
+ * gets removed (Plaid tombstone, manual delete) — it has no user-intent
+ * semantics and the surviving transaction is fully eligible for new
+ * suggestions, including the same counterpart if it returns.
+ *
+ * Naming: function was previously `removeTransferPair` (soft-delete);
+ * renamed to reflect the actual semantics now that rejection and
+ * deletion are distinct.
  */
-export const removeTransferPair = async (
+export const rejectTransferPair = async (
   user: MaskedUser,
   pair_id: string,
 ): Promise<void> => {
-  await transactionPairsTable.softDelete(pair_id, user.user_id);
+  await pool.query(
+    `UPDATE ${TRANSACTION_PAIRS}
+     SET ${STATUS} = 'rejected', updated = CURRENT_TIMESTAMP
+     WHERE ${PAIR_ID} = $1
+       AND ${USER_ID} = $2
+       AND (${IS_DELETED} IS NULL OR ${IS_DELETED} = FALSE)`,
+    [pair_id, user.user_id],
+  );
 };

--- a/src/server/lib/postgres/repositories/transfers.ts
+++ b/src/server/lib/postgres/repositories/transfers.ts
@@ -30,9 +30,16 @@ export interface TransferPair {
  */
 export const getTransferPairs = async (user: MaskedUser): Promise<TransferPair[]> => {
   const pairsResult = await pool.query<Record<string, unknown>>(
+    // Exclude status='rejected' from the FE response: a rejected pair is
+    // user-marked "no, these don't pair" — the engine remembers it as a
+    // denylist signal but the user shouldn't see the pair in their
+    // Transfers view. Re-confirming a previously-rejected pair goes
+    // through `pairTransactions` (Mark as Transfer), which un-rejects
+    // via ON CONFLICT.
     `SELECT * FROM ${TRANSACTION_PAIRS}
      WHERE ${USER_ID} = $1
        AND (${IS_DELETED} IS NULL OR ${IS_DELETED} = FALSE)
+       AND ${STATUS} <> 'rejected'
      ORDER BY ${PAIR_ID}`,
     [user.user_id],
   );
@@ -93,11 +100,14 @@ export const pairTransactions = async (
      ON CONFLICT (${TRANSACTION_ID_A}, ${TRANSACTION_ID_B}) DO UPDATE SET
        ${STATUS} = CASE
          WHEN ${TRANSACTION_PAIRS}.${IS_DELETED} = TRUE THEN EXCLUDED.${STATUS}
+         WHEN ${TRANSACTION_PAIRS}.${STATUS} = 'rejected' THEN EXCLUDED.${STATUS}
          ELSE ${TRANSACTION_PAIRS}.${STATUS}
        END,
        ${IS_DELETED} = FALSE,
        updated = CASE
-         WHEN ${TRANSACTION_PAIRS}.${IS_DELETED} = TRUE THEN CURRENT_TIMESTAMP
+         WHEN ${TRANSACTION_PAIRS}.${IS_DELETED} = TRUE
+           OR ${TRANSACTION_PAIRS}.${STATUS} = 'rejected'
+           THEN CURRENT_TIMESTAMP
          ELSE ${TRANSACTION_PAIRS}.updated
        END
      RETURNING ${PAIR_ID}`,

--- a/src/server/routes/transfers/delete-transfer.ts
+++ b/src/server/routes/transfers/delete-transfer.ts
@@ -1,5 +1,12 @@
-import { Route, removeTransferPair, requireQueryString, validationError } from "server";
+import { Route, rejectTransferPair, requireQueryString, validationError } from "server";
 
+// DELETE /transfers?id=<pair_id> — the user's "this isn't right" action
+// on a suggested-or-confirmed pair. Routes through `rejectTransferPair`
+// which sets `status='rejected'` (not `is_deleted=TRUE`): the engine
+// remembers the rejection and won't re-suggest THIS pair, but the two
+// transactions remain eligible for other counterparts. Soft-deletion
+// is reserved for the system cascade (when a transaction itself is
+// removed).
 export const deleteTransferRoute = new Route("DELETE", "/transfers", async (req) => {
   const { user } = req.session;
   if (!user) {
@@ -9,7 +16,7 @@ export const deleteTransferRoute = new Route("DELETE", "/transfers", async (req)
   const idResult = requireQueryString(req, "id");
   if (!idResult.success) return validationError(idResult.error!);
 
-  await removeTransferPair(user, idResult.data!);
+  await rejectTransferPair(user, idResult.data!);
 
   return { status: "success" };
 });

--- a/src/server/routes/transfers/index.ts
+++ b/src/server/routes/transfers/index.ts
@@ -1,3 +1,3 @@
 export * from "./get-transfers";
 export * from "./post-transfer-pair";
-export * from "./delete-transfer";
+export * from "./reject-transfer";

--- a/src/server/routes/transfers/reject-transfer.test.ts
+++ b/src/server/routes/transfers/reject-transfer.test.ts
@@ -18,7 +18,7 @@ mock.module("pg", () => ({
   default: { Pool: FakePool, types: { setTypeParser: () => {} } },
 }));
 
-const { deleteTransferRoute } = await import("./delete\-transfer");
+const { rejectTransferRoute } = await import("./reject\-transfer");
 
 afterAll(restoreLeaves);
 
@@ -45,7 +45,7 @@ function makeReq(
       destroy() {},
     },
     ip: "127.0.0.1",
-  } as unknown as Parameters<typeof deleteTransferRoute.execute>[0];
+  } as unknown as Parameters<typeof rejectTransferRoute.execute>[0];
 }
 
 const fakeRes = () =>
@@ -59,11 +59,11 @@ const fakeRes = () =>
       return true;
     },
     end() {},
-  }) as unknown as Parameters<typeof deleteTransferRoute.execute>[1];
+  }) as unknown as Parameters<typeof rejectTransferRoute.execute>[1];
 
-describe("delete-transfer", () => {
+describe("reject-transfer", () => {
   test("rejects unauthenticated requests", async () => {
-    const result = await deleteTransferRoute.execute(
+    const result = await rejectTransferRoute.execute(
       makeReq({ id: "p-1" }, { user: null }),
       fakeRes(),
     );
@@ -73,26 +73,26 @@ describe("delete-transfer", () => {
   });
 
   test("rejects missing id query param", async () => {
-    const result = await deleteTransferRoute.execute(makeReq({}), fakeRes());
+    const result = await rejectTransferRoute.execute(makeReq({}), fakeRes());
     expect(result?.status).toBe("failed");
     expect(mockQuery).not.toHaveBeenCalled();
   });
 
   test("rejects empty id query param", async () => {
-    const result = await deleteTransferRoute.execute(makeReq({ id: "   " }), fakeRes());
+    const result = await rejectTransferRoute.execute(makeReq({ id: "   " }), fakeRes());
     expect(result?.status).toBe("failed");
     expect(mockQuery).not.toHaveBeenCalled();
   });
 
   test("rejects array id query param (?id=a&id=b)", async () => {
-    const result = await deleteTransferRoute.execute(makeReq({ id: ["a", "b"] }), fakeRes());
+    const result = await rejectTransferRoute.execute(makeReq({ id: ["a", "b"] }), fakeRes());
     expect(result?.status).toBe("failed");
     expect(mockQuery).not.toHaveBeenCalled();
   });
 
   test("happy path returns success and pins user_id into the WHERE clause", async () => {
     mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-    const result = await deleteTransferRoute.execute(makeReq({ id: "p-1" }), fakeRes());
+    const result = await rejectTransferRoute.execute(makeReq({ id: "p-1" }), fakeRes());
     expect(result?.status).toBe("success");
     expect(mockQuery).toHaveBeenCalledTimes(1);
     const [sql, values] = mockQuery.mock.calls[0];
@@ -104,7 +104,7 @@ describe("delete-transfer", () => {
 
   test("cross-user delete: the route forwards the session user_id, never a client value", async () => {
     mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-    const result = await deleteTransferRoute.execute(
+    const result = await rejectTransferRoute.execute(
       makeReq({ id: "p-belongs-to-B" }, { user: { user_id: "u-A", username: "a" } }),
       fakeRes(),
     );

--- a/src/server/routes/transfers/reject-transfer.ts
+++ b/src/server/routes/transfers/reject-transfer.ts
@@ -7,7 +7,7 @@ import { Route, rejectTransferPair, requireQueryString, validationError } from "
 // transactions remain eligible for other counterparts. Soft-deletion
 // is reserved for the system cascade (when a transaction itself is
 // removed).
-export const deleteTransferRoute = new Route("DELETE", "/transfers", async (req) => {
+export const rejectTransferRoute = new Route("DELETE", "/transfers", async (req) => {
   const { user } = req.session;
   if (!user) {
     return { status: "failed", message: "Request user is not authenticated." };


### PR DESCRIPTION
Multi-concern sweep on the transfer-detection layer. All four pieces fold together because they share the same engine code path and the same user-visible "labeled transactions never get paired" bug.

## Scope

| # | Concern | Files |
|---|---|---|
| 1 | Hidden-account tiebreak + 7-day window | `compute-tools/detect-transfers.ts` |
| 2 | Cascade soft-delete to pairs when a transaction is removed; catch-up cleanup for stale rows | `repositories/transactions.ts`, `compute-tools/detect-transfers.ts` |
| 3 | `status='rejected'` distinct from `is_deleted=TRUE` (rejection vs system-deletion) | `repositories/transfers.ts`, `routes/transfers/reject-transfer.ts` (renamed), `Transaction.ts` |
| 4 | Engine respects rejection (denylist specific pair, transactions stay eligible for OTHER counterparts) | `compute-tools/detect-transfers.ts` |

## Concern 1 — hidden-account tiebreak + 7-day window

When multiple candidates share the same `date_delta`, the previous secondary sort fell straight through to `transaction_id ASC` — opaque alpha order. For users with Plaid duplicate-data accounts (same product mirrored on two account_ids, one hidden), the engine picked the hidden account 50% of the time. The user's manual labels pair against the visible side.

- `fetchCandidates` SQL `LEFT JOIN accounts a1/a2` (LEFT for safety: missing account row → COALESCE(.hide, FALSE)).
- `hidden_count = (a1.hide ? 1 : 0) + (a2.hide ? 1 : 0)`.
- ORDER BY: `date_delta ASC, hidden_count ASC, transaction_id ASC`.
- `DATE_WINDOW_DAYS`: 3 → 7 (catches ACH-delayed transfers).

## Concern 2 — cascade soft-delete + catch-up cleanup

Plaid pending→settled tombstones soft-delete the pending transaction. The pair previously linking to it didn't cascade, so the surviving counterpart stayed "stuck" paired with a ghost — the engine refused to re-suggest it. (The the stuck checking-account case from the linked Discord thread.)

- `deleteTransactions` in `repositories/transactions.ts` now also calls `transactionPairsTable.bulkSoftDeleteByColumn(TRANSACTION_ID_A | _B, tx_id)` per soft-deleted transaction. Mirrors the existing splits cascade.
- `runTransferDetection` starts each per-user loop with an UPDATE that soft-deletes pairs where either transaction is itself soft-deleted (catch-up for already-stale rows that existed before the cascade landed). Logs the count when > 0.

## Concern 3 — rejection distinct from deletion

Per Hoie call: `DELETE /transfers?id=<pair_id>` was soft-deleting the pair (`is_deleted = TRUE`), conflating user-explicit rejection with system-side cascade and losing the user's "no" on the next sync.

- `removeTransferPair` → `rejectTransferPair`. Sets `status = 'rejected'` (leaves `is_deleted = FALSE`).
- Route file renamed `delete-transfer.ts` → `reject-transfer.ts`; export `deleteTransferRoute` → `rejectTransferRoute`. Wire contract unchanged.
- `TransferPairStatus` union extended with `'rejected'`.
- `getTransferPairs` filters `AND status <> 'rejected'` so the FE never receives rejected rows — they're an engine-side denylist signal, not user-visible state.
- `pairTransactions` ON CONFLICT now ALSO un-rejects when a user manually re-pairs (CASE picks `EXCLUDED.status` when existing.status='rejected'). Caught by reviewoie round 1: the prior CASE only un-tombstoned on `is_deleted=TRUE`, so manual confirm silently failed against rejected rows.

## Concern 4 — engine respects rejection

- `fetchCandidates` has two new NOT EXISTS clauses:
  1. Existing-pair filter exempts `status='rejected'` pairs (so the two transactions in a rejected pair stay eligible for OTHER counterparts).
  2. Per-pair denylist excludes the SAME (a, b) from re-suggestion if a rejected pair exists for that exact transaction pair.
- `createPair` INSERT guard symmetric: only suggested/confirmed pairs block; per-pair denylist matches the UNIQUE constraint shape exactly (no is_deleted predicate — UNIQUE doesn't care).

## Verification (against admin user's prod data)

Clean-slate simulation against 385 labeled-as-Transfer transactions, 209 truth-pairs:

| Algorithm | both-labeled ✓ | one-labeled ? | none-labeled ✗ |
|---|---|---|---|
| OLD (3d, txn_id tiebreak) | 161 | 20 | 27 |
| **NEW (7d, hidden-count tiebreak) ★** | **166** | **7** | 36 |

- **+5 correct pairs** (both sides user-labeled-as-Transfer).
- **-65% wrong "one-labeled" pairs** (engine paired a labeled-Transfer with a non-labeled counterpart — the type of mistake that confuses users).
- "None-labeled" (+9) are status='suggested' candidates for user review, not commitments.

For the the stuck checking-account case specifically: catch-up cleanup unsticks the ghost pair on next sync; new candidate `(8q6EJ, 3r9aX)` gets emitted; user sees a suggested pair to confirm.

## Migrations

**No schema migration.** All new behavior uses existing columns:
- `accounts.hide` (existing, boolean).
- `transaction_pairs.status` (existing, VARCHAR(20), now accepts `'rejected'` in addition to `'suggested'` / `'confirmed'`).
- `transaction_pairs.is_deleted` + `updated` (existing).

**Data migration (catch-up):** the engine's per-user stale-pair cleanup runs on next sync. The stuck case + any other stuck pair gets unstuck automatically; user sees the new suggested pair within an hour of deploy.

## Follow-up

- **#542** — delta-by-cursor sync + tombstone delivery for `GET /transfers`. Mirrors the #536 transactions pattern. The cache-staleness implication of cascade soft-delete is masked by the current full-fetch behavior; #542 fixes it properly for future per-pair delta sync.

## Test plan

- `bun test src/server` → **647 pass / 0 fail** (1484 expect calls).
- `bun run typecheck` → clean.
- Engine SQL changes covered via SQL-shape assertions in `detect-transfers.test.ts`.
- `pairTransactions` un-reject branch covered indirectly via existing ON CONFLICT shape test (regex matches the unchanged is_deleted=TRUE THEN EXCLUDED.status branch); a FakePool-fixture for the rejected-row re-pair scenario would strengthen this.
- `rejectTransferPair` SQL asserts `SET status = 'rejected'`, NOT `is_deleted = TRUE`.

## Reviewoie rounds

- Round-1 (concern 1 only): 1 MED + 3 LOWs. Addressed in `fee46ded`.
- Round-2 (after concerns 2+3 folded): 3 HIGH + 2 MED + 2 LOW. Addressed in `59205564` — the HIGH "scope creep" intentionally NOT split per Hoie call (folded by design); title and body updated to make the multi-concern scope explicit.

---

*[Edited 2026-06-23: redacted a specific account balance + account name (real prod figure) from concern 2, verification, and migrations sections — security self-audit §2a. The engine logic and pair IDs are unchanged.]*