### PR TITLE
refactor(transfers): per-status byTransactionId predicates on TransferDictionary

### DIFF
--- a/src/client/components/FlowChartRow/lib.ts
+++ b/src/client/components/FlowChartRow/lib.ts
@@ -55,9 +55,6 @@ export const getSankeyData = (
   let income = 0;
   let expense = 0;
 
-  const isConfirmedTransferHalf = (transaction_id: string): boolean =>
-    transfers.getByTransactionId(transaction_id)?.status === "confirmed";
-
   // Group split children under their parent so the parent's flow
   // contribution can be reduced by what the children re-attribute.
   // Skip splits whose parent transaction is absent or is a confirmed
@@ -66,13 +63,13 @@ export const getSankeyData = (
   splitTransactions.forEach((splitTransaction) => {
     const { transaction_id } = splitTransaction;
     if (!transactions.get(transaction_id)) return;
-    if (isConfirmedTransferHalf(transaction_id)) return;
+    if (transfers.byTransactionId.hasConfirmed(transaction_id)) return;
     transactionFamilies.add(transaction_id, splitTransaction);
   });
 
   const processTransaction = (t: Transaction | InvestmentTransaction) => {
     const isInvestment = t instanceof InvestmentTransaction;
-    if (!isInvestment && isConfirmedTransferHalf(t.transaction_id)) {
+    if (!isInvestment && transfers.byTransactionId.hasConfirmed(t.transaction_id)) {
       return;
     }
     const authorized_date = !isInvestment ? t.authorized_date : undefined;
@@ -132,7 +129,7 @@ export const getSankeyData = (
     // the synthetic transaction's id to the split's own id, so the
     // in-`processTransaction` confirmed-transfer guard would never fire
     // for a split even when its parent is a confirmed transfer half.
-    if (isConfirmedTransferHalf(st.transaction_id)) return;
+    if (transfers.byTransactionId.hasConfirmed(st.transaction_id)) return;
     processTransaction(st.toTransaction());
   });
 

--- a/src/client/components/TransactionProperties/index.tsx
+++ b/src/client/components/TransactionProperties/index.tsx
@@ -281,7 +281,7 @@ export const TransactionProperties = ({ transaction }: Props) => {
       const tDateMs = new LocalDate(t.authorized_date || t.date).getTime();
       if (Math.abs(tDateMs - txDateMs) > PARTNER_DATE_WINDOW_DAYS * ONE_DAY_MS) return;
       // Skip transactions already in any pair (confirmed or suggested).
-      if (transfers.getByTransactionId(t.transaction_id)) return;
+      if (transfers.byTransactionId.has(t.transaction_id)) return;
       candidates.push(t);
     });
     candidates.sort((a, b) => {

--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -105,7 +105,7 @@ const TransactionRow = ({ transaction }: Props) => {
   // transactions, and a split inherits its parent's transaction_id.
   const pendingTransferPair = isSplitTransaction
     ? undefined
-    : transfers.getByTransactionId(transaction_id);
+    : transfers.byTransactionId.get(transaction_id);
   const suggestedPairId =
     pendingTransferPair?.status === "suggested" ? pendingTransferPair.pair_id : undefined;
 

--- a/src/client/components/TransactionsTable/index.tsx
+++ b/src/client/components/TransactionsTable/index.tsx
@@ -29,7 +29,7 @@ export const TransactionsTable = ({ transactions }: Props) => {
       // a TransferRow; suggested pairs still render as two
       // individual TransactionRows with the Confirm/Reject controls.
       if (e instanceof Transaction) {
-        const lookedUp = transfers.getByTransactionId(e.transaction_id);
+        const lookedUp = transfers.byTransactionId.get(e.transaction_id);
         const pair = lookedUp?.status === "confirmed" ? lookedUp : undefined;
         if (pair) {
           if (renderedPairIds.has(pair.pair_id)) return null;

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -45,20 +45,17 @@ export const getBudgetData = (
 
   const transactionFamilies = new TransactionFamilies();
 
-  const isConfirmedTransferHalf = (transaction_id: string): boolean =>
-    transfers.getByTransactionId(transaction_id)?.status === "confirmed";
-
   splitTransactions.forEach((splitTransaction) => {
     const { transaction_id } = splitTransaction;
     const transaction = transactions.get(transaction_id);
     if (!transaction) return;
-    if (isConfirmedTransferHalf(transaction_id)) return;
+    if (transfers.byTransactionId.hasConfirmed(transaction_id)) return;
     transactionFamilies.add(transaction_id, splitTransaction);
   });
 
   const processTransaction = (transaction: Transaction) => {
     const { transaction_id, authorized_date, date, account_id, label, amount } = transaction;
-    if (isConfirmedTransferHalf(transaction_id)) return;
+    if (transfers.byTransactionId.hasConfirmed(transaction_id)) return;
     const transactionDate = new LocalDate(authorized_date || date);
     const account = accounts.get(account_id);
     if (!account || account.hide) return;
@@ -165,7 +162,7 @@ export const getBudgetData = (
     // split's own id per `SplitTransaction.toTransaction()` — so the
     // in-`processTransaction` guard on line ~51 would never fire for
     // splits even when their parent is a confirmed transfer).
-    if (isConfirmedTransferHalf(st.transaction_id)) return;
+    if (transfers.byTransactionId.hasConfirmed(st.transaction_id)) return;
     const transaction = st.toTransaction();
     processTransaction(transaction);
   });

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -277,8 +277,9 @@ interface FetchTransfersResult {
  * useSync alongside the other model fetches so a cold/warm load
  * paints with pair state already in place. Returns a single
  * TransferDictionary (pair_id → TransferPair) — consumers resolve
- * transaction_id lookups via `transfers.getByTransactionId(id)` which
- * is O(1) over the dictionary's internal pivot map. Mutation methods
+ * transaction_id lookups via `transfers.byTransactionId.get(id)` (and
+ * the `has`/`hasSuggested`/`hasConfirmed` membership predicates), each
+ * O(1) over the dictionary's internal pivot map. Mutation methods
  * in `useTransfers` update `data.transfers` in-place via `setData`
  * (no re-fetch on mutation).
  */

--- a/src/client/lib/models/Data.ts
+++ b/src/client/lib/models/Data.ts
@@ -119,13 +119,17 @@ export class TransactionDictionary extends Dictionary<Transaction, TransactionDi
  * Pair-keyed dictionary of transfers. Keys are pair_id; values are the
  * server's TransferPair (with status + the two transactions). Maintains
  * a private `pivot: transaction_id → pair` so consumers can resolve "is
- * this transaction part of any pair?" in O(1) via getByTransactionId(),
- * without standing up a parallel map at the Data level. Overrides
+ * this transaction part of any pair?" in O(1) via the `byTransactionId`
+ * accessor, without standing up a parallel map at the Data level. Overrides
  * `set`/`delete` to keep the pivot in sync with the primary map.
  *
- * Suggested and confirmed pairs live in the same dictionary — consumers
- * filter on `pair.status` at the point of use (matches the suggested-
- * vs-confirmed category-label pattern already in use elsewhere).
+ * Suggested and confirmed pairs live in the same dictionary. The
+ * `byTransactionId` accessor exposes the per-status membership predicates
+ * (`hasSuggested`/`hasConfirmed`) so the calc layer reads "is this a
+ * confirmed transfer half?" as one method call instead of spelling out
+ * a `pair?.status === "confirmed"` check at every site (matches the
+ * suggested-vs-confirmed category-label pattern already in use
+ * elsewhere). `.get` returns the pair for consumers that need its body.
  */
 export class TransferDictionary extends Dictionary<TransferPair, TransferDictionary> {
   private pivot = new Map<string, TransferPair>();
@@ -140,8 +144,22 @@ export class TransferDictionary extends Dictionary<TransferPair, TransferDiction
     });
   }
 
-  getByTransactionId = (transaction_id: string): TransferPair | undefined => {
-    return this.pivot.get(transaction_id);
+  /**
+   * Per-transaction_id accessors over the pivot. `get`/`has` answer
+   * membership; `hasSuggested`/`hasConfirmed` answer "is this transaction
+   * a half of a pair in that status?" in O(1) without the caller spelling
+   * out the `.status === …` check. Note: keys are real transaction_ids;
+   * synthetic split transactions (`SplitTransaction.toTransaction()`)
+   * carry the split's own id, so a lookup on a synthetic split returns
+   * undefined — callers guard the split pass on the PARENT's id.
+   */
+  byTransactionId = {
+    get: (transaction_id: string): TransferPair | undefined => this.pivot.get(transaction_id),
+    has: (transaction_id: string): boolean => this.pivot.has(transaction_id),
+    hasSuggested: (transaction_id: string): boolean =>
+      this.pivot.get(transaction_id)?.status === "suggested",
+    hasConfirmed: (transaction_id: string): boolean =>
+      this.pivot.get(transaction_id)?.status === "confirmed",
   };
 
   // Dictionary's `set` is an arrow-function field, not a prototype

--- a/src/client/lib/models/TransferDictionary.test.ts
+++ b/src/client/lib/models/TransferDictionary.test.ts
@@ -1,0 +1,75 @@
+import { test, expect, describe } from "bun:test";
+import type { TransferPair } from "server";
+import { TransferDictionary } from "./Data";
+
+// Build a one-pair dictionary whose two halves carry the given ids and
+// status. Mirrors what `data.transfers` holds after `fetchTransfers`.
+const makePair = (
+  pair_id: string,
+  status: TransferPair["status"],
+  transaction_ids: [string, string],
+): TransferPair => ({
+  pair_id,
+  status,
+  transactions: transaction_ids.map((id) => ({ transaction_id: id }) as never),
+});
+
+describe("TransferDictionary.byTransactionId", () => {
+  const dict = new TransferDictionary();
+  dict.set("conf", makePair("conf", "confirmed", ["c1", "c2"]));
+  dict.set("sugg", makePair("sugg", "suggested", ["s1", "s2"]));
+
+  test("get returns the pair for either half, undefined for a non-member", () => {
+    expect(dict.byTransactionId.get("c1")?.pair_id).toBe("conf");
+    expect(dict.byTransactionId.get("c2")?.pair_id).toBe("conf");
+    expect(dict.byTransactionId.get("s1")?.pair_id).toBe("sugg");
+    expect(dict.byTransactionId.get("nope")).toBeUndefined();
+  });
+
+  test("has answers membership regardless of status", () => {
+    expect(dict.byTransactionId.has("c1")).toBe(true);
+    expect(dict.byTransactionId.has("s2")).toBe(true);
+    expect(dict.byTransactionId.has("nope")).toBe(false);
+  });
+
+  test("hasConfirmed is true only for halves of a confirmed pair", () => {
+    expect(dict.byTransactionId.hasConfirmed("c1")).toBe(true);
+    expect(dict.byTransactionId.hasConfirmed("c2")).toBe(true);
+    expect(dict.byTransactionId.hasConfirmed("s1")).toBe(false);
+    expect(dict.byTransactionId.hasConfirmed("nope")).toBe(false);
+  });
+
+  test("hasSuggested is true only for halves of a suggested pair", () => {
+    expect(dict.byTransactionId.hasSuggested("s1")).toBe(true);
+    expect(dict.byTransactionId.hasSuggested("s2")).toBe(true);
+    expect(dict.byTransactionId.hasSuggested("c1")).toBe(false);
+    expect(dict.byTransactionId.hasSuggested("nope")).toBe(false);
+  });
+
+  test("status flips follow set(): re-setting a pair as confirmed updates the predicates", () => {
+    const d = new TransferDictionary();
+    d.set("p", makePair("p", "suggested", ["a", "b"]));
+    expect(d.byTransactionId.hasSuggested("a")).toBe(true);
+    expect(d.byTransactionId.hasConfirmed("a")).toBe(false);
+    d.set("p", makePair("p", "confirmed", ["a", "b"]));
+    expect(d.byTransactionId.hasSuggested("a")).toBe(false);
+    expect(d.byTransactionId.hasConfirmed("a")).toBe(true);
+  });
+
+  test("delete evicts both halves from the pivot", () => {
+    const d = new TransferDictionary();
+    d.set("p", makePair("p", "confirmed", ["a", "b"]));
+    expect(d.byTransactionId.has("a")).toBe(true);
+    d.delete("p");
+    expect(d.byTransactionId.has("a")).toBe(false);
+    expect(d.byTransactionId.has("b")).toBe(false);
+  });
+
+  test("pivot is hydrated from the constructor init (not just incremental set)", () => {
+    const seed = new TransferDictionary();
+    seed.set("p", makePair("p", "confirmed", ["a", "b"]));
+    const copy = new TransferDictionary(seed);
+    expect(copy.byTransactionId.hasConfirmed("a")).toBe(true);
+    expect(copy.byTransactionId.get("b")?.pair_id).toBe("p");
+  });
+});

--- a/src/client/pages/TransactionDetailPage/index.tsx
+++ b/src/client/pages/TransactionDetailPage/index.tsx
@@ -25,7 +25,7 @@ export const TransactionDetailPage = () => {
   // entity, not one side of it (Hoie 2026-06-17). Branch on whether the
   // clicked transaction is part of a confirmed pair and render the
   // dedicated `TransferProperties` view if so.
-  const lookedUp = transfers.getByTransactionId(transaction.transaction_id);
+  const lookedUp = transfers.byTransactionId.get(transaction.transaction_id);
   const confirmedTransfer = lookedUp?.status === "confirmed" ? lookedUp : undefined;
 
   return (

--- a/src/client/pages/TransactionsPage/index.tsx
+++ b/src/client/pages/TransactionsPage/index.tsx
@@ -142,7 +142,7 @@ export const TransactionsPage = () => {
           // (TransactionsTable/index.tsx, TransactionRow.tsx).
           return (
             e instanceof Transaction &&
-            !!transfers.getByTransactionId(e.transaction_id)
+            transfers.byTransactionId.has(e.transaction_id)
           );
         }
         return false;


### PR DESCRIPTION
## What

Adds a `byTransactionId` accessor to `TransferDictionary` (`src/client/lib/models/Data.ts`) exposing four O(1) reads over the existing `transaction_id → pair` pivot:

- `get(id)` — the pair (for consumers that need its body)
- `has(id)` — membership in any pair
- `hasSuggested(id)` / `hasConfirmed(id)` — membership in a pair of that status

The calc layer can now read "is this a confirmed transfer half?" as one method call instead of spelling out `getByTransactionId(id)?.status === "confirmed"` at every site. Removes the local `isConfirmedTransferHalf` helper that `getBudgetData` and `getSankeyData` each hand-rolled, and migrates the 7 consumer call sites (TransactionProperties, TransactionsTable, TransactionRow, TransactionsPage, TransactionDetailPage, plus the two calc functions) off the removed `getByTransactionId` method onto the new accessor (`.get` where the pair body is used, `.has` for membership-only checks). The `useFetchTransfers` JSDoc in `src/client/lib/hooks/sync.ts` is updated to reference the new accessor (comment-only; no runtime change).

This is the read-side / transfer half of the PR #528 review ask ("the membership predicates we use in calc should live on the dictionary, not inline").

## Behavior-preserving

The predicates read the same pivot the old helper read, so the confirmed-transfer exclusion in budget + flow calculations is unchanged. The split-pass guards still key on the PARENT transaction_id (synthetic split transactions carry the split's own id, which is not a pivot key — documented on the accessor).

## Why the label-category half is deferred

The issue also sketched `transactions.byLabel.hasConfirmed(transaction_id)` to replace the `category_confidence === 1 && category_id` derivation in `getBudgetData`. That half is **not** in this PR: `processTransaction` is also called with synthetic split transactions (`SplitTransaction.toTransaction()`, budgets.ts) whose `transaction_id` is the split's own id and is **not** a key in the `transactions` dictionary — so a by-id `byLabel.hasConfirmed(id)` lookup would return undefined and misclassify confirmed splits as unsorted. That needs a predicate that reads the in-hand label rather than re-looking-up by id; left open on the issue for a design call.

## Test plan

- `bun test src/client/lib/models/TransferDictionary.test.ts` — 7 new tests pinning get/has/hasSuggested/hasConfirmed, pivot hydration on construct, status flip via `set()`, eviction via `delete()`. All pass.
- `bun test src/client/lib/hooks/calculation/budgets.test.ts` — 16 existing budget calc tests green (confirmed-transfer exclusion unchanged).
- `bun test src/client/lib/models src/client/lib/hooks/calculation` — 217 pass, 0 fail.
- `npx tsc --noEmit` — clean. `eslint` on all changed files — clean.
- E2E (Transactions page transfer rows, transaction detail transfer view, Flow chart): see sandbox verification in a follow-up comment.

Part of #532 (transfer-predicate half). The TransactionDictionary `byLabel` half remains open there.
