### PR TITLE
fix(transfers): engine takes per-user advisory lock — close concurrent-engine race (#548)

### DIFF
--- a/src/server/lib/compute-tools/detect-transfers.test.ts
+++ b/src/server/lib/compute-tools/detect-transfers.test.ts
@@ -80,10 +80,59 @@ describe("scoreConfidence", () => {
   });
 });
 
+/**
+ * Pattern-match the SQL to decide what to return. Tests set the relevant
+ * arrays/responses before invoking; transaction control (BEGIN, advisory
+ * lock, SAVEPOINT, RELEASE, ROLLBACK TO, COMMIT, ROLLBACK) all return
+ * empty by default. Per-user-loop runs BEGIN → advisory lock → cleanup
+ * UPDATE → candidates SELECT → (SAVEPOINT → INSERT → RELEASE) per pair
+ * → COMMIT — 8+ calls; mockResolvedValueOnce sequencing got brittle, so
+ * we match on SQL shape.
+ */
+function setupMock(opts: {
+  users?: ReturnType<typeof userRow>[];
+  candidates?: unknown[];
+  insertResult?: { rows: unknown[]; rowCount: number };
+  insertRejector?: (sql: string, values: unknown[]) => boolean;
+}) {
+  const users = opts.users ?? [];
+  const candidates = opts.candidates ?? [];
+  const insertResult = opts.insertResult ?? { rows: [], rowCount: 1 };
+
+  mockQuery.mockImplementation(async (sql: string, values?: unknown[]) => {
+    // Boilerplate (transaction control): all return empty.
+    if (
+      /^\s*(BEGIN|COMMIT|ROLLBACK|SAVEPOINT|RELEASE|ROLLBACK TO)\b/i.test(sql) ||
+      /pg_advisory_xact_lock/i.test(sql)
+    ) {
+      return { rows: [], rowCount: 0 };
+    }
+    // Stale-pair cleanup UPDATE.
+    if (/^\s*UPDATE\s+transaction_pairs/i.test(sql) && /is_deleted\s*=\s*TRUE/i.test(sql)) {
+      return { rows: [], rowCount: 0 };
+    }
+    // SELECT users.
+    if (/FROM\s+users/i.test(sql) && /^SELECT/i.test(sql.trim())) {
+      return { rows: users, rowCount: users.length };
+    }
+    // fetchCandidates SELECT.
+    if (/JOIN\s+transactions\s+t2/i.test(sql)) {
+      return { rows: candidates, rowCount: candidates.length };
+    }
+    // INSERT INTO transaction_pairs.
+    if (/INSERT\s+INTO\s+transaction_pairs/i.test(sql)) {
+      if (opts.insertRejector && opts.insertRejector(sql, values ?? [])) {
+        throw new Error("insert rejected by test");
+      }
+      return insertResult;
+    }
+    return { rows: [], rowCount: 0 };
+  });
+}
+
 describe("runTransferDetection", () => {
   test("does nothing when there are no users", async () => {
-    // SELECT users returns empty → loop doesn't enter.
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    setupMock({ users: [] });
 
     await runTransferDetection();
 
@@ -91,78 +140,73 @@ describe("runTransferDetection", () => {
   });
 
   test("inserts a pair for a single candidate above threshold", async () => {
-    // SELECT users → [user-1]
-    mockQuery.mockResolvedValueOnce({ rows: [userRow({ user_id: "user-1" })], rowCount: 1 });
-    // Stale-pair cleanup UPDATE — runs before fetchCandidates (0 cleaned).
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-    // SELECT candidates for user-1 → one matching pair
-    mockQuery.mockResolvedValueOnce({
-      rows: [
-        {
-          transaction_id_a: "txn-a",
-          transaction_id_b: "txn-b",
-          date_delta: 1,
-          is_plaid_transfer: false,
-        },
+    setupMock({
+      users: [userRow({ user_id: "user-1" })],
+      candidates: [
+        { transaction_id_a: "txn-a", transaction_id_b: "txn-b", date_delta: 1, is_plaid_transfer: false },
       ],
-      rowCount: 1,
     });
-    // INSERT transaction_pairs
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
     await runTransferDetection();
 
     const inserts = findInsertCalls();
     expect(inserts).toHaveLength(1);
-    // Insert carries user_id + both transaction_ids.
     expect(inserts[0].values).toContain("user-1");
     expect(inserts[0].values).toContain("txn-a");
     expect(inserts[0].values).toContain("txn-b");
   });
 
   test("prevents a single transaction from being paired twice in one run", async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [userRow({ user_id: "user-1" })], rowCount: 1 });
-    // Stale-pair cleanup UPDATE.
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-    mockQuery.mockResolvedValueOnce({
-      rows: [
-        {
-          transaction_id_a: "txn-shared",
-          transaction_id_b: "txn-1",
-          date_delta: 0,
-          is_plaid_transfer: false,
-        },
-        {
-          transaction_id_a: "txn-shared",
-          transaction_id_b: "txn-2",
-          date_delta: 1,
-          is_plaid_transfer: false,
-        },
-        {
-          transaction_id_a: "txn-1",
-          transaction_id_b: "txn-3",
-          date_delta: 0,
-          is_plaid_transfer: false,
-        },
+    setupMock({
+      users: [userRow({ user_id: "user-1" })],
+      candidates: [
+        { transaction_id_a: "txn-shared", transaction_id_b: "txn-1", date_delta: 0, is_plaid_transfer: false },
+        { transaction_id_a: "txn-shared", transaction_id_b: "txn-2", date_delta: 1, is_plaid_transfer: false },
+        { transaction_id_a: "txn-1", transaction_id_b: "txn-3", date_delta: 0, is_plaid_transfer: false },
       ],
-      rowCount: 3,
     });
-    // Only ONE INSERT should fire — the second/third candidates are
-    // skipped because their txn ids are already used in the first pair.
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
     await runTransferDetection();
 
     const inserts = findInsertCalls();
     expect(inserts).toHaveLength(1);
-    // First candidate consumed txn-shared + txn-1.
     expect(inserts[0].values).toContain("txn-shared");
     expect(inserts[0].values).toContain("txn-1");
     expect(inserts[0].values).not.toContain("txn-2");
     expect(inserts[0].values).not.toContain("txn-3");
   });
 
-  test("processes each user independently and isolates failures", async () => {
+  test("per-user BEGIN+advisory-lock+COMMIT wraps the work (serializes against manual mutations and concurrent engine runs)", async () => {
+    setupMock({
+      users: [userRow({ user_id: "user-1" })],
+      candidates: [
+        { transaction_id_a: "tx-a", transaction_id_b: "tx-b", date_delta: 0, is_plaid_transfer: false },
+      ],
+    });
+
+    await runTransferDetection();
+
+    const calls = mockQuery.mock.calls.map((c) => c[0] as string);
+    const begins = calls.filter((s) => /^BEGIN$/i.test(s));
+    const locks = calls.filter((s) => /pg_advisory_xact_lock/i.test(s));
+    const commits = calls.filter((s) => /^COMMIT$/i.test(s));
+    expect(begins).toHaveLength(1);
+    expect(locks).toHaveLength(1);
+    expect(commits).toHaveLength(1);
+    // Lock key uses the user_id (so engine + manual mutations on the same
+    // user serialize). Round 1 (`pairTransactions`) uses the same key.
+    const lockCall = mockQuery.mock.calls.find((c) =>
+      /pg_advisory_xact_lock/i.test(c[0] as string),
+    )!;
+    expect(lockCall[1] as unknown[]).toContain("user-1");
+  });
+
+  test.skip("processes each user independently and isolates failures", async () => {
+    // Skipped: the new pattern-based mock can't easily stage different
+    // per-user candidate responses. Coverage retained via the
+    // savepoint-isolation test below + the engine's outer per-user
+    // try/catch wraps the BEGIN/COMMIT block so a user's failure rolls
+    // back its own transaction and the loop continues.
     // SELECT users → [user-bad, user-good]
     mockQuery.mockResolvedValueOnce({
       rows: [userRow({ user_id: "user-bad" }), userRow({ user_id: "user-good" })],
@@ -196,7 +240,46 @@ describe("runTransferDetection", () => {
     expect(inserts[0].values).toContain("g-b");
   });
 
-  test("logs but continues when an INSERT throws", async () => {
+  test("savepoint-isolates per-pair INSERT failure — failing pair rolls back to savepoint, loop continues with rest", async () => {
+    // Two candidates. First INSERT will throw; the engine should ROLLBACK
+    // TO SAVEPOINT, log the error, and proceed to the second candidate.
+    let inserts = 0;
+    setupMock({
+      users: [userRow({ user_id: "user-1" })],
+      candidates: [
+        { transaction_id_a: "a1", transaction_id_b: "b1", date_delta: 0, is_plaid_transfer: false },
+        { transaction_id_a: "a2", transaction_id_b: "b2", date_delta: 0, is_plaid_transfer: false },
+      ],
+      insertRejector: (_sql, values) => {
+        inserts++;
+        // First attempt throws (UNIQUE collision simulation); second succeeds.
+        return inserts === 1;
+      },
+    });
+
+    await runTransferDetection();
+
+    const insertCalls = findInsertCalls();
+    // Both INSERT attempts fired: first threw (caught + ROLLBACK TO SAVEPOINT),
+    // second succeeded.
+    expect(insertCalls).toHaveLength(2);
+    // SAVEPOINT was issued for BOTH attempts.
+    const savepoints = mockQuery.mock.calls.filter((c) =>
+      /^SAVEPOINT/i.test(c[0] as string),
+    );
+    expect(savepoints.length).toBeGreaterThanOrEqual(2);
+    // ROLLBACK TO SAVEPOINT fired (for the failed first attempt).
+    const rollbackTos = mockQuery.mock.calls.filter((c) =>
+      /^ROLLBACK TO SAVEPOINT/i.test(c[0] as string),
+    );
+    expect(rollbackTos.length).toBeGreaterThanOrEqual(1);
+    // Outer transaction still COMMITs (we want the second pair to persist).
+    const commits = mockQuery.mock.calls.filter((c) => /^COMMIT$/i.test(c[0] as string));
+    expect(commits).toHaveLength(1);
+  });
+
+  test.skip("logs but continues when an INSERT throws", async () => {
+    // Superseded by the savepoint-isolation test above.
     mockQuery.mockResolvedValueOnce({ rows: [userRow({ user_id: "user-1" })], rowCount: 1 });
     // Stale-pair cleanup UPDATE.
     mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });

--- a/src/server/lib/compute-tools/detect-transfers.test.ts
+++ b/src/server/lib/compute-tools/detect-transfers.test.ts
@@ -91,12 +91,15 @@ describe("scoreConfidence", () => {
  */
 function setupMock(opts: {
   users?: ReturnType<typeof userRow>[];
-  candidates?: unknown[];
+  candidates?: unknown[] | ((userId: string) => unknown[]);
   insertResult?: { rows: unknown[]; rowCount: number };
   insertRejector?: (sql: string, values: unknown[]) => boolean;
+  /** Throws on the cleanup UPDATE for the named user — simulates a per-user
+   *  failure so we can verify the engine isolates it and continues to the
+   *  next user. */
+  cleanupFailOnUser?: string;
 }) {
   const users = opts.users ?? [];
-  const candidates = opts.candidates ?? [];
   const insertResult = opts.insertResult ?? { rows: [], rowCount: 1 };
 
   mockQuery.mockImplementation(async (sql: string, values?: unknown[]) => {
@@ -109,6 +112,9 @@ function setupMock(opts: {
     }
     // Stale-pair cleanup UPDATE.
     if (/^\s*UPDATE\s+transaction_pairs/i.test(sql) && /is_deleted\s*=\s*TRUE/i.test(sql)) {
+      if (opts.cleanupFailOnUser && (values ?? [])[0] === opts.cleanupFailOnUser) {
+        throw new Error("cleanup rejected by test");
+      }
       return { rows: [], rowCount: 0 };
     }
     // SELECT users.
@@ -117,6 +123,10 @@ function setupMock(opts: {
     }
     // fetchCandidates SELECT.
     if (/JOIN\s+transactions\s+t2/i.test(sql)) {
+      const candidates =
+        typeof opts.candidates === "function"
+          ? opts.candidates((values ?? [])[0] as string)
+          : opts.candidates ?? [];
       return { rows: candidates, rowCount: candidates.length };
     }
     // INSERT INTO transaction_pairs.
@@ -201,12 +211,47 @@ describe("runTransferDetection", () => {
     expect(lockCall[1] as unknown[]).toContain("user-1");
   });
 
-  test.skip("processes each user independently and isolates failures", async () => {
-    // Skipped: the new pattern-based mock can't easily stage different
-    // per-user candidate responses. Coverage retained via the
-    // savepoint-isolation test below + the engine's outer per-user
-    // try/catch wraps the BEGIN/COMMIT block so a user's failure rolls
-    // back its own transaction and the loop continues.
+  test("processes each user independently and isolates failures", async () => {
+    // user-bad's cleanup UPDATE throws → ROLLBACK + log + continue to user-good.
+    // user-good has a candidate that's INSERTed successfully.
+    setupMock({
+      users: [
+        userRow({ user_id: "user-bad" }),
+        userRow({ user_id: "user-good" }),
+      ],
+      candidates: (userId) =>
+        userId === "user-good"
+          ? [
+              {
+                transaction_id_a: "g-a",
+                transaction_id_b: "g-b",
+                date_delta: 0,
+                is_plaid_transfer: true,
+              },
+            ]
+          : [],
+      cleanupFailOnUser: "user-bad",
+    });
+
+    await runTransferDetection();
+
+    const inserts = findInsertCalls();
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0].values).toContain("user-good");
+    expect(inserts[0].values).toContain("g-a");
+    expect(inserts[0].values).toContain("g-b");
+    // user-bad's transaction must have ROLLBACK'd.
+    const rollbacks = mockQuery.mock.calls.filter(
+      (c) => /^ROLLBACK$/i.test(c[0] as string),
+    );
+    expect(rollbacks.length).toBeGreaterThanOrEqual(1);
+    // user-good's transaction must have COMMITted.
+    const commits = mockQuery.mock.calls.filter((c) => /^COMMIT$/i.test(c[0] as string));
+    expect(commits).toHaveLength(1);
+  });
+
+  test.skip("processes each user independently and isolates failures (legacy)", async () => {
+    // Superseded by the multi-user test above.
     // SELECT users → [user-bad, user-good]
     mockQuery.mockResolvedValueOnce({
       rows: [userRow({ user_id: "user-bad" }), userRow({ user_id: "user-good" })],

--- a/src/server/lib/compute-tools/detect-transfers.test.ts
+++ b/src/server/lib/compute-tools/detect-transfers.test.ts
@@ -295,7 +295,7 @@ describe("runTransferDetection", () => {
         { transaction_id_a: "a1", transaction_id_b: "b1", date_delta: 0, is_plaid_transfer: false },
         { transaction_id_a: "a2", transaction_id_b: "b2", date_delta: 0, is_plaid_transfer: false },
       ],
-      insertRejector: (_sql, values) => {
+      insertRejector: (_sql, _values) => {
         inserts++;
         // First attempt throws (UNIQUE collision simulation); second succeeds.
         return inserts === 1;

--- a/src/server/lib/compute-tools/detect-transfers.ts
+++ b/src/server/lib/compute-tools/detect-transfers.ts
@@ -242,6 +242,36 @@ export const runTransferDetection = async (): Promise<void> => {
           });
         }
 
+        // Pre-step 2: backfill cleanup for hidden-account pairs left over
+        // from before #541's hidden-account exclusion landed.
+        // `fetchCandidates` now excludes hidden accounts at the source so
+        // no NEW such pairs get created, but legacy rows (recurring
+        // monthly suggestions involving hidden duplicate-data accounts)
+        // still surface as live suggestions in the FE. Soft-delete them:
+        // these are duplicate-data-shadow pairs the user never intended;
+        // the visible-account pair is the real one. Same mechanism as
+        // the stale-pair cleanup above — system-side cascade
+        // (`is_deleted=TRUE`), not user-intent rejection.
+        const hiddenPairCleanup = await client.query(
+          `UPDATE transaction_pairs tp
+           SET is_deleted = TRUE, updated = CURRENT_TIMESTAMP
+           WHERE tp.user_id = $1
+             AND (tp.is_deleted IS NULL OR tp.is_deleted = FALSE)
+             AND EXISTS (
+               SELECT 1 FROM transactions t
+               JOIN accounts a ON a.account_id = t.account_id
+               WHERE t.transaction_id IN (tp.transaction_id_a, tp.transaction_id_b)
+                 AND COALESCE(a.hide, FALSE) = TRUE
+             )`,
+          [userId],
+        );
+        if ((hiddenPairCleanup.rowCount ?? 0) > 0) {
+          logger.info("Cleaned hidden-account transfer pairs", {
+            userId,
+            count: hiddenPairCleanup.rowCount,
+          });
+        }
+
         const candidates = await fetchCandidates(userId, client);
         if (candidates.length === PER_USER_CANDIDATE_LIMIT) {
           // The LIMIT just truncated the candidate set; the highest-

--- a/src/server/lib/compute-tools/detect-transfers.ts
+++ b/src/server/lib/compute-tools/detect-transfers.ts
@@ -242,36 +242,6 @@ export const runTransferDetection = async (): Promise<void> => {
           });
         }
 
-        // Pre-step 2: backfill cleanup for hidden-account pairs left over
-        // from before #541's hidden-account exclusion landed.
-        // `fetchCandidates` now excludes hidden accounts at the source so
-        // no NEW such pairs get created, but legacy rows (recurring
-        // monthly suggestions involving hidden duplicate-data accounts)
-        // still surface as live suggestions in the FE. Soft-delete them:
-        // these are duplicate-data-shadow pairs the user never intended;
-        // the visible-account pair is the real one. Same mechanism as
-        // the stale-pair cleanup above — system-side cascade
-        // (`is_deleted=TRUE`), not user-intent rejection.
-        const hiddenPairCleanup = await client.query(
-          `UPDATE transaction_pairs tp
-           SET is_deleted = TRUE, updated = CURRENT_TIMESTAMP
-           WHERE tp.user_id = $1
-             AND (tp.is_deleted IS NULL OR tp.is_deleted = FALSE)
-             AND EXISTS (
-               SELECT 1 FROM transactions t
-               JOIN accounts a ON a.account_id = t.account_id
-               WHERE t.transaction_id IN (tp.transaction_id_a, tp.transaction_id_b)
-                 AND COALESCE(a.hide, FALSE) = TRUE
-             )`,
-          [userId],
-        );
-        if ((hiddenPairCleanup.rowCount ?? 0) > 0) {
-          logger.info("Cleaned hidden-account transfer pairs", {
-            userId,
-            count: hiddenPairCleanup.rowCount,
-          });
-        }
-
         const candidates = await fetchCandidates(userId, client);
         if (candidates.length === PER_USER_CANDIDATE_LIMIT) {
           // The LIMIT just truncated the candidate set; the highest-

--- a/src/server/lib/compute-tools/detect-transfers.ts
+++ b/src/server/lib/compute-tools/detect-transfers.ts
@@ -1,5 +1,5 @@
 import { pool, logger, usersTable } from "server";
-import { canonicalizePairIds } from "../postgres/models";
+import { canonicalizePairIds, QueryExecutor } from "../postgres/models";
 
 const BASE_CONFIDENCE = 0.7;
 const PLAID_TRANSFER_BOOST = 0.2;
@@ -30,7 +30,10 @@ const fetchUsers = async (): Promise<string[]> => {
   return users.map((u) => u.user_id);
 };
 
-const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> => {
+const fetchCandidates = async (
+  userId: string,
+  executor: QueryExecutor = pool,
+): Promise<DetectionCandidate[]> => {
   // Hidden-account exclusion: `account.hide=TRUE` marks an account as
   // duplicate-data view of another (Plaid occasionally surfaces the
   // same product on two `account_id`s; the user hides the redundant
@@ -40,7 +43,7 @@ const fetchCandidates = async (userId: string): Promise<DetectionCandidate[]> =>
   // transactions compete with their visible twins, leaving labeled
   // transactions on the hidden side unpaired even when the engine
   // would correctly pair the visible side.
-  const result = await pool.query(
+  const result = await executor.query(
     `SELECT
        t1.transaction_id AS transaction_id_a,
        t2.transaction_id AS transaction_id_b,
@@ -107,6 +110,7 @@ const createPair = async (
   userId: string,
   transactionIdA: string,
   transactionIdB: string,
+  executor: QueryExecutor = pool,
 ): Promise<void> => {
   const pair_id = crypto.randomUUID();
   const canonical = canonicalizePairIds(transactionIdA, transactionIdB);
@@ -117,7 +121,7 @@ const createPair = async (
   // pair, even with a different counterpart (the candidates query already
   // filters these out, but the IN clause closes the SELECT-then-INSERT
   // race window).
-  await pool.query(
+  await executor.query(
     `INSERT INTO transaction_pairs
        (pair_id, user_id, transaction_id_a, transaction_id_b, status)
      SELECT $1, $2, $3, $4, 'suggested'
@@ -194,7 +198,23 @@ export const runTransferDetection = async (): Promise<void> => {
   try {
     const userIds = await fetchUsers();
     for (const userId of userIds) {
+      // Per-user transaction with advisory lock: serializes against
+      // `pairTransactions` / `confirmTransferPair` (same lock key, added
+      // in #547) AND against any other concurrent `runTransferDetection`
+      // invocation for this user (e.g. scheduled cron + manual sync
+      // trigger firing back-to-back). Without this, both engine runs
+      // see "A is free" via separate NOT EXISTS reads under READ
+      // COMMITTED and both INSERT pairs involving A — a transaction in
+      // two simultaneous active pairs, the exact invariant #547 was
+      // meant to enforce.
+      const client = await pool.connect();
       try {
+        await client.query("BEGIN");
+        await client.query(
+          `SELECT pg_advisory_xact_lock(hashtext($1 || ':transfers'))`,
+          [userId],
+        );
+
         // Pre-step: cascade soft-delete any existing pair whose own
         // `is_deleted` is FALSE but at least one of its referenced
         // transactions has been soft-deleted since the pair was
@@ -203,7 +223,7 @@ export const runTransferDetection = async (): Promise<void> => {
         // filter excludes it from re-detection forever. Going forward,
         // `deleteTransactions` cascades to pairs at the source, so
         // this catch-up step handles already-stale rows.
-        const stalePairCleanup = await pool.query(
+        const stalePairCleanup = await client.query(
           `UPDATE transaction_pairs tp
            SET is_deleted = TRUE, updated = CURRENT_TIMESTAMP
            WHERE tp.user_id = $1
@@ -222,7 +242,7 @@ export const runTransferDetection = async (): Promise<void> => {
           });
         }
 
-        const candidates = await fetchCandidates(userId);
+        const candidates = await fetchCandidates(userId, client);
         if (candidates.length === PER_USER_CANDIDATE_LIMIT) {
           // The LIMIT just truncated the candidate set; the highest-
           // `date_delta` rows fell off the end. Surface so the cap can
@@ -249,16 +269,27 @@ export const runTransferDetection = async (): Promise<void> => {
           );
           if (confidence < SUGGEST_THRESHOLD) continue;
 
+          // SAVEPOINT-per-pair: if `createPair` throws (UNIQUE violation
+          // from a concurrent insert that snuck through, transient DB
+          // error, etc.), we want to ROLLBACK TO that savepoint and
+          // continue with the rest of the candidates — not abort the
+          // whole per-user transaction and lose any pairs created
+          // earlier in the loop. Matches the pre-transaction semantics
+          // where each `createPair` failure logged + continued.
+          await client.query("SAVEPOINT pair_attempt");
           try {
             await createPair(
               userId,
               candidate.transaction_id_a,
               candidate.transaction_id_b,
+              client,
             );
+            await client.query("RELEASE SAVEPOINT pair_attempt");
             usedTxnIds.add(candidate.transaction_id_a);
             usedTxnIds.add(candidate.transaction_id_b);
             userSuggested++;
           } catch (err) {
+            await client.query("ROLLBACK TO SAVEPOINT pair_attempt");
             logger.error(
               "Failed to insert transfer pair",
               {
@@ -271,6 +302,8 @@ export const runTransferDetection = async (): Promise<void> => {
           }
         }
 
+        await client.query("COMMIT");
+
         totalSuggested += userSuggested;
         totalUsers++;
         if (userSuggested > 0) {
@@ -281,7 +314,10 @@ export const runTransferDetection = async (): Promise<void> => {
           });
         }
       } catch (err) {
+        await client.query("ROLLBACK").catch(() => {});
         logger.error("Transfer detection failed for user", { userId }, err);
+      } finally {
+        client.release();
       }
     }
   } catch (err) {

--- a/src/server/lib/compute-tools/detect-transfers.ts
+++ b/src/server/lib/compute-tools/detect-transfers.ts
@@ -1,4 +1,5 @@
 import { pool, logger, usersTable } from "server";
+import type { PoolClient } from "pg";
 import { canonicalizePairIds, QueryExecutor } from "../postgres/models";
 
 const BASE_CONFIDENCE = 0.7;
@@ -207,8 +208,9 @@ export const runTransferDetection = async (): Promise<void> => {
       // COMMITTED and both INSERT pairs involving A — a transaction in
       // two simultaneous active pairs, the exact invariant #547 was
       // meant to enforce.
-      const client = await pool.connect();
+      let client: PoolClient | undefined;
       try {
+        client = await pool.connect();
         await client.query("BEGIN");
         await client.query(
           `SELECT pg_advisory_xact_lock(hashtext($1 || ':transfers'))`,
@@ -314,10 +316,10 @@ export const runTransferDetection = async (): Promise<void> => {
           });
         }
       } catch (err) {
-        await client.query("ROLLBACK").catch(() => {});
+        if (client) await client.query("ROLLBACK").catch(() => {});
         logger.error("Transfer detection failed for user", { userId }, err);
       } finally {
-        client.release();
+        if (client) client.release();
       }
     }
   } catch (err) {


### PR DESCRIPTION
Closes #548

## What

`runTransferDetection` (the cron engine) didn't take the per-user `pg_advisory_xact_lock` that #547 added to `pairTransactions`/`confirmTransferPair`. Two concurrent engine runs could both pass each-other's NOT EXISTS guards under READ COMMITTED and INSERT overlapping pairs `(A, B)` + `(A, C)` — exactly the integrity invariant #547 was meant to enforce.

## Fix

Wrap per-user body in a DB transaction + acquire the same advisory lock as the manual paths:

```ts
const client = await pool.connect();
await client.query("BEGIN");
await client.query(
  `SELECT pg_advisory_xact_lock(hashtext($1 || ':transfers'))`,
  [userId],
);
// cleanup UPDATE + fetchCandidates + per-pair createPair loop
await client.query("COMMIT");
```

Same lock key as #547 → engine serializes against `pairTransactions`/`confirmTransferPair` too, not just other engine invocations.

**SAVEPOINT-per-pair** preserves the original per-pair failure isolation. Without savepoints, a single `createPair` failure (UNIQUE 23505, transient DB error) would abort the whole per-user transaction. With savepoints, only the failing pair is rolled back; the rest of the loop continues.

**`fetchCandidates`** and **`createPair`** widened to accept an optional `QueryExecutor` (default `pool`), so the engine can thread its transaction client through.

## Test plan

- [x] `bun test src/server` — 654 pass / 0 fail / 2 skip (1512 expects)
- [x] `bun run typecheck` — clean
- [x] New test: "per-user BEGIN+advisory-lock+COMMIT wraps the work" asserts exactly 1 BEGIN, 1 advisory_lock with `user_id` in values, 1 COMMIT per user run.
- [x] New test: "savepoint-isolates per-pair INSERT failure" simulates UNIQUE collision on first pair → ROLLBACK TO SAVEPOINT → continues + commits successful second pair.
- [ ] **E2E sandbox** — pending: drive two concurrent `runTransferDetection` invocations against the sandbox, verify no overlapping pairs created.

Test refactor note: `runTransferDetection` tests switched from sequential `mockResolvedValueOnce` staging to a pattern-based `mockImplementation`. Two pre-existing tests `.skip`'d (process-each-user-independently, logs-but-continues) — coverage retained by the new savepoint-isolation test + outer per-user try/catch (which already isolates user failures pre-transaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
