### PR TITLE
fix(transactions): Accept-All alerts on per-item failures (collision/stale) (#551)

### DIFF
--- a/src/client/pages/TransactionsPage/index.tsx
+++ b/src/client/pages/TransactionsPage/index.tsx
@@ -354,17 +354,48 @@ export const TransactionsPage = () => {
     );
 
     const acceptedIds = new Set<string>();
+    let failedLabels = 0;
+    let firstFailedLabelMessage: string | undefined;
     labelResults.forEach((r, i) => {
       if (r.status === "fulfilled" && r.value.status === "success") {
         acceptedIds.add(suggestedInView[i]!.id);
+      } else {
+        failedLabels++;
+        if (!firstFailedLabelMessage && r.status === "fulfilled" && r.value.message) {
+          firstFailedLabelMessage = r.value.message;
+        }
       }
     });
     const acceptedPairIds = new Set<string>();
+    let failedPairs = 0;
+    let firstFailedPairMessage: string | undefined;
     transferResults.forEach((r, i) => {
       if (r.status === "fulfilled" && r.value.status === "success") {
         acceptedPairIds.add(suggestedTransferPairsInView[i]!.pair_id);
+      } else {
+        failedPairs++;
+        if (!firstFailedPairMessage && r.status === "fulfilled" && r.value.message) {
+          firstFailedPairMessage = r.value.message;
+        }
       }
     });
+
+    // Surface any per-item failures so the user knows the bulk Accept-All
+    // wasn't fully applied. Common cause: a transfer pair-confirm collides
+    // with an already-confirmed pair (per the #547 integrity guard). Per-row
+    // mutations surface via `useTransfers.confirm`'s alert; the bulk path
+    // had no such signal before — failures were silently dropped from
+    // `acceptedPairIds`.
+    const totalFailed = failedLabels + failedPairs;
+    if (totalFailed > 0) {
+      const totalAttempted = labelResults.length + transferResults.length;
+      const sampleMessage = firstFailedPairMessage ?? firstFailedLabelMessage;
+      const detail = sampleMessage ? ` First reason: ${sampleMessage}` : "";
+      window.alert(
+        `${totalFailed} of ${totalAttempted} couldn't be accepted` +
+          ` (likely a collision with an existing confirmed pair or stale state).${detail}`,
+      );
+    }
 
     if (acceptedIds.size || acceptedPairIds.size) {
       setData((oldData) => {


### PR DESCRIPTION
Closes #551

## What

`TransactionsPage.onClickAcceptAll` was using `Promise.allSettled` and silently dropping failed mutations from `acceptedPairIds` / `acceptedIds`. After #547 introduced the per-row collision-rejection on transfer-pair confirms, the bulk path could now genuinely return `{ status: "failed" }` responses — but the user got no signal. Click "Accept all 25 suggestions", 24 confirm, 1 collides, the FE just shows 24 confirmed.

## Fix

Count per-bucket failures + surface a summary alert with the first server-returned message as a hint:

```
N of M couldn't be accepted (likely a collision with an existing confirmed pair or stale state). First reason: <server message>
```

Same `window.alert` surface as the per-row `useTransfers.confirm` / `.pair` alert #547 added. Polished toast UI is a separate concern.

Per-item state still updates correctly — accepted items flip to confirmed in FE state; failed items remain in their pre-click state (still suggested in the dictionary).

## Test plan

- [x] `bun test src/server` → 654 pass / 0 fail (1509 expects).
- [x] `bun run typecheck` → clean.
- [ ] **E2E sandbox** — pending: seed a collision (confirmed `(A,B)` + suggested `(A,C)`), click Accept-all, verify alert shows "1 of N couldn't be accepted".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
