### PR TITLE
feat(accounts): user-toggleable 'archived' flag for accounts no longer in active use (#555)

### DIFF
--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -214,13 +214,20 @@ export const AccountProperties = ({ account }: Props) => {
               <span className="propertyName">Hide</span>
               <ToggleInput checked={isHidden} onChange={onClickHide} />
             </div>
-            <div className="row keyValue">
-              <span className="propertyName">Archive</span>
-              <ToggleInput checked={isArchived} onChange={onClickArchive} />
-            </div>
           </div>
         </>
       )}
+      {/* Archive is available for both Plaid- and manual-tracked accounts.
+       *  Manual accounts can age out too (e.g. a brokerage account the user
+       *  stopped using). Distinct from Delete, which removes the history
+       *  the user wants to preserve. */}
+      <div className="propertyLabel">Archive</div>
+      <div className="property">
+        <div className="row keyValue">
+          <span className="propertyName">Archive</span>
+          <ToggleInput checked={isArchived} onChange={onClickArchive} />
+        </div>
+      </div>
       <div className="propertyLabel">Navigate</div>
       <div className="property">
         <div className="row button">

--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -44,6 +44,8 @@ export const AccountProperties = ({ account }: Props) => {
     onChangeBudgetSelect,
     isHidden,
     onClickHide,
+    isArchived,
+    onClickArchive,
     useTransactionsForGraph,
     onClickUseTransactionsForGraph,
     useSnapshotsForGraph,
@@ -211,6 +213,10 @@ export const AccountProperties = ({ account }: Props) => {
             <div className="row keyValue">
               <span className="propertyName">Hide</span>
               <ToggleInput checked={isHidden} onChange={onClickHide} />
+            </div>
+            <div className="row keyValue">
+              <span className="propertyName">Archive</span>
+              <ToggleInput checked={isArchived} onChange={onClickArchive} />
             </div>
           </div>
         </>

--- a/src/client/components/AccountProperties/lib/hooks.ts
+++ b/src/client/components/AccountProperties/lib/hooks.ts
@@ -18,7 +18,7 @@ import { ChangeEventHandler, MouseEventHandler, useEffect, useState } from "reac
 import { AccountPostResponse, SnapshotPostResponse } from "server";
 
 export const useAccountEventHandlers = (account: Account, cursorAmount?: number) => {
-  const { account_id, custom_name, type, label, hide, graphOptions, balances } = account;
+  const { account_id, custom_name, type, label, hide, archived, graphOptions, balances } = account;
 
   const { data, setData, viewDate, router } = useAppContext();
 
@@ -46,6 +46,7 @@ export const useAccountEventHandlers = (account: Account, cursorAmount?: number)
   const [selectedBudgetIdLabel, setSelectedBudgetIdLabel] = useState(label.budget_id || "");
 
   const [isHidden, setIsHidden] = useState(hide);
+  const [isArchived, setIsArchived] = useState(archived ?? false);
   const [useTransactionsForGraph, setUseTransactionsForGraph] = useState(
     graphOptions?.useTransactions,
   );
@@ -138,6 +139,37 @@ export const useAccountEventHandlers = (account: Account, cursorAmount?: number)
       .catch((error) => {
         console.error("Failed to update account visibility:", error);
         setIsHidden(previousValue);
+      });
+  };
+
+  const onClickArchive: ChangeEventHandler<HTMLInputElement> = (e) => {
+    e.stopPropagation();
+    const { checked } = e.target;
+    const previousValue = isArchived;
+    setIsArchived(checked);
+    if (!account_id) return;
+    call
+      .post("/api/account", { account_id, archived: checked })
+      .then((r) => {
+        if (r.status === "success") {
+          setData((oldData) => {
+            const newData = new Data(oldData);
+            const existingAccount = newData.accounts.get(account_id);
+            if (!existingAccount) return oldData;
+            const newAccount = new Account({ ...existingAccount, archived: checked });
+            indexedDb.save(newAccount).catch(console.error);
+            const newAccounts = new AccountDictionary(newData.accounts);
+            newAccounts.set(account_id, newAccount);
+            newData.accounts = newAccounts;
+            return newData;
+          });
+        } else {
+          setIsArchived(previousValue);
+        }
+      })
+      .catch((error) => {
+        console.error("Failed to update account archived state:", error);
+        setIsArchived(previousValue);
       });
   };
 
@@ -358,6 +390,8 @@ export const useAccountEventHandlers = (account: Account, cursorAmount?: number)
     onChangeBudgetSelect,
     isHidden,
     onClickHide,
+    isArchived,
+    onClickArchive,
     useTransactionsForGraph,
     onClickUseTransactionsForGraph,
     useSnapshotsForGraph,

--- a/src/client/components/AccountsTable/index.tsx
+++ b/src/client/components/AccountsTable/index.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from "react";
+import { CSSProperties, ReactNode, useState } from "react";
 import { AccountType } from "plaid";
 import {
   Account,
@@ -26,6 +26,12 @@ export const AccountsTable = ({ donutData, style }: Props) => {
   const { data, setData } = useAppContext();
   const { accounts } = data;
 
+  // Archived accounts hidden behind a toggle. Distinct from "Hide" (which
+  // removes the account from view entirely + skips it for transfer
+  // detection / duplicate-data shadowing). Archived = "I'm done using
+  // this account but its history still counts in budget calc."
+  const [showArchived, setShowArchived] = useState(false);
+
   const donutAccounts: ReactNode[] = donutData.map(({ id, color }) => {
     const account = accounts.get(id);
     if (!account) return <></>;
@@ -33,11 +39,18 @@ export const AccountsTable = ({ donutData, style }: Props) => {
   });
 
   const creditAccounts: ReactNode[] = [];
+  const archivedAccounts: ReactNode[] = [];
   let hasHiddenAccounts = false;
+  let archivedCount = 0;
 
   accounts.forEach((a) => {
     if (a.hide) {
       hasHiddenAccounts = true;
+      return;
+    }
+    if (a.archived) {
+      archivedCount++;
+      archivedAccounts.push(<AccountRow key={a.account_id} account={a} />);
       return;
     }
     const element = <AccountRow key={a.account_id} account={a} />;
@@ -84,6 +97,14 @@ export const AccountsTable = ({ donutData, style }: Props) => {
     <div className="AccountsTable" style={style}>
       {!!donutAccounts.length && <div className="rows">{donutAccounts}</div>}
       {!!creditAccounts.length && <div className="rows">{creditAccounts}</div>}
+      {archivedCount > 0 && (
+        <div>
+          <button onClick={() => setShowArchived((v) => !v)}>
+            {showArchived ? "Hide" : "Show"}&nbsp;archived&nbsp;({archivedCount})
+          </button>
+          {showArchived && <div className="rows">{archivedAccounts}</div>}
+        </div>
+      )}
       <div>{hasHiddenAccounts && <button onClick={onClickUnhide}>Unhide&nbsp;All</button>}</div>
       {!accounts.size && (
         <div className="placeholder">

--- a/src/client/lib/models/Account.ts
+++ b/src/client/lib/models/Account.ts
@@ -39,6 +39,12 @@ export class Account implements JSONAccount {
    */
   hide: boolean = false;
   /**
+   * User-set "archived" flag — hides the account from the Accounts page by
+   * default while keeping its historical transactions in calc. Distinct
+   * from `hide` (duplicate-data shadow). Calc layer ignores this flag.
+   */
+  archived: boolean = false;
+  /**
    * Represents relations by budget_id.
    */
   label: AccountLabel = {

--- a/src/client/pages/AccountsPage/index.tsx
+++ b/src/client/pages/AccountsPage/index.tsx
@@ -36,12 +36,16 @@ export const AccountsPage = () => {
       .toArray()
       .sort((a, b) => getAccountBalance(b) - getAccountBalance(a));
 
-    const filteredAccounts = sortedAccounts.filter(({ hide, type }) => {
-      return !hide && type !== AccountType.Credit;
+    // Exclude both `hide` (duplicate-data Plaid shadow) and `archived`
+    // (user-marked-out-of-active-view, typically expired cards) from the
+    // donut + credit-total. Both flags only affect FE visibility; the
+    // calc layer iterates all non-deleted accounts regardless.
+    const filteredAccounts = sortedAccounts.filter(({ hide, archived, type }) => {
+      return !hide && !archived && type !== AccountType.Credit;
     });
 
-    sortedAccounts.forEach(({ hide, type, balances }) => {
-      if (hide || type !== AccountType.Credit) return;
+    sortedAccounts.forEach(({ hide, archived, type, balances }) => {
+      if (hide || archived || type !== AccountType.Credit) return;
       totalCredit += balances.current || 0;
       numberOfCredits++;
     });

--- a/src/common/models/Account.ts
+++ b/src/common/models/Account.ts
@@ -70,6 +70,20 @@ export interface JSONAccount extends PlaidAccount {
    */
   hide: boolean;
   /**
+   * User-set flag for "keep this account's history but hide it from the
+   * Accounts page by default" — typically used for expired cards or closed
+   * accounts whose historical transactions are still meaningful for budget
+   * calculation. Distinct from `hide` (which is the duplicate-data-shadow
+   * flag for Plaid's multi-account-id products). Budget/balance/sankey
+   * calc ignores this flag; it's FE-visibility only.
+   *
+   * Optional: legacy account rows from before the column existed return
+   * `undefined`; sync paths that construct fresh `JSONAccount` from Plaid
+   * data don't pre-set it. Reader sites should treat `undefined` as
+   * `false`.
+   */
+  archived?: boolean;
+  /**
    * Represents relations by budget_id.
    */
   label: AccountLabel;

--- a/src/server/lib/postgres/models/account.ts
+++ b/src/server/lib/postgres/models/account.ts
@@ -22,6 +22,7 @@ import {
   BALANCES_ISO_CURRENCY_CODE,
   CUSTOM_NAME,
   HIDE,
+  ARCHIVED,
   LABEL_BUDGET_ID,
   GRAPH_OPTIONS_USE_SNAPSHOTS,
   GRAPH_OPTIONS_USE_HOLDING_SNAPSHOTS,
@@ -48,6 +49,7 @@ const accountSchema = {
   [BALANCES_ISO_CURRENCY_CODE]: "VARCHAR(10)",
   [CUSTOM_NAME]: "TEXT",
   [HIDE]: "BOOLEAN DEFAULT FALSE",
+  [ARCHIVED]: "BOOLEAN DEFAULT FALSE",
   [LABEL_BUDGET_ID]: "UUID",
   [GRAPH_OPTIONS_USE_SNAPSHOTS]: "BOOLEAN DEFAULT TRUE",
   [GRAPH_OPTIONS_USE_HOLDING_SNAPSHOTS]: "BOOLEAN DEFAULT TRUE",
@@ -74,6 +76,7 @@ export class AccountModel extends Model<JSONAccount, AccountSchema> implements A
   declare balances_iso_currency_code: string;
   declare custom_name: string;
   declare hide: boolean;
+  declare archived: boolean;
   declare label_budget_id: string | null;
   declare graph_options_use_snapshots: boolean;
   declare graph_options_use_holding_snapshots: boolean;
@@ -96,6 +99,7 @@ export class AccountModel extends Model<JSONAccount, AccountSchema> implements A
     balances_iso_currency_code: isNullableString,
     custom_name: isNullableString,
     hide: isNullableBoolean,
+    archived: isNullableBoolean,
     label_budget_id: isNullableString,
     graph_options_use_snapshots: isNullableBoolean,
     graph_options_use_holding_snapshots: isNullableBoolean,
@@ -128,6 +132,7 @@ export class AccountModel extends Model<JSONAccount, AccountSchema> implements A
       },
       custom_name: this.custom_name,
       hide: this.hide,
+      archived: this.archived ?? false,
       label: { budget_id: this.label_budget_id },
       graphOptions: {
         useSnapshots: this.graph_options_use_snapshots,
@@ -150,6 +155,7 @@ export class AccountModel extends Model<JSONAccount, AccountSchema> implements A
     if (!isUndefined(a.subtype)) r.subtype = a.subtype;
     if (!isUndefined(a.custom_name)) r.custom_name = a.custom_name;
     if (!isUndefined(a.hide)) r.hide = a.hide;
+    if (!isUndefined(a.archived)) r.archived = a.archived;
     if (a.label && !isUndefined(a.label.budget_id)) r.label_budget_id = a.label.budget_id;
     if (a.balances) {
       if (!isUndefined(a.balances.available)) r.balances_available = a.balances.available;
@@ -166,7 +172,14 @@ export class AccountModel extends Model<JSONAccount, AccountSchema> implements A
       if (!isUndefined(a.graphOptions.useTransactions))
         r.graph_options_use_transactions = a.graphOptions.useTransactions;
     }
-    const { custom_name: _custom_name, hide: _hide, label: _label, graphOptions: _graphOptions, ...providerData } = a;
+    const {
+      custom_name: _custom_name,
+      hide: _hide,
+      archived: _archived,
+      label: _label,
+      graphOptions: _graphOptions,
+      ...providerData
+    } = a;
     r.raw = providerData;
     return r;
   }

--- a/src/server/lib/postgres/models/common.ts
+++ b/src/server/lib/postgres/models/common.ts
@@ -68,6 +68,7 @@ export const BALANCES_LIMIT = "balances_limit";
 export const BALANCES_ISO_CURRENCY_CODE = "balances_iso_currency_code";
 export const CUSTOM_NAME = "custom_name";
 export const HIDE = "hide";
+export const ARCHIVED = "archived";
 export const LABEL_BUDGET_ID = "label_budget_id";
 export const GRAPH_OPTIONS_USE_SNAPSHOTS = "graph_options_use_snapshots";
 export const GRAPH_OPTIONS_USE_HOLDING_SNAPSHOTS = "graph_options_use_holding_snapshots";

--- a/src/server/lib/postgres/repositories/accounts.test.ts
+++ b/src/server/lib/postgres/repositories/accounts.test.ts
@@ -45,6 +45,7 @@ function makeAccountRow(overrides: Record<string, unknown> = {}) {
     balances_iso_currency_code: "USD",
     custom_name: null,
     hide: false,
+    archived: false,
     label_budget_id: null,
     graph_options_use_snapshots: false,
     graph_options_use_holding_snapshots: false,


### PR DESCRIPTION
Closes #555

## What

Expired credit cards (and other inactive accounts) clutter the Accounts page even though their historical transactions are still meaningful for budget calc. The existing `accounts.hide` flag is reserved for duplicate-data Plaid shadows (#541) — different semantics.

Per Hoie 2026-06-24 (channel 1519476246407286795): no auto-detection (Plaid doesn't expose card-expiration; inactivity heuristics flake on manual accounts). User-toggleable flag only.

## Fix shape

- **Schema:** `accounts.archived BOOLEAN DEFAULT FALSE` column. Auto-migration applies on deploy; existing rows default `false`.
- **Server:** `AccountModel` declares + serializes the field. The existing `POST /api/account` route already handles arbitrary field updates via `AccountPostBody`.
- **FE:**
  - New "Archive" toggle row in `AccountProperties` (below "Hide"), wired to a new `onClickArchive` handler.
  - `AccountsPage` donut + credit-total exclude `archived` in addition to `hide`.
  - `AccountsTable` puts archived accounts in a separate section behind a "Show archived (N)" / "Hide archived (N)" toggle.

## Calc layer: unchanged

`getBalanceData` / `getBudgetData` / `getSankeyData` / transfer-detection / engine continue iterating `accounts.filter(!is_deleted)` regardless of `archived`. The flag is FE-visibility-only.

## Composability with `hide`

- `hide=TRUE` (Plaid duplicate-data shadow): hidden from Accounts page + excluded from transfer-detection candidate generation (#541). Surfaced via "Unhide All" button.
- `archived=TRUE` (user marked out of active view): hidden from Accounts page + included in the archived section behind a toggle.
- Both: hidden from Accounts page, only re-surfaces via "Unhide All" (hide takes precedence).

## Test plan

- [x] `bun test src/server` → 654 pass / 0 fail (1509 expects)
- [x] `bun run typecheck` → clean
- [ ] **E2E sandbox** — pending: click Archive on a real account, verify it disappears from donut + credit list, appears in "Show archived (1)" toggle, calc-layer (`/api/budgets` etc.) still includes its transactions.

## Out of scope

- Auto-detection of expired/closed cards (Plaid doesn't expose the data; manual-account inactivity is unreliable).
- Bulk archive / multi-select.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
