### PR TITLE
fix(transfers): align manual-pair window with engine (7 days, not 3)

### DIFF
--- a/src/client/components/TransactionProperties/index.tsx
+++ b/src/client/components/TransactionProperties/index.tsx
@@ -1,5 +1,10 @@
 import { ChangeEventHandler, useMemo, useState, useEffect } from "react";
-import { currencyCodeToSymbol, LocalDate, numberToCommaString } from "common";
+import {
+  currencyCodeToSymbol,
+  LocalDate,
+  numberToCommaString,
+  TRANSFER_DATE_WINDOW_DAYS as PARTNER_DATE_WINDOW_DAYS,
+} from "common";
 import { NewSplitTransactionGetResponse } from "server";
 import {
   Category,
@@ -18,11 +23,11 @@ import { InstitutionSpan, TransferArrowIcon } from "client/components";
 import SplitTransactionRow from "./SplitTransactionRow";
 import "./index.css";
 
-// Window for the partner-candidate filter — matches the detect-transfers
-// cron's `DATE_WINDOW_DAYS` (see `compute-tools/detect-transfers.ts:8`).
-// Keeping these aligned means a user-driven "Mark as Transfer" surfaces
-// the same set of candidates the algorithm would have considered.
-const PARTNER_DATE_WINDOW_DAYS = 3;
+// Window for the partner-candidate filter — single source of truth in
+// `common/transfers.ts` so the FE picker stays in lockstep with the
+// detect-transfers cron. Previously this was a separate `const` that
+// drifted to 3 days while the cron moved to 7, so engine-surfaced
+// partners outside ±3 days couldn't be manually re-paired.
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 interface Props {

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,3 +1,4 @@
 export * from "./utils";
 export * from "./models";
 export * from "./types";
+export * from "./transfers";

--- a/src/common/transfers.ts
+++ b/src/common/transfers.ts
@@ -1,0 +1,12 @@
+// Constants shared between the server-side transfer-detection engine
+// (`server/lib/compute-tools/detect-transfers.ts`) and the FE manual
+// "Mark as Transfer" partner-picker (`client/components/TransactionProperties`).
+//
+// Both must use the SAME window so any partner the engine would have
+// suggested is also reachable via the manual picker — otherwise the
+// engine produces a suggestion the user can't manually reproduce when
+// they reject it and want to re-pair. (Bug reported 2026-06-25: a 2/2
+// transaction's engine-suggested partner from late January was outside
+// the FE's 3-day window — engine uses 7 — so the manual picker showed
+// "no matching transactions" for a pair the engine had just surfaced.)
+export const TRANSFER_DATE_WINDOW_DAYS = 7;

--- a/src/server/lib/compute-tools/detect-transfers.ts
+++ b/src/server/lib/compute-tools/detect-transfers.ts
@@ -1,3 +1,4 @@
+import { TRANSFER_DATE_WINDOW_DAYS } from "common";
 import { pool, logger, usersTable } from "server";
 import { canonicalizePairIds } from "../postgres/models";
 
@@ -5,7 +6,8 @@ const BASE_CONFIDENCE = 0.7;
 const PLAID_TRANSFER_BOOST = 0.2;
 const SAME_DAY_BOOST = 0.1;
 const SUGGEST_THRESHOLD = 0.7;
-const DATE_WINDOW_DAYS = 7;
+// Re-exported under the local name kept in the SQL comments + JSDoc.
+const DATE_WINDOW_DAYS = TRANSFER_DATE_WINDOW_DAYS;
 const PER_USER_CANDIDATE_LIMIT = 500;
 
 export interface DetectionCandidate {


### PR DESCRIPTION
## Bug

Hoie reported 2026-06-25 with a screenshot: a 2/2 transaction's engine-surfaced suggested-pair partner was a transaction from late January. Going to that transaction's detail page and trying to manually pair via "Mark as Transfer" → the partner-picker showed "no matching transactions within ±3 days".

## Root cause

`PARTNER_DATE_WINDOW_DAYS` in `client/components/TransactionProperties/index.tsx` was **3**.
`DATE_WINDOW_DAYS` in `server/lib/compute-tools/detect-transfers.ts` is **7**.

The two drifted apart — likely the cron's bump from 3→7 (PR #193) wasn't mirrored on the FE. So the engine could suggest a partner 4-7 days away, but the manual picker filtered it out, leaving the user with no way to manually reproduce the pair if they rejected the engine's suggestion and wanted to re-pair it (or pick a different counterpart on the same transaction).

## Fix

Promote the constant to `src/common/transfers.ts` as `TRANSFER_DATE_WINDOW_DAYS = 7`. Both sites import the single source of truth, so any future bump moves them in lockstep.

- Server `DATE_WINDOW_DAYS` keeps its local name (used inside the SQL string + JSDoc) but assigns from the common import.
- FE imports as `PARTNER_DATE_WINDOW_DAYS` (preserves the local name used in the "No matching transactions within ±N days" string).
- Comments at both call sites explain the constraint so the next bump doesn't drift again.

## Test plan

- [x] `bun test src/server` → 654 pass / 0 fail (1509 expects)
- [x] `bun run typecheck` → clean
- [ ] **E2E sandbox**: open a transaction with an engine-suggested partner that's 4-7 days away → "Mark as Transfer" picker → verify the partner appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
