### PR TITLE
fix(budgets): rollover accrues for budget-likes with no confirmed transactions (#545)

### DIFF
--- a/src/client/lib/hooks/calculation/budgets.rollover.test.ts
+++ b/src/client/lib/hooks/calculation/budgets.rollover.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../../models/Data";
 import { Transaction } from "../../models/Transaction";
 import { Budget } from "../../models/Budget";
+import { Category } from "../../models/Category";
 import { Account } from "../../models/Account";
 
 const MONTHLY_CAPACITY = 100;
@@ -137,5 +138,132 @@ describe("getBudgetData rollover cold-sync skip (#484)", () => {
     const stage1 = rolledThisMonth(OLD_START, new TransactionDictionary(), true);
     const stage2 = rolledThisMonth(OLD_START, txns, true);
     expect(stage1).toBe(stage2);
+  });
+});
+
+// Regression coverage for #545: the warm-load accrual loop iterated
+// `budgetData`'s existing keys, so it only ran for budget-likes a confirmed
+// (or, for budgets, any) transaction had touched. A rollover-enabled
+// budget-like with zero such transactions never got a `budgetData` entry, its
+// accrual never ran, and the bar rendered "+ 0 rolled" despite a real capacity
+// and a years-old `roll_over_start_date`. The fix drives the accrual over the
+// budget/section/category dictionaries instead, so the carry is independent of
+// transaction presence.
+describe("getBudgetData rollover accrues without transactions (#545)", () => {
+  const OLD_START = "2022-06-01";
+  const SPEND = 50;
+
+  const makeTwoBudgets = (): BudgetDictionary => {
+    const dict = new BudgetDictionary();
+    // Byte-identical config; the only difference will be that bud-with gets a
+    // single transaction and bud-zero gets none.
+    for (const id of ["bud-with", "bud-zero"]) {
+      const b = new Budget({
+        budget_id: id,
+        user_id: "u1",
+        name: id,
+        iso_currency_code: "USD",
+        capacities: [
+          { active_from: null, children: {}, year: MONTHLY_CAPACITY * 12, month: MONTHLY_CAPACITY, week: 0, day: 0 },
+        ],
+        roll_over: true,
+        roll_over_start_date: OLD_START,
+      });
+      dict.set(b.budget_id, b);
+    }
+    return dict;
+  };
+
+  const makeAccountFor = (budgetId: string): AccountDictionary => {
+    const a = new Account({
+      account_id: "acc-1",
+      name: "Checking",
+      type: "depository" as never,
+      subtype: "checking" as never,
+      label: { budget_id: budgetId, category_id: null },
+    } as never);
+    const dict = new AccountDictionary();
+    dict.set(a.account_id, a);
+    return dict;
+  };
+
+  const makeSpendOn = (budgetId: string): TransactionDictionary => {
+    const dict = new TransactionDictionary();
+    const d = new ViewDate("month").previous(); // last month → rolls into this month
+    const t = new Transaction({
+      transaction_id: "txn-with",
+      account_id: "acc-1",
+      name: "Coffee",
+      merchant_name: "Cafe",
+      amount: SPEND,
+      date: d.getStartDate().toISOString().slice(0, 10),
+      pending: false,
+      label: { budget_id: budgetId, category_id: null },
+    } as never);
+    dict.set(t.transaction_id, t);
+    return dict;
+  };
+
+  const runTwoBudgets = () => {
+    const { budgetData } = getBudgetData(
+      makeSpendOn("bud-with"),
+      emptySplits(),
+      makeAccountFor("bud-with"),
+      makeTwoBudgets(),
+      emptySections(),
+      emptyCategories(),
+      new TransferDictionary(),
+      false, // warm / steady state
+    );
+    const now = new ViewDate("month").getEndDate();
+    return {
+      withTxn: budgetData.get("bud-with", now).rolled_over_amount,
+      zeroTxn: budgetData.get("bud-zero", now).rolled_over_amount,
+    };
+  };
+
+  test("a budget with zero transactions still accrues its capacity carry (not the buggy 0)", () => {
+    const { zeroTxn } = runTwoBudgets();
+    // Full-span capacity carry with no offsetting spending → strongly negative
+    // surplus. The bug rendered exactly 0 here.
+    expect(zeroTxn).toBeLessThan(0);
+  });
+
+  test("zero-txn and with-txn carries differ by exactly the single spend (A/B divergence is only the spend)", () => {
+    const { withTxn, zeroTxn } = runTwoBudgets();
+    // Identical config; the one 50 spend on bud-with reduces its surplus by
+    // exactly that amount. Before the fix, zeroTxn was 0 and the two diverged
+    // by the whole multi-year accrual.
+    expect(withTxn).toBeCloseTo(zeroTxn + SPEND, 6);
+  });
+
+  test("a rollover category with zero transactions accrues (section/category path)", () => {
+    const categories = new CategoryDictionary();
+    const c = new Category({
+      category_id: "cat-1",
+      section_id: "sec-1",
+      name: "Untouched Category",
+      capacities: [
+        { active_from: null, children: {}, year: MONTHLY_CAPACITY * 12, month: MONTHLY_CAPACITY, week: 0, day: 0 },
+      ],
+      roll_over: true,
+      roll_over_start_date: OLD_START,
+    } as never);
+    categories.set(c.category_id, c);
+
+    const { budgetData } = getBudgetData(
+      new TransactionDictionary(),
+      emptySplits(),
+      new AccountDictionary(),
+      new BudgetDictionary(),
+      emptySections(),
+      categories,
+      new TransferDictionary(),
+      false,
+    );
+    const now = new ViewDate("month").getEndDate();
+    // The category is touched by no transaction at all, so under the old
+    // budgetData-keyed loop its accrual never ran and it read 0.
+    expect(budgetData.get("cat-1", now).rolled_over_amount).toBeLessThan(0);
   });
 });

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -11,6 +11,9 @@ import {
   CategoryDictionary,
   AccountDictionary,
   BudgetDictionary,
+  Budget,
+  Section,
+  Category,
 } from "client";
 
 interface GetBudgetDataResult {
@@ -194,12 +197,21 @@ export const getBudgetData = (
     return { transactionFamilies, budgetData };
   }
 
-  budgetData.forEach((history, budgetLikeId) => {
-    const budgetLike =
-      budgets.get(budgetLikeId) || sections.get(budgetLikeId) || categories.get(budgetLikeId);
-    if (!budgetLike) return;
+  // Accrue the per-month capacity carry-forward for EVERY rollover-enabled
+  // budget-like, not just the ones a confirmed transaction happened to
+  // touch. Iterating `budgetData`'s existing keys would skip any budget-like
+  // with no confirmed (sorted) transactions in the window — its history was
+  // never created by `processTransaction`, so its accrual never ran and the
+  // bar rendered "+ 0 rolled" despite a real capacity and a years-old
+  // `roll_over_start_date`. Driving the walk over the budget/section/category
+  // dictionaries makes the carry independent of transaction presence:
+  // `budgetData.get(id)` auto-creates the history for untouched rows, while
+  // touched rows keep the spending `processTransaction` already deposited
+  // (the walk only adds the capacity carry on top of it).
+  const accrueRollover = (budgetLike: Budget | Section | Category) => {
     const { roll_over, roll_over_start_date } = budgetLike;
     if (!roll_over || !roll_over_start_date) return;
+    const history = budgetData.get(budgetLike.id);
     const startDate = new ViewDate("month", roll_over_start_date).next();
     while (startDate.getEndDate() <= endDate.getEndDate()) {
       const previousDate = startDate.clone().previous();
@@ -213,7 +225,11 @@ export const getBudgetData = (
       });
       startDate.next();
     }
-  });
+  };
+
+  budgets.forEach(accrueRollover);
+  sections.forEach(accrueRollover);
+  categories.forEach(accrueRollover);
 
   return { transactionFamilies, budgetData };
 };


### PR DESCRIPTION
## Summary

Closes #545. On the Budgets page, the rollover readout ("+ X rolled" in `LabeledBar`) showed **0** for any rollover-enabled budget / section / category that had **no confirmed (sorted) transactions** in the loaded window — even with a real monthly capacity and a `roll_over_start_date` years in the past. Two identically-configured rollover budget-likes displayed wildly different rollover amounts solely because one happened to have a confirmed transaction and the other had none.

## Root cause

`src/client/lib/hooks/calculation/budgets.ts` — the warm-load accrual loop iterated `budgetData.forEach(...)`, i.e. only the budget-likes that `processTransaction` had already `add()`-ed an entry for. A rollover-enabled budget-like with zero confirmed transactions (for budgets, zero transactions at all — unsorted ones still touch the budget) never got a `budgetData` entry, so its per-month capacity-carry walk never ran and `rolled_over_amount` stayed at the `BudgetSummary` default of 0.

## Fix

Drive the accrual walk over the **budget / section / category dictionaries** (the union of all rollover-enabled budget-likes) instead of over `budgetData`'s existing keys. `budgetData.get(id)` already auto-creates a `BudgetHistory` for untouched rows, and touched rows keep the spending `processTransaction` already deposited — the walk only adds the capacity carry on top, so their steady-state values are byte-identical to before. The cold-sync early-return is unchanged and still sits ahead of the loop, so cold loads are unaffected.

The walk per budget-like is independent of every other (it operates on that row's own history), so iterating in budget→section→category order is equivalent to the old `budgetData` iteration order for the rows that were already covered.

## Tests

Added three cases to `budgets.rollover.test.ts` (existing #484 cold-sync cases still pass):

- A budget with **zero transactions** still accrues its full multi-year capacity carry (a strongly-negative surplus) instead of the buggy 0.
- An A/B pair of byte-identical rollover budgets — one with a single spend, one with none — now diverge by **exactly the one spend amount** (before the fix the zero-txn side was 0 and the two diverged by the whole accrual).
- A rollover **category** touched by no transaction at all accrues a non-zero carry (exercises the section/category path, the common real-world case where every transaction is unconfirmed).

## Verification

- `bun test` rollover suite: 7 pass (4 existing #484 + 3 new). Full `src/client/lib/hooks/calculation/` suite: 96 pass / 0 fail.
- `tsc --noEmit` clean; eslint clean on the changed files.
- E2E walkthrough on the PR sandbox follows in a comment — the assertion is qualitative: a rollover budget-like with no confirmed transactions renders a non-zero "+ … rolled" matching its capacity carry, and a sibling with the same capacity but one confirmed transaction differs only by that transaction's amount (rows and the carry agree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
