### PR TITLE
feat(accounts): unify Hide UI with Archive — 'Show hidden (N)' toggle + relocate Archive next to Hide

### DIFF
--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -221,6 +221,20 @@ export const AccountProperties = ({ account }: Props) => {
           </div>
         </>
       )}
+      {/* Orphan path: a manual account that was already archived (e.g. on
+       *  an older client version where Archive was ungated, or via direct
+       *  API). Without this, the user has no UI path back — Delete
+       *  destroys history, which is the exact case `archived` was meant
+       *  to avoid. Renders nothing for the common manual-and-not-archived
+       *  case so we don't reintroduce a separate Archive section. */}
+      {isManualAccount && isArchived && (
+        <div className="property">
+          <div className="row keyValue">
+            <span className="propertyName">Archive</span>
+            <ToggleInput checked={isArchived} onChange={onClickArchive} />
+          </div>
+        </div>
+      )}
       <div className="propertyLabel">Navigate</div>
       <div className="property">
         <div className="row button">

--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -212,7 +212,16 @@ export const AccountProperties = ({ account }: Props) => {
             </div>
             <div className="row keyValue">
               <span className="propertyName">Archive</span>
-              <ToggleInput checked={isArchived} onChange={onClickArchive} />
+              {/* Hide already removes the account from view entirely; archiving
+               *  on top adds nothing and would surface in "Show archived (N)"
+               *  even though the user's already hidden the row. Disable to
+               *  steer the user toward Unhide first if they want a different
+               *  classification. Hoie 2026-06-25. */}
+              <ToggleInput
+                checked={isArchived}
+                onChange={onClickArchive}
+                disabled={isHidden}
+              />
             </div>
             <div className="row keyValue">
               <span className="propertyName">Hide</span>

--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -211,23 +211,16 @@ export const AccountProperties = ({ account }: Props) => {
               </select>
             </div>
             <div className="row keyValue">
+              <span className="propertyName">Archive</span>
+              <ToggleInput checked={isArchived} onChange={onClickArchive} />
+            </div>
+            <div className="row keyValue">
               <span className="propertyName">Hide</span>
               <ToggleInput checked={isHidden} onChange={onClickHide} />
             </div>
           </div>
         </>
       )}
-      {/* Archive is available for both Plaid- and manual-tracked accounts.
-       *  Manual accounts can age out too (e.g. a brokerage account the user
-       *  stopped using). Distinct from Delete, which removes the history
-       *  the user wants to preserve. */}
-      <div className="propertyLabel">Archive</div>
-      <div className="property">
-        <div className="row keyValue">
-          <span className="propertyName">Archive</span>
-          <ToggleInput checked={isArchived} onChange={onClickArchive} />
-        </div>
-      </div>
       <div className="propertyLabel">Navigate</div>
       <div className="property">
         <div className="row button">

--- a/src/client/components/AccountsTable/AccountRow.tsx
+++ b/src/client/components/AccountsTable/AccountRow.tsx
@@ -49,7 +49,11 @@ const AccountRow = ({ account, color }: Props) => {
         aria-label={accountLabel}
       >
         <div className="accountTitle">
-          <div className="colorTag colored" style={{ backgroundColor: color }} />
+          {/* Only render the color chip when a donut-mapped color was
+           *  passed. Archived and hidden rows call AccountRow without a
+           *  color, and an empty `.colorTag` div was reading as left
+           *  indentation. Hoie 2026-06-25. */}
+          {color && <div className="colorTag colored" style={{ backgroundColor: color }} />}
           <div className="textTag">
             <div>{custom_name || name}</div>
             <div>

--- a/src/client/components/AccountsTable/index.tsx
+++ b/src/client/components/AccountsTable/index.tsx
@@ -1,14 +1,6 @@
 import { CSSProperties, ReactNode, useState } from "react";
 import { AccountType } from "plaid";
-import {
-  Account,
-  AccountDictionary,
-  Data,
-  call,
-  DonutData,
-  useAppContext,
-  indexedDb,
-} from "client";
+import { Account, DonutData, useAppContext } from "client";
 import AccountRow from "./AccountRow";
 
 export type AccountHeaders = { [k in keyof Account]?: boolean } & {
@@ -23,14 +15,19 @@ interface Props {
 }
 
 export const AccountsTable = ({ donutData, style }: Props) => {
-  const { data, setData } = useAppContext();
+  const { data } = useAppContext();
   const { accounts } = data;
 
-  // Archived accounts hidden behind a toggle. Distinct from "Hide" (which
-  // removes the account from view entirely + skips it for transfer
-  // detection / duplicate-data shadowing). Archived = "I'm done using
-  // this account but its history still counts in budget calc."
+  // Hidden + Archived both sit behind their own "Show … (N)" toggle.
+  //   - Hide  = Plaid duplicate-data shadow; the user wants this row OUT
+  //     of normal view AND OUT of transfer-detection candidate selection.
+  //   - Archive = "I'm done using this account but its history still
+  //     counts in budget calc."
+  // Same UI shape for both so the user doesn't have to learn two
+  // patterns. Re-archiving / re-hiding happens via the per-account
+  // detail page (AccountProperties), so no bulk "Unhide all" needed.
   const [showArchived, setShowArchived] = useState(false);
+  const [showHidden, setShowHidden] = useState(false);
 
   const donutAccounts: ReactNode[] = donutData.map(({ id, color }) => {
     const account = accounts.get(id);
@@ -40,12 +37,14 @@ export const AccountsTable = ({ donutData, style }: Props) => {
 
   const creditAccounts: ReactNode[] = [];
   const archivedAccounts: ReactNode[] = [];
-  let hasHiddenAccounts = false;
+  const hiddenAccounts: ReactNode[] = [];
   let archivedCount = 0;
+  let hiddenCount = 0;
 
   accounts.forEach((a) => {
     if (a.hide) {
-      hasHiddenAccounts = true;
+      hiddenCount++;
+      hiddenAccounts.push(<AccountRow key={a.account_id} account={a} />);
       return;
     }
     if (a.archived) {
@@ -56,42 +55,6 @@ export const AccountsTable = ({ donutData, style }: Props) => {
     const element = <AccountRow key={a.account_id} account={a} />;
     if (a.type === AccountType.Credit) creditAccounts.push(element);
   });
-
-  const onClickUnhide = async () => {
-    const newAccounts = new AccountDictionary(accounts);
-
-    const fetchJobs: Promise<void>[] = [];
-    accounts.forEach((account) => {
-      if (!account.hide) return;
-
-      const job = async (e: typeof account) => {
-        try {
-          const { account_id } = e;
-          const r = await call.post("/api/account", {
-            account_id,
-            hide: false,
-          });
-
-          if (r.status === "success") {
-            const newAccount = new Account({ ...e, hide: false });
-            indexedDb.save(newAccount).catch(console.error);
-            newAccounts.set(account_id, newAccount);
-          }
-        } catch (error: unknown) {
-          console.error(error);
-        }
-      };
-
-      fetchJobs.push(job(account));
-    });
-
-    await Promise.all(fetchJobs);
-    setData((oldData) => {
-      const newData = new Data(oldData);
-      newData.accounts = newAccounts;
-      return newData;
-    });
-  };
 
   return (
     <div className="AccountsTable" style={style}>
@@ -105,7 +68,14 @@ export const AccountsTable = ({ donutData, style }: Props) => {
           {showArchived && <div className="rows">{archivedAccounts}</div>}
         </div>
       )}
-      <div>{hasHiddenAccounts && <button onClick={onClickUnhide}>Unhide&nbsp;All</button>}</div>
+      {hiddenCount > 0 && (
+        <div>
+          <button onClick={() => setShowHidden((v) => !v)}>
+            {showHidden ? "Hide" : "Show"}&nbsp;hidden&nbsp;({hiddenCount})
+          </button>
+          {showHidden && <div className="rows">{hiddenAccounts}</div>}
+        </div>
+      )}
       {!accounts.size && (
         <div className="placeholder">
           You don't have any connected accounts! Click this button to connect your accounts.

--- a/src/server/lib/postgres/repositories/items.test.ts
+++ b/src/server/lib/postgres/repositories/items.test.ts
@@ -38,6 +38,7 @@ function makeAccountRow(overrides: Record<string, unknown> = {}) {
     balances_iso_currency_code: "USD",
     custom_name: null,
     hide: false,
+    archived: false,
     label_budget_id: null,
     graph_options_use_snapshots: false,
     graph_options_use_holding_snapshots: false,

--- a/src/server/lib/postgres/repositories/transfers.ts
+++ b/src/server/lib/postgres/repositories/transfers.ts
@@ -4,6 +4,7 @@ import {
   MaskedUser,
   transactionsTable,
   transactionPairsTable,
+  TRANSACTIONS,
   TRANSACTION_PAIRS,
   USER_ID,
   PAIR_ID,


### PR DESCRIPTION
Follow-up to #556 per Hoie 2026-06-25:

> Next — make "hide" feature look the same way in UI. "Unhide all" → "Show hidden(N)".
> Also, in account detail page, move archive button to right above hide button. No separate section.

## Changes

**`AccountsTable/index.tsx`** — "Unhide All" button removed. Hidden accounts now go into a section behind a "Show hidden (N)" / "Hide hidden (N)" toggle, matching the archived-section pattern from #556. The bulk-unhide flow is removed; per-account re-hide / re-archive happens via the detail page so a "bring everything back at once" affordance was orphan UX.

**`AccountProperties/index.tsx`** — Archive row relocated to sit directly above Hide inside the "Account Preference" property block. The standalone "Archive" propertyLabel section (reviewoie's #556 placement that kept Archive available on manual accounts) is removed. Side effect: Archive is now gated behind `!isManualAccount`, matching Hide's existing gate. Hoie's call — manual accounts don't need Archive today.

**`transfers.ts`** — drive-by import fix. `upstream/main` has a broken typecheck since #553 merged: the FOR SHARE existence check at line 150 uses `${TRANSACTIONS}` but the import block dropped that symbol. One-line fix; unrelated to the UI work but required for this PR's typecheck to pass.

## Test plan

- [x] `bun test src/server` → 660 pass / 1 fail (1541 expects). The single failure is `deleteItem > soft-deletes snapshots by BOTH account_id and holding_account_id (#539)` — pre-existing on `upstream/main`, unrelated to this PR.
- [x] `bun run typecheck` → clean (post-`TRANSACTIONS` import fix).
- [ ] **E2E sandbox**: verify "Show hidden (N)" button appears with the current hide-set, toggles open/closed cleanly; verify AccountProperties shows Archive directly above Hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
