### PR TITLE
fix(sankey): exclude invest Buy/Sell — position allocation, not cash flow

### DIFF
--- a/src/client/components/FlowChartRow/lib.test.ts
+++ b/src/client/components/FlowChartRow/lib.test.ts
@@ -248,61 +248,52 @@ const runInv = (d: ReturnType<typeof buildInvDicts>) =>
     noTransfers,
   );
 
-describe("getSankeyData — investment cash-flow polarity", () => {
-  test("a BUY is cash out → counted as expense, not income", () => {
-    // buy: price·quantity = +1000 cash leaving the account
+describe("getSankeyData — investment transactions are skipped (internal moves)", () => {
+  // Investment transactions are internal household moves between user-owned
+  // cash and user-owned equity, not external cash flow. The cash-side
+  // counterpart (the wire from checking to brokerage) is a regular
+  // `transactions` row that already represents the household cash flow.
+  // Counting BOTH the cash-side row and the investment-side row in Sankey
+  // double-counts every dollar moved into or out of brokerage. Verified
+  // against real account data: investment Buys appeared on BOTH the
+  // cash-side (a brokerage-funding wire labeled under a "Transfers" budget
+  // — Sankey doesn't honor budget-name semantics, so it counts as expense)
+  // AND the invest-side, producing a spurious deficit that contradicted the
+  // Accounts donut's balance Δ for the same month. Skipping investment txns
+  // brings the two views into reconciliation modulo market appreciation.
+  // See issue 564 for the cross-table transfer-detection follow-up that
+  // would surface the cash-side wires as confirmed-transfer halves and let
+  // Sankey attribute investment activity per-budget.
+  test("a BUY is skipped (no contribution to expense or income)", () => {
     const { tableData } = runInv(buildInvDicts([mkInvestment(InvestmentTransactionType.Buy, 10, 100)]));
-    expect(tableData.expense).toBe(1000);
+    expect(tableData.expense).toBe(0);
     expect(tableData.income).toBe(0);
   });
 
-  test("a SELL is cash in → counted as income, not expense", () => {
-    // sell: price·quantity = -800 cash entering the account
+  test("a SELL is skipped (no contribution to expense or income)", () => {
     const { tableData } = runInv(buildInvDicts([mkInvestment(InvestmentTransactionType.Sell, -8, 100)]));
-    expect(tableData.income).toBe(800);
     expect(tableData.expense).toBe(0);
+    expect(tableData.income).toBe(0);
   });
 
-  test("buys and sells net to the correct Surplus/Deficit verdict", () => {
-    // 1000 bought (out) vs 800 sold (in) → net 200 deficit, not a surplus
-    const { tableData } = runInv(
+  test("mixed buys + sells contribute nothing to Sankey flow", () => {
+    const { tableData, graphData } = runInv(
       buildInvDicts([
         mkInvestment(InvestmentTransactionType.Buy, 10, 100),
         mkInvestment(InvestmentTransactionType.Sell, -8, 100),
       ]),
     );
-    expect(tableData.expense).toBe(1000);
-    expect(tableData.income).toBe(800);
-    expect(tableData.expense - tableData.income).toBe(200); // deficit
-  });
-
-  // Sign-based detection (Hoie, PR #514): polarity follows `type`, not the
-  // stored sign of `quantity`. A buy with a negative quantity is still cash
-  // out (expense); a sell with a positive quantity is still cash in (income).
-  test("a BUY with a negative quantity is still an expense (sign from type, not quantity)", () => {
-    const { tableData } = runInv(buildInvDicts([mkInvestment(InvestmentTransactionType.Buy, -10, 100)]));
-    expect(tableData.expense).toBe(1000);
-    expect(tableData.income).toBe(0);
-  });
-
-  test("a SELL with a positive quantity is still income (sign from type, not quantity)", () => {
-    const { tableData } = runInv(buildInvDicts([mkInvestment(InvestmentTransactionType.Sell, 8, 100)]));
-    expect(tableData.income).toBe(800);
     expect(tableData.expense).toBe(0);
+    expect(tableData.income).toBe(0);
+    expect(graphData.every((col) => col.length === 0)).toBe(true);
   });
 
-  // Only buy/sell are external cash flow. A `transfer` (or cash/fee/dividend)
-  // row is internal movement and must NOT contribute — even when it carries a
-  // nonzero price·quantity. This is the benchmark.ts "count only Buy/Sell"
-  // convention; without the type gate a transfer's magnitude would inflate a
-  // column (reviewoie HIGH on PR #514).
-  test("a non-buy/sell investment type (transfer) with nonzero price·quantity is skipped", () => {
+  test("a non-buy/sell investment type (transfer/cash/fee/dividend) is skipped — same as before", () => {
     const { tableData, graphData } = runInv(
       buildInvDicts([mkInvestment(InvestmentTransactionType.Transfer, 4875, 1)]),
     );
     expect(tableData.income).toBe(0);
     expect(tableData.expense).toBe(0);
-    // No Surplus/Deficit node either — nothing flowed.
     expect(graphData.every((col) => col.length === 0)).toBe(true);
   });
 

--- a/src/client/components/FlowChartRow/lib.ts
+++ b/src/client/components/FlowChartRow/lib.ts
@@ -1,4 +1,3 @@
-import { InvestmentTransactionType } from "plaid";
 
 import { LocalDate, ViewDate } from "common";
 import {
@@ -86,31 +85,44 @@ export const getSankeyData = (
     const category = category_id && categories.get(category_id);
     const section_id = (category && category.section_id) || `${budget_id}_Unknown`;
     const section = sections.get(section_id);
-    // For an investment, only buy/sell rows are external cash flow; derive
-    // their polarity from the transaction TYPE (a buy is cash out → expense /
-    // positive amount, a sell is cash in → income / negative amount) rather
-    // than from the stored sign of `quantity`, so it stays correct even if
-    // Plaid emits a buy with a negative quantity. Every other type — `cash`,
-    // `fee`, `dividend`, `transfer` — is skipped, matching benchmark.ts
-    // (which counts only `Buy`/`Sell` at lib/hooks/calculation/benchmark.ts).
-    // Skipping `transfer` matters: those carry a nonzero `price * quantity`
-    // (internal movement, not external flow) and would otherwise inflate a
-    // column. Including dividends/fees as flow is deferred per Closes #499.
+    // Investment transactions are internal household moves between
+    // user-owned cash and user-owned equity, not external cash flow.
+    // Their cash-side counterpart is a regular `transactions` row on
+    // the checking account (the wire that funded the Buy, or the
+    // deposit that received the Sell). Counting BOTH the cash-side
+    // row AND the investment-side row in Sankey double-counts every
+    // dollar moved into or out of brokerage. The cash-side row alone
+    // already represents the household cash flow; the
+    // investment-side row represents the asset transformation, which
+    // doesn't belong in cash-flow accounting. Skip all investment
+    // transaction types — buy/sell included.
     //
-    // For a regular parent transaction, subtract its split children's total
-    // so only the un-split remainder is attributed to the parent's label.
-    // Synthetic split transactions (from `toTransaction()`) carry the
-    // split's own id, which keys no family, so their amount is unchanged.
-    let amount: number;
-    if (isInvestment) {
-      if (t.type !== InvestmentTransactionType.Buy && t.type !== InvestmentTransactionType.Sell) {
-        return;
-      }
-      const magnitude = Math.abs(t.price * t.quantity);
-      amount = t.type === InvestmentTransactionType.Buy ? magnitude : -magnitude;
-    } else {
-      amount = t.amount - transactionFamilies.getChildrenAmountTotal(t.transaction_id);
-    }
+    // Trade-off: appreciation/depreciation of manual-tracked
+    // investments (e.g. 401Ks with no transactions) was already
+    // invisible to Sankey and continues to be — Sankey is cash flow,
+    // not net-worth change. The Accounts donut's "from last <interval>"
+    // delta is the right widget for total balance change including
+    // appreciation.
+    //
+    // Verified against real account data: dropping invest-Buy rows from
+    // Out moves Sankey from a spurious deficit to a surplus that
+    // reconciles with the Accounts donut's balance Δ (modulo manual
+    // 401K/RSU appreciation, which Sankey correctly ignores). Closes
+    // the cash-side ↔ invest-side double-count.
+    //
+    // Long-term fix (cross-table transfer-detection) tracked
+    // separately — that would surface the cash-side wires as
+    // confirmed-transfer halves so they're excluded from Sankey
+    // alongside the invest-side, giving the user a richer view that
+    // can still attribute investment activity per-budget.
+    //
+    // For a regular parent transaction, subtract its split children's
+    // total so only the un-split remainder is attributed to the
+    // parent's label. Synthetic split transactions (from
+    // `toTransaction()`) carry the split's own id, which keys no
+    // family, so their amount is unchanged.
+    if (isInvestment) return;
+    const amount = t.amount - transactionFamilies.getChildrenAmountTotal(t.transaction_id);
     if (amount < 0) {
       income -= amount;
       incomeSections.set(section_id, {


### PR DESCRIPTION
Closes the cash-side ↔ invest-side Sankey mismatch Hoie flagged 2026-06-27. Issue #564 captured the diagnosis; this is fix (A) of the two-PR split Hoie asked for. The follow-up was pivoted from cross-table pairing (#566 closed) to manual-account transaction recording (#567 filed) per Hoie's 2026-06-28 design call.

## Verified gap

On the unscrambled prod-clone, April 2026 view (figures redacted):
- **Accounts donut BalanceInfo**: positive balance Δ from last month (Mar→Apr).
- **Dashboard → Cash Flow chart-detail**: substantial Out > In → Net **deficit**.
- The two views disagree by an amount large enough to flip surplus → deficit.

## Root cause

Sankey was treating `investment_transactions` of `type='buy'`/`'sell'` as cash-flow events (Sankey expense / income, respectively, at `FlowChartRow/lib.ts:106`). They aren't household cash flow.

- A **Buy** is a position-allocation inside the brokerage: cash that already arrived at the brokerage being used to acquire securities. No money leaves the household.
- A **Sell** is the inverse: securities → brokerage cash sub-balance. No money enters the household.
- The actual household cash-flow event for a Buy happens earlier at the **cash-side wire** (e.g. a "Manual DB-Bkrg" `transactions` row debiting checking). That row is already counted by Sankey under whatever budget the user labels it.

Counting the Buy as well inflates Sankey's Out by the wire amount; analogous for Sell on the In side.

(Aside: the cash-side wire is recorded on the cash account, but the corresponding credit on the brokerage's cash sub-balance is missing from Plaid's `transactions` feed — a separate data-quality gap that #567 lets the user close manually. This PR doesn't depend on that.)

## Concrete evidence

- N invest Buys on the user's brokerage in the viewed month → counted as Sankey Out via the invest-side path.
- M "Manual DB-Bkrg" `transactions` on the cash-side account, same period → counted as Sankey Out via the cash-side path.
- Sum inflates Sankey Out by the wire total relative to actual external cash flow.

After removing invest-side Buys/Sells, the Sankey reconciles with the Accounts donut's balance Δ modulo manual-401(K)+RSU appreciation that Sankey never sees (Sankey is cash flow; market appreciation is not a cash-flow event).

## Fix

Investment transactions of every type are skipped at the top of `processTransaction`. They never contribute to Sankey flow. The cash-side wire carries the household cash-flow contribution alone, under whatever budget the user labeled it.

## Follow-up — #567 (separate PR)

Manual-account transaction recording UI. Lets the user add `transactions` rows on accounts not connected via Plaid (Fidelity, etc.). The new rows participate in the existing transfer-detection engine and Sankey-exclusion path, closing the remaining gap where intra-household transfers from Plaid-invisible accounts show as Sankey income/expense. No schema change.

## Test plan

- [x] `bun test src/client/components/FlowChartRow` → 8 pass / 0 fail
- [x] `bun test src/server` → 661 pass / 0 fail
- [x] `bun run typecheck` → clean
- [x] **E2E unscrambled local dev** — April 2026 chart-detail with fix: Out drops by the invest-Buy total; Net flips from deficit to surplus. Reconciles with BalanceInfo modulo manual-account market appreciation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
