### PR TITLE
fix(budget): section unfold should scroll the section to viewport top, not jump away

### DIFF
--- a/src/client/components/SectionBar.tsx
+++ b/src/client/components/SectionBar.tsx
@@ -48,6 +48,8 @@ export const SectionBar = ({ section, onSetOrder }: Props) => {
   }, [categories, section_id, setCategoriesOrder]);
 
   const childrenDivRef = useRef<HTMLDivElement>(null);
+  const sectionBarRef = useRef<HTMLDivElement>(null);
+  const pendingScrollToOpen = useRef(false);
 
   const observerRef = useRef(
     new ResizeObserver((entries) => {
@@ -81,11 +83,15 @@ export const SectionBar = ({ section, onSetOrder }: Props) => {
   const { iso_currency_code } = budget;
 
   const openCategory = () => {
+    pendingScrollToOpen.current = true;
     setIsOpen(true);
-    const childrenDiv = childrenDivRef.current;
-    if (!childrenDiv) return;
-    childrenDiv.scrollIntoView({ behavior: "smooth", block: "center" });
   };
+
+  useEffect(() => {
+    if (!isOpen || !pendingScrollToOpen.current) return;
+    pendingScrollToOpen.current = false;
+    sectionBarRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, [isOpen]);
 
   const onClickInfo = () => {
     const params = new URLSearchParams(router.params);
@@ -132,7 +138,7 @@ export const SectionBar = ({ section, onSetOrder }: Props) => {
   const childrenClassNames = ["children", "transition"];
 
   return (
-    <div className="SectionBar">
+    <div className="SectionBar" ref={sectionBarRef}>
       {isOpen ? (
         <div
           className="openLabel"


### PR DESCRIPTION
Closes the budget-page section-unfold scroll bug Hoie flagged 2026-06-28: clicking a section header to unfold it scrolls the page away from the user's intended position instead of bringing the section header to the top of the viewport.

## Root cause

In `SectionBar.tsx`, `openCategory` called `scrollIntoView({ block: "center" })` on the inner `children` div **synchronously** right after `setIsOpen(true)`:

```ts
const openCategory = () => {
  setIsOpen(true);
  const childrenDiv = childrenDivRef.current;
  if (!childrenDiv) return;
  childrenDiv.scrollIntoView({ behavior: "smooth", block: "center" });
};
```

Two problems:
1. `setIsOpen(true)` is queued — React hasn't committed the state change yet when the next line runs. `childrenDivRef` still points at the empty (height = 0) children div.
2. `block: "center"` then centers a zero-height point at the viewport center. The section header sits just above it, ending up in the *middle* of the viewport rather than at the top — which is the "the page scrolled" feeling the user perceives.

## Fix

Move the scroll into a `useEffect` that fires after React commits `isOpen = true`, target the SectionBar's outer ref with `block: "start"`, and gate it behind a `pendingScrollToOpen` ref so re-mounts that read `isOpen=true` from `useMemoryState` (e.g. page reload while a section was open) do NOT auto-scroll.

```ts
const sectionBarRef = useRef<HTMLDivElement>(null);
const pendingScrollToOpen = useRef(false);

const openCategory = () => {
  pendingScrollToOpen.current = true;
  setIsOpen(true);
};

useEffect(() => {
  if (!isOpen || !pendingScrollToOpen.current) return;
  pendingScrollToOpen.current = false;
  sectionBarRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
}, [isOpen]);
```

## Test plan

- [x] `bun run typecheck` → clean
- [x] `bun test src/client/components` → 8 pass / 0 fail
- [x] **E2E (Playwright on local dev, unscrambled prod-clone)**:
  - Scroll the budget detail page down; click a section near the top of the viewport — the section header lands at viewport top (`getBoundingClientRect().top === 0`), not at the middle. Previously it shifted ~halfway down the viewport.
  - Click a section that's currently off-screen below — the page scrolls down to bring the section into view at the top (clamped to max scroll when the document isn't tall enough to fully scroll the section to top).
  - Click an already-open section to close it — scroll position does NOT change (the close path doesn't trigger the effect).
  - Reload while a section is open (`useMemoryState` persists `isOpen=true`) — no auto-scroll on mount; the user lands at whatever scroll the route restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
