### PR TITLE
feat(transfers): label confirmed transfer rows as excluded from budget totals

### DIFF
--- a/src/client/components/TransactionsTable/TransferRow.tsx
+++ b/src/client/components/TransactionsTable/TransferRow.tsx
@@ -85,6 +85,9 @@ const TransferRow = ({ transactions }: Props) => {
       <div className="budgetCategoryActions">
         <div className="labelControls">
           <span className="transferChip transferChipConfirmed">Transfer</span>
+          <span className="transferExclusionNote">
+            Excluded from budget totals
+          </span>
         </div>
         <div>
           <button className="kebabButton" onClick={onClickKebab}>

--- a/src/client/components/TransactionsTable/index.css
+++ b/src/client/components/TransactionsTable/index.css
@@ -127,6 +127,20 @@ div.TransactionRow .transferChip.transferChipConfirmed {
   color: #b8b8b8;
 }
 
+/* Confirmed transfer row: stack the "Transfer" chip over a caption
+   that tells the user why the row is absent from the budget math. */
+div.TransferRow > .budgetCategoryActions > .labelControls {
+  flex-direction: column;
+  gap: 2px;
+}
+
+div.TransferRow .transferExclusionNote {
+  font-size: 11px;
+  color: #858585;
+  text-align: center;
+  white-space: nowrap;
+}
+
 div.TransactionRow .transferAmount {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #355.

## What

Confirmed transfer pairs already fold into a single bundled `TransferRow` (PR #490) and are already excluded from the budget aggregations (PR #528). The bundled row shows a static **Transfer** chip, but nothing tells the user *why* that row is absent from the budget math — the one residual flagged on the issue after the first two success criteria shipped.

This adds the **"Excluded from budget totals"** caption directly under the Transfer chip — the affordance the original issue's scope listed ("an 'excluded from budget totals' label under the row").

## Change

- `TransferRow.tsx` — one `<span className="transferExclusionNote">` inside the existing `labelControls`, under the chip.
- `index.css` — scoped to `.TransferRow`: `labelControls` stacks the chip over the caption (`flex-direction: column`); the caption reuses the existing muted small-text styling (11px, `#858585`, centered).

No logic change — purely the missing affordance. Suggested pairs (Phase 3a Confirm/Reject rows) are untouched.

## Verification

- `bun run typecheck` — clean.
- **Sandbox E2E (Playwright, real confirmed data on the scrambled clone)** — on the Transactions list:
  - 214 transaction rows rendered, of which 10 are confirmed bundled `TransferRow`s in view.
  - The "Excluded from budget totals" caption renders on **all 10** confirmed rows (caption count == TransferRow count → no bleed onto the 204 regular rows or onto suggested-pair rows).
  - Layout asserted: `labelControls` is `flex-direction: column`, the chip text is "Transfer", the caption text is "Excluded from budget totals", styled 11px `rgb(133,133,133)`, and the caption sits **below** the chip (bounding-box check). Zero console errors.

## Scope note

The original issue title named three deliverables — badge, paired bracket, budget-total exclusion. The **badge** (Transfer chip) and **budget-total exclusion** already shipped (PR #490 / #528); the **paired bracket** was superseded by the bundled single-row design (one row, no cross-row bracket geometry — see the status comment on #355). This PR closes out the last residual (the exclusion caption). Phase 3c (#356 — context-menu link/unlink + Transfers sidebar) remains separate and unimplemented.
