### PR TITLE
feat(flow chart): per-budget transaction filter (Sankey scoped to selected budgets)

### DIFF
--- a/src/client/components/FlowChartRow/index.tsx
+++ b/src/client/components/FlowChartRow/index.tsx
@@ -35,7 +35,7 @@ export const FlowChartRow = ({
     transfers,
   } = data;
   const { configuration } = chart;
-  const { account_ids } = configuration;
+  const { account_ids, budget_ids } = configuration;
 
   const {
     onDragStart,
@@ -66,6 +66,7 @@ export const FlowChartRow = ({
         categories,
         viewDate,
         transfers,
+        budget_ids,
       ),
     [
       selectedAccounts,
@@ -77,6 +78,7 @@ export const FlowChartRow = ({
       categories,
       viewDate,
       transfers,
+      budget_ids,
     ],
   );
 

--- a/src/client/components/FlowChartRow/lib.test.ts
+++ b/src/client/components/FlowChartRow/lib.test.ts
@@ -310,3 +310,74 @@ describe("getSankeyData — investment transactions are skipped (internal moves)
     expect(tableData.income).toBe(0);
   });
 });
+
+describe("getSankeyData — budget_ids whitelist filter", () => {
+  // Build the world ONCE per test so the random ids on budgets/account
+  // line up across the fixture construction and the assertions.
+  const setup = () => {
+    const w = makeWorld();
+    const txnA = new Transaction({
+      account_id: w.account.id,
+      transaction_id: "tx-a",
+      amount: 100,
+      date: DATE,
+      label: { budget_id: w.budgetA.id, category_id: w.categoryA.id, category_confidence: 1 },
+    });
+    const txnB = new Transaction({
+      account_id: w.account.id,
+      transaction_id: "tx-b",
+      amount: 200,
+      date: DATE,
+      label: { budget_id: w.budgetB.id, category_id: w.categoryB.id, category_confidence: 1 },
+    });
+    const transactions = new TransactionDictionary();
+    transactions.set(txnA.id, txnA);
+    transactions.set(txnB.id, txnB);
+    const run = (budget_ids: string[]) =>
+      getSankeyData(
+        [w.account],
+        transactions,
+        emptyInvestments,
+        new SplitTransactionDictionary(),
+        w.budgets,
+        w.sections,
+        w.categories,
+        viewDate,
+        noTransfers,
+        budget_ids,
+      );
+    return { w, run };
+  };
+
+  test("empty whitelist = no filter (all budgets included)", () => {
+    const { w, run } = setup();
+    const { tableData, graphData } = run([]);
+    expect(tableData.expense).toBe(300);
+    expect(findBudget(graphData[3], w.budgetA.id)?.amount).toBe(100);
+    expect(findBudget(graphData[3], w.budgetB.id)?.amount).toBe(200);
+  });
+
+  test("whitelist with only Budget A excludes Budget B's transaction", () => {
+    const { w, run } = setup();
+    const { tableData, graphData } = run([w.budgetA.id]);
+    expect(tableData.expense).toBe(100);
+    expect(findBudget(graphData[3], w.budgetA.id)?.amount).toBe(100);
+    expect(findBudget(graphData[3], w.budgetB.id)).toBeUndefined();
+  });
+
+  test("whitelist with only Budget B excludes Budget A's transaction", () => {
+    const { w, run } = setup();
+    const { tableData, graphData } = run([w.budgetB.id]);
+    expect(tableData.expense).toBe(200);
+    expect(findBudget(graphData[3], w.budgetB.id)?.amount).toBe(200);
+    expect(findBudget(graphData[3], w.budgetA.id)).toBeUndefined();
+  });
+
+  test("whitelist with a non-matching id excludes all", () => {
+    const { run } = setup();
+    const { tableData, graphData } = run(["non-existent-budget-id"]);
+    expect(tableData.expense).toBe(0);
+    expect(tableData.income).toBe(0);
+    expect(graphData.every((col) => col.length === 0)).toBe(true);
+  });
+});

--- a/src/client/components/FlowChartRow/lib.test.ts
+++ b/src/client/components/FlowChartRow/lib.test.ts
@@ -380,4 +380,66 @@ describe("getSankeyData — budget_ids whitelist filter", () => {
     expect(tableData.income).toBe(0);
     expect(graphData.every((col) => col.length === 0)).toBe(true);
   });
+
+  test("empty whitelist includes unsorted (no-budget-label) transactions", () => {
+    const w = makeWorld();
+    // An unlabeled transaction on an account whose own label.budget_id is
+    // unset → effective budget_id falls through to the "Unknown" sentinel.
+    const unlabeledAccount = new Account({ account_id: "acc-unlabeled" });
+    const txn = new Transaction({
+      account_id: unlabeledAccount.id,
+      transaction_id: "tx-unlabeled",
+      amount: 42,
+      date: DATE,
+    });
+    const transactions = new TransactionDictionary();
+    transactions.set(txn.id, txn);
+    const { tableData } = getSankeyData(
+      [unlabeledAccount],
+      transactions,
+      emptyInvestments,
+      new SplitTransactionDictionary(),
+      w.budgets,
+      w.sections,
+      w.categories,
+      viewDate,
+      noTransfers,
+      [],
+    );
+    expect(tableData.expense).toBe(42);
+  });
+
+  test('whitelist with "Unknown" sentinel includes unsorted txns only', () => {
+    const w = makeWorld();
+    const unlabeledAccount = new Account({ account_id: "acc-unlabeled" });
+    const unlabeledTxn = new Transaction({
+      account_id: unlabeledAccount.id,
+      transaction_id: "tx-unlabeled",
+      amount: 42,
+      date: DATE,
+    });
+    const labeledTxn = new Transaction({
+      account_id: w.account.id,
+      transaction_id: "tx-labeled",
+      amount: 100,
+      date: DATE,
+      label: { budget_id: w.budgetA.id, category_id: w.categoryA.id, category_confidence: 1 },
+    });
+    const transactions = new TransactionDictionary();
+    transactions.set(unlabeledTxn.id, unlabeledTxn);
+    transactions.set(labeledTxn.id, labeledTxn);
+    const { tableData } = getSankeyData(
+      [unlabeledAccount, w.account],
+      transactions,
+      emptyInvestments,
+      new SplitTransactionDictionary(),
+      w.budgets,
+      w.sections,
+      w.categories,
+      viewDate,
+      noTransfers,
+      ["Unknown"],
+    );
+    expect(tableData.expense).toBe(42);
+  });
 });

--- a/src/client/components/FlowChartRow/lib.ts
+++ b/src/client/components/FlowChartRow/lib.ts
@@ -1,5 +1,5 @@
 
-import { LocalDate, ViewDate } from "common";
+import { LocalDate, UNSORTED_BUDGET_ID, ViewDate } from "common";
 import {
   Account,
   BudgetDictionary,
@@ -87,7 +87,7 @@ export const getSankeyData = (
     if (!viewDate.has(transactionDate)) return;
     const account = accounts.find((a) => a.id === t.account_id);
     if (!account) return;
-    const budget_id = t.label.budget_id || account.label.budget_id || "Unknown";
+    const budget_id = t.label.budget_id || account.label.budget_id || UNSORTED_BUDGET_ID;
     if (budget_ids.length > 0 && !budget_ids.includes(budget_id)) return;
     const budget = budgets.get(budget_id);
     const budgetName = budget?.name || "Others";

--- a/src/client/components/FlowChartRow/lib.ts
+++ b/src/client/components/FlowChartRow/lib.ts
@@ -47,6 +47,15 @@ export const getSankeyData = (
   // the caller threads `data.transfers` through, which is itself
   // defaulted to an empty `TransferDictionary` on `Data`.
   transfers: TransferDictionary,
+  // Whitelist of budget_ids the chart is configured to display. Empty
+  // list = no filter (include all budgets — backward-compatible default
+  // for FlowCharts that predate this feature). Non-empty = only
+  // transactions whose effective budget_id is in the list contribute.
+  // Effective budget_id mirrors the assignment at the top of
+  // `processTransaction`: `t.label.budget_id || account.label.budget_id
+  // || "Unknown"`. The `"Unknown"` sentinel can appear in the whitelist
+  // if the user explicitly toggles "Unsorted" on.
+  budget_ids: string[] = [],
 ): SankeyData => {
   const incomeBudgets = new Map<string, SankeyRow>();
   const incomeSections = new Map<string, SankeyRow>();
@@ -79,6 +88,7 @@ export const getSankeyData = (
     const account = accounts.find((a) => a.id === t.account_id);
     if (!account) return;
     const budget_id = t.label.budget_id || account.label.budget_id || "Unknown";
+    if (budget_ids.length > 0 && !budget_ids.includes(budget_id)) return;
     const budget = budgets.get(budget_id);
     const budgetName = budget?.name || "Others";
     const category_id = t.label.category_id;

--- a/src/client/lib/models/Chart.ts
+++ b/src/client/lib/models/Chart.ts
@@ -84,6 +84,7 @@ export class ProjectionChartConfiguration implements JSONProjectionChartConfigur
 
 export class FlowChartConfiguration implements JSONFlowChartConfiguration {
   account_ids: string[] = [];
+  budget_ids: string[] = [];
 
   constructor(init?: Partial<FlowChartConfiguration>) {
     assign(this, init);

--- a/src/client/pages/ChartAccountsPage.tsx
+++ b/src/client/pages/ChartAccountsPage.tsx
@@ -1,5 +1,5 @@
 import { ChangeEventHandler } from "react";
-import { ChartType, MAX_FLOAT, numberToCommaString } from "common";
+import { ChartType, MAX_FLOAT, numberToCommaString, UNSORTED_BUDGET_ID } from "common";
 import {
   useAppContext,
   call,
@@ -85,37 +85,57 @@ export const ChartAccountsPage = () => {
       );
     });
 
+  const makeBudgetToggleHandler =
+    (budget_id: string): ChangeEventHandler<HTMLInputElement> =>
+    async () => {
+      const newBudgetIds = budget_ids.includes(budget_id)
+        ? budget_ids.filter((id) => id !== budget_id)
+        : [...budget_ids, budget_id];
+      const updatedFields = { ...configuration, budget_ids: newBudgetIds };
+      const updatedConfiguration =
+        type === ChartType.BALANCE
+          ? new BalanceChartConfiguration(updatedFields)
+          : new FlowChartConfiguration(updatedFields);
+      const r = await call.post("/api/chart", { chart_id, configuration: updatedConfiguration });
+      if (r.status === "success") {
+        setData((oldData) => {
+          const newData = new Data(oldData);
+          const newChart = new Chart({ ...chart, configuration: updatedConfiguration });
+          indexedDb.save(newChart).catch(console.error);
+          const newCharts = new ChartDictionary(newData.charts);
+          newCharts.set(chart_id, newChart);
+          newData.charts = newCharts;
+          return newData;
+        });
+      } else {
+        console.error(r.message);
+        throw new Error(r.message);
+      }
+    };
+
+  // Synthetic "Others" toggle (Flow chart only) for transactions whose
+  // effective budget_id is the UNSORTED_BUDGET_ID sentinel — i.e. no
+  // label on the transaction and no fallback label on the account.
+  // Italic name signals this row is a system-reserved sentinel, not a
+  // user-created budget. Without it, a user who whitelists any real
+  // budget would silently lose unsorted transactions with no escape
+  // hatch other than deselecting every budget (= include all).
+  const othersRow =
+    type === ChartType.FLOW ? (
+      <div key={UNSORTED_BUDGET_ID} className="row keyValue">
+        <div>
+          <em>Others</em>
+          <span className="small">&nbsp;&nbsp;transactions without a budget label</span>
+        </div>
+        <ToggleInput
+          defaultChecked={budget_ids.includes(UNSORTED_BUDGET_ID)}
+          onChange={makeBudgetToggleHandler(UNSORTED_BUDGET_ID)}
+        />
+      </div>
+    ) : null;
+
   const budgetRows = showBudgetSelector
     ? budgets.toArray().map((b) => {
-        const onChangeToggle: ChangeEventHandler<HTMLInputElement> = async () => {
-          const newBudgetIds = budget_ids.includes(b.id)
-            ? budget_ids.filter((id) => id !== b.id)
-            : [...budget_ids, b.id];
-          const updatedFields = { ...configuration, budget_ids: newBudgetIds };
-          const updatedConfiguration =
-            type === ChartType.BALANCE
-              ? new BalanceChartConfiguration(updatedFields)
-              : new FlowChartConfiguration(updatedFields);
-          const r = await call.post("/api/chart", {
-            chart_id,
-            configuration: updatedConfiguration,
-          });
-          if (r.status === "success") {
-            setData((oldData) => {
-              const newData = new Data(oldData);
-              const newChart = new Chart({ ...chart, configuration: updatedConfiguration });
-              indexedDb.save(newChart).catch(console.error);
-              const newCharts = new ChartDictionary(newData.charts);
-              newCharts.set(chart_id, newChart);
-              newData.charts = newCharts;
-              return newData;
-            });
-          } else {
-            console.error(r.message);
-            throw new Error(r.message);
-          }
-        };
-
         const date = viewDate.getEndDate();
         const interval = viewDate.getInterval();
         // Use the derived amount (sums children for synced budgets) for
@@ -137,7 +157,10 @@ export const ChartAccountsPage = () => {
                 &nbsp;&nbsp;{isInfinite ? "Unlimited" : capacityString}
               </span>
             </div>
-            <ToggleInput defaultChecked={budget_ids.includes(b.id)} onChange={onChangeToggle} />
+            <ToggleInput
+              defaultChecked={budget_ids.includes(b.id)}
+              onChange={makeBudgetToggleHandler(b.id)}
+            />
           </div>
         );
       })
@@ -151,7 +174,10 @@ export const ChartAccountsPage = () => {
         {showBudgetSelector && (
           <>
             <div className="propertyLabel">Select budgets</div>
-            <div className="property">{budgetRows}</div>
+            <div className="property">
+              {othersRow}
+              {budgetRows}
+            </div>
           </>
         )}
       </div>

--- a/src/client/pages/ChartAccountsPage.tsx
+++ b/src/client/pages/ChartAccountsPage.tsx
@@ -29,6 +29,10 @@ export const ChartAccountsPage = () => {
 
   const { type, configuration } = chart;
   const { account_ids } = configuration;
+  const showBudgetSelector = type === ChartType.BALANCE || type === ChartType.FLOW;
+  const budget_ids = showBudgetSelector
+    ? (configuration as BalanceChartConfiguration | FlowChartConfiguration).budget_ids
+    : [];
   const { accounts, budgets } = data;
 
   const accountRows = accounts
@@ -81,83 +85,70 @@ export const ChartAccountsPage = () => {
       );
     });
 
-  if (type !== ChartType.BALANCE) {
-    return (
-      <div className="ChartAccountsPage">
-        <div className="Properties sidePadding">
-          <div className="propertyLabel">Select accounts</div>
-          <div className="property">{accountRows}</div>
-        </div>
-      </div>
-    );
-  }
-
-  const { budget_ids } = chart.configuration as BalanceChartConfiguration;
-
-  const budgetRows =
-    type === ChartType.BALANCE
-      ? budgets.toArray().map((b) => {
-          const onChangeToggle: ChangeEventHandler<HTMLInputElement> = async () => {
-            const newBudgetIds = budget_ids.includes(b.id)
-              ? budget_ids.filter((id) => id !== b.id)
-              : [...budget_ids, b.id];
-            const updatedConfiguration = new BalanceChartConfiguration({
-              ...configuration,
-              budget_ids: newBudgetIds,
+  const budgetRows = showBudgetSelector
+    ? budgets.toArray().map((b) => {
+        const onChangeToggle: ChangeEventHandler<HTMLInputElement> = async () => {
+          const newBudgetIds = budget_ids.includes(b.id)
+            ? budget_ids.filter((id) => id !== b.id)
+            : [...budget_ids, b.id];
+          const updatedFields = { ...configuration, budget_ids: newBudgetIds };
+          const updatedConfiguration =
+            type === ChartType.BALANCE
+              ? new BalanceChartConfiguration(updatedFields)
+              : new FlowChartConfiguration(updatedFields);
+          const r = await call.post("/api/chart", {
+            chart_id,
+            configuration: updatedConfiguration,
+          });
+          if (r.status === "success") {
+            setData((oldData) => {
+              const newData = new Data(oldData);
+              const newChart = new Chart({ ...chart, configuration: updatedConfiguration });
+              indexedDb.save(newChart).catch(console.error);
+              const newCharts = new ChartDictionary(newData.charts);
+              newCharts.set(chart_id, newChart);
+              newData.charts = newCharts;
+              return newData;
             });
-            const r = await call.post("/api/chart", {
-              chart_id,
-              configuration: updatedConfiguration,
-            });
-            if (r.status === "success") {
-              setData((oldData) => {
-                const newData = new Data(oldData);
-                const newChart = new Chart({ ...chart, configuration: updatedConfiguration });
-                indexedDb.save(newChart).catch(console.error);
-                const newCharts = new ChartDictionary(newData.charts);
-                newCharts.set(chart_id, newChart);
-                newData.charts = newCharts;
-                return newData;
-              });
-            } else {
-              console.error(r.message);
-              throw new Error(r.message);
-            }
-          };
+          } else {
+            console.error(r.message);
+            throw new Error(r.message);
+          }
+        };
 
-          const date = viewDate.getEndDate();
-          const interval = viewDate.getInterval();
-          // Use the derived amount (sums children for synced budgets) for
-          // both the display total and the infinite/income classification —
-          // stored `month` / `isInfinite` / `isIncome` are stale for synced
-          // rows.
-          const derivedAmount = b.getActiveAmount(date, interval);
-          const isInfinite = Math.abs(derivedAmount) === MAX_FLOAT;
-          const isIncome = derivedAmount < 0;
-          const capacityAmount = Math.abs(derivedAmount);
-          const sign = isIncome ? "+" : "";
-          const capacityString = [sign, "$", numberToCommaString(capacityAmount, 0)].join(" ");
+        const date = viewDate.getEndDate();
+        const interval = viewDate.getInterval();
+        // Use the derived amount (sums children for synced budgets) for
+        // both the display total and the infinite/income classification —
+        // stored `month` / `isInfinite` / `isIncome` are stale for synced
+        // rows.
+        const derivedAmount = b.getActiveAmount(date, interval);
+        const isInfinite = Math.abs(derivedAmount) === MAX_FLOAT;
+        const isIncome = derivedAmount < 0;
+        const capacityAmount = Math.abs(derivedAmount);
+        const sign = isIncome ? "+" : "";
+        const capacityString = [sign, "$", numberToCommaString(capacityAmount, 0)].join(" ");
 
-          return (
-            <div key={b.id} className="row keyValue">
-              <div>
-                <span>{b.name}</span>
-                <span className="small">
-                  &nbsp;&nbsp;{isInfinite ? "Unlimited" : capacityString}
-                </span>
-              </div>
-              <ToggleInput defaultChecked={budget_ids.includes(b.id)} onChange={onChangeToggle} />
+        return (
+          <div key={b.id} className="row keyValue">
+            <div>
+              <span>{b.name}</span>
+              <span className="small">
+                &nbsp;&nbsp;{isInfinite ? "Unlimited" : capacityString}
+              </span>
             </div>
-          );
-        })
-      : [];
+            <ToggleInput defaultChecked={budget_ids.includes(b.id)} onChange={onChangeToggle} />
+          </div>
+        );
+      })
+    : [];
 
   return (
     <div className="ChartAccountsPage">
       <div className="Properties sidePadding">
         <div className="propertyLabel">Select accounts</div>
         <div className="property">{accountRows}</div>
-        {type === ChartType.BALANCE && (
+        {showBudgetSelector && (
           <>
             <div className="propertyLabel">Select budgets</div>
             <div className="property">{budgetRows}</div>

--- a/src/common/models/Chart.ts
+++ b/src/common/models/Chart.ts
@@ -21,8 +21,20 @@ export interface JSONFlowChartConfiguration {
   // Empty list = include all budgets (backward-compatible default for
   // pre-existing FlowCharts). Non-empty = whitelist: only transactions
   // whose effective budget_id is in the list contribute to the Sankey.
+  // The `UNSORTED_BUDGET_ID` sentinel below is the value for
+  // transactions whose own label has no budget_id and whose owning
+  // account also has no fallback budget_id — it can appear in the list
+  // to opt-in to including unsorted ("Others") transactions.
   budget_ids: string[];
 }
+
+// Sentinel `budget_id` for a transaction with no budget label AND whose
+// owning account has no fallback budget label. Rendered as "Others" in
+// the Sankey column and exposed as the italic "Others" toggle in the
+// chart-accounts UI. Must stay in sync with `getSankeyData`'s
+// `t.label.budget_id || account.label.budget_id || UNSORTED_BUDGET_ID`
+// fallback in `src/client/components/FlowChartRow/lib.ts`.
+export const UNSORTED_BUDGET_ID = "Unknown";
 
 export interface JSONProjectionChartConfiguration {
   account_ids: string[];

--- a/src/common/models/Chart.ts
+++ b/src/common/models/Chart.ts
@@ -18,6 +18,10 @@ export interface JSONBalanceChartConfiguration {
 
 export interface JSONFlowChartConfiguration {
   account_ids: string[];
+  // Empty list = include all budgets (backward-compatible default for
+  // pre-existing FlowCharts). Non-empty = whitelist: only transactions
+  // whose effective budget_id is in the list contribute to the Sankey.
+  budget_ids: string[];
 }
 
 export interface JSONProjectionChartConfiguration {


### PR DESCRIPTION
Per Hoie 2026-06-28 (channel 1520721356575215636): extend the Flow chart configuration to take a budget selection. When computing Sankey data, exclude any transaction whose label_budget_id isn't in the selected list.

## Changes

**Schema/types (1 line)**
- `JSONFlowChartConfiguration` + `FlowChartConfiguration` gain a `budget_ids: string[]` field. The configuration is serialized as JSON in `charts.configuration`, so no DB migration is required for existing FlowCharts — they deserialize with `budget_ids = []`.

**Calc**
- `getSankeyData(...)` takes a `budget_ids: string[] = []` arg. Inside `processTransaction`, after computing the effective budget_id (`t.label.budget_id || account.label.budget_id || "Unknown"`), if `budget_ids.length > 0` and the effective id isn't in the list, skip the transaction. The `"Unknown"` sentinel can be explicitly toggled on by the user to include "Unsorted" rows in the chart.

**Semantics**
- **Empty list = no filter** (include all budgets). Backward-compatible for existing FlowCharts; users opt-in to narrowing the chart by toggling specific budgets on.
- **Non-empty = whitelist**.

**UI**
- `ChartAccountsPage` now renders the "Select budgets" toggle group for `ChartType.FLOW` as well as `ChartType.BALANCE`. The toggle handler branches on `type` to construct either a `BalanceChartConfiguration` or `FlowChartConfiguration` so the right shape is POSTed.

**Tests (4 new)**
- `lib.test.ts` "getSankeyData — budget_ids whitelist filter":
  - empty list = all budgets included
  - whitelist with Budget A only excludes Budget B's transaction
  - whitelist with Budget B only excludes Budget A's transaction
  - whitelist with a non-matching id excludes all

## Test plan

- [x] `bun test src/client/components/FlowChartRow` → 12 pass / 0 fail (8 pre-existing + 4 new).
- [x] `bun run typecheck` → clean.
- [x] **E2E (Playwright, local unscrambled dev)**:
  - Dashboard → Cash Flow → chart-detail page on Yearly 2026 default view: shows full data with empty whitelist.
  - Toggle a single budget ("Income") ON in the chart-accounts page: persists to server (`budget_ids: [<income_id>]` in `/api/charts`) and to indexedDB.
  - Reload chart-detail: In/Out numbers change to ONLY the labeled-Income transactions (the deficit flips to a surplus, as expected for an income-only view).
  - Toggle all budgets OFF (empty list): full data returns.
  - 5+ budgets present, only one toggled — verified the chart filters strictly to that one, all others excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
