### PR TITLE
fix(budgets): sum all months into the yearly graph spending line

### DIFF
--- a/src/client/lib/models/Calculations.budget.test.ts
+++ b/src/client/lib/models/Calculations.budget.test.ts
@@ -306,6 +306,38 @@ describe("BudgetHistory", () => {
       expect(arr.length).toBe(1);
       expect(arr[0].sorted_amount).toBe(300);
     });
+
+    test("year interval sums all months of a year into its span (matches aggregateYear)", () => {
+      const history = new BudgetHistory();
+      // 12 months of 2025, each with 500 sorted + 100 unsorted spend.
+      for (let month = 0; month < 12; month++) {
+        history.set(new Date(2025, month, 1), { sorted_amount: 500, unsorted_amount: 100 });
+      }
+
+      const viewDate = new ViewDate("year", new Date(2025, 11, 1));
+      const arr = history.toArray(viewDate);
+
+      // Year collapses to a single span; its value is the full-year sum,
+      // not one arbitrary month (the bug understated it by 12x).
+      expect(arr[0].sorted_amount).toBe(6000); // 12 * 500
+      expect(arr[0].unsorted_amount).toBe(1200); // 12 * 100
+      const aggregate = history.aggregateYear(2025);
+      expect(arr[0].sorted_amount).toBe(aggregate.sorted_amount);
+      expect(arr[0].unsorted_amount).toBe(aggregate.unsorted_amount);
+    });
+
+    test("year interval indexes distinct years by span and sums within each", () => {
+      const history = new BudgetHistory();
+      history.set(new Date(2026, 0, 1), { sorted_amount: 100 });
+      history.set(new Date(2026, 6, 1), { sorted_amount: 200 }); // same year, later month
+      history.set(new Date(2025, 0, 1), { sorted_amount: 700 });
+
+      const viewDate = new ViewDate("year", new Date(2026, 11, 1));
+      const arr = history.toArray(viewDate);
+
+      expect(arr[0].sorted_amount).toBe(300); // 2026: 100 + 200
+      expect(arr[1].sorted_amount).toBe(700); // 2025: prior-year span
+    });
   });
 
   describe("constructor with initial data", () => {

--- a/src/client/lib/models/Calculations.ts
+++ b/src/client/lib/models/Calculations.ts
@@ -277,17 +277,23 @@ export class BudgetHistory {
   };
 
   /**
-   * Returns an array of budget history.
-   * Values are 0-indexed where 0 is the month of the given `viewDate`,
-   * 1 is the previous month, and so on.
+   * Returns an array of budget history indexed by span from `viewDate`
+   * (0 is the current period, 1 the previous, and so on).
+   *
+   * For a "year" interval every month of a year maps to the same span, so the
+   * per-span value is the full-year aggregate (via `aggregateYear`) — the same
+   * summation `LabeledBar` uses — not a single arbitrary month. Assigning the
+   * raw monthly bucket here would be last-write-wins and understate a year's
+   * spending by up to 12x.
    */
   toArray = (viewDate: ViewDate) => {
     const result: BudgetSummary[] = [];
+    const isYear = viewDate.getInterval() === "year";
     Object.entries(this.data).forEach(([key, value]) => {
       const date = this.getDate(key);
       if (!isDate(date)) return;
       const span = viewDate.getSpanFrom(date);
-      if (span >= 0) result[span] = value;
+      if (span >= 0) result[span] = isYear ? this.aggregateYear(date.getFullYear()) : value;
     });
     return result;
   };


### PR DESCRIPTION
## What

In **Yearly** view, the budget-detail spending graph collapsed all 12 months of a year onto a single span index, so the green spending line plotted **one arbitrary month** of a year against the **full-year** capacity line — understating spend by up to 12x and contradicting the bar's year-summed "spent" total directly above the graph.

Closes #571.

## Root cause

`BudgetHistory.toArray(viewDate)` (`src/client/lib/models/Calculations.ts`) maps each monthly bucket to `span = viewDate.getSpanFrom(date)` and does `result[span] = value`. For a **year** interval, `ViewDate.getSpanFrom` returns `thisYear - thatYear`, so every month of a year yields the **same** span index and the assignment is last-write-wins — the array holds one month, not the year's sum.

The sibling `LabeledBar` already reads `aggregateYear(year)` for the year interval, so within one Yearly budget-detail page the **bar** showed the year sum while the **graph** showed one month — a direct internal contradiction. `getYearlyAmount`'s own docstring requires the spending side aggregate the same way as `aggregateYear`.

## Fix

`toArray` now returns the full-year aggregate via the **canonical `aggregateYear`** (the same summation the bar uses) when the interval is `"year"`; the month path is byte-for-byte unchanged. One-line behavioral change, reusing existing aggregation rather than duplicating it. `BudgetHistory.toArray` has a single production caller (`useBudgetGraph`), so the blast radius is the budget-detail graph only (`BalanceHistory.toArray` is a separate class, unaffected).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 971 pass / 0 fail / 2 skip (full bundled + non-bundled suite)
- [x] Regression tests added to `Calculations.budget.test.ts` `BudgetHistory > toArray`:
  - 12 months of a year → yearly span equals `12 * monthly` and equals `aggregateYear(year)` (was 1/12 before the fix).
  - Two years of data index by distinct spans and sum within each year.
- [x] **UI E2E** — Playwright, scrambled prod-clone sandbox, Yearly view, logged in as admin, same budget on baseline (`upstream/main`) vs this PR (identical scrambled data for the budget):
  - **Baseline (buggy):** budget-detail graph — green spending line lies flat near `$0` across every year (2022–2026) while the bar above reports `$<redacted> spent of $<redacted>`. The graph contradicts the bar.
  - **This PR (fixed):** same budget, same Yearly view — green spending line now rises to the year-sum scale and tracks below the grey capacity line; the current-year point lands consistent with the bar's `spent of` figure (no longer flat near zero). Grey capacity line/area unchanged.
  - `/budget-detail` rendered with 0 failed/5xx requests; only the known dev-server `sw.js` service-worker console artifact.
  - Screenshots: `/tmp/pr-577-baseline-graph.png`, `/tmp/pr-577-prfix-graph.png`.
