### PR TITLE
refactor(holdings): drop S&P 500 column, add $ vs benchmark row to Investment Performance

### DIFF
--- a/src/client/components/HoldingsComposition/index.css
+++ b/src/client/components/HoldingsComposition/index.css
@@ -6,7 +6,7 @@
 .holdingsTable .holdingsHeader,
 .holdingsTable .holdingsRow {
   display: grid;
-  grid-template-columns: 1fr 6em 7em 5em;
+  grid-template-columns: 1fr 6em 7em;
   gap: 0.25em;
   padding: 0.35em 0.75em;
   font-size: 0.85em;
@@ -44,8 +44,7 @@
 }
 
 .holdingsTable .col-value,
-.holdingsTable .col-gain,
-.holdingsTable .col-bench {
+.holdingsTable .col-gain {
   text-align: right;
   white-space: nowrap;
 }
@@ -78,13 +77,11 @@
   white-space: nowrap;
 }
 
-.holdingsTable .col-gain.positive,
-.holdingsTable .col-bench.positive {
+.holdingsTable .col-gain.positive {
   color: #4ade80;
 }
 
-.holdingsTable .col-gain.negative,
-.holdingsTable .col-bench.negative {
+.holdingsTable .col-gain.negative {
   color: #f87171;
 }
 

--- a/src/client/components/HoldingsComposition/index.tsx
+++ b/src/client/components/HoldingsComposition/index.tsx
@@ -44,10 +44,6 @@ interface TickerRow {
   unrealizedGain: number | null;
   costBasisInferred: boolean;
   isCash: boolean;
-  /** Every security_id that bucketed here — the S&P 500 benchmark gathers
-   *  this bucket's investment-transaction contributions across all of them
-   *  (same ticker can span multiple security_ids across institutions). */
-  securityIds: string[];
   /** Whether the row routes to the detail page. False only for placeholder
    *  buckets that have no underlying snapshots (shouldn't happen given the
    *  filter at construction). */
@@ -143,7 +139,6 @@ export const HoldingsComposition = ({ account }: Props) => {
       name: string | null;
       ticker: string | null;
       securityId: string;
-      securityIds: Set<string>; // all contributors, for the benchmark calc
     }
     const buckets = new Map<string, Acc>();
 
@@ -171,10 +166,8 @@ export const HoldingsComposition = ({ account }: Props) => {
           name: row.name,
           ticker: row.ticker,
           securityId: row.securityId,
-          securityIds: new Set([row.securityId]),
         });
       } else {
-        existing.securityIds.add(row.securityId);
         existing.quantity += row.quantity;
         existing.value += row.value;
         existing.costBasis =
@@ -208,7 +201,6 @@ export const HoldingsComposition = ({ account }: Props) => {
         unrealizedGain: b.unrealizedGain,
         costBasisInferred: b.costBasisInferred,
         isCash: b.isCash,
-        securityIds: Array.from(b.securityIds),
         clickable: true,
       };
     });

--- a/src/client/components/HoldingsComposition/index.tsx
+++ b/src/client/components/HoldingsComposition/index.tsx
@@ -1,15 +1,7 @@
 import { KeyboardEvent, useMemo } from "react";
 import { currencyCodeToSymbol, ItemProvider, numberToCommaString, ViewDate } from "common";
-import { Account, PATH, useAppContext, useVooHistory } from "client";
-import {
-  CashFlow,
-  extractCashFlowsBySecurity,
-  buildBenchmarkPriceAt,
-  computeHoldingBenchmark,
-} from "client/lib/hooks/calculation/benchmark";
+import { Account, PATH, useAppContext } from "client";
 import "./index.css";
-
-const toDateString = (d: Date) => d.toISOString().slice(0, 10);
 
 interface Props {
   account: Account;
@@ -71,8 +63,7 @@ export const HoldingsComposition = ({ account }: Props) => {
 
   const { calculations, router, viewDate, data } = useAppContext();
   const { holdingsValueData, balanceData } = calculations;
-  const { items, securitySnapshots, investmentTransactions, holdingSnapshots } = data;
-  const vooHistory = useVooHistory();
+  const { items, securitySnapshots } = data;
 
   // Every row is clickable and drills into HOLDING_DETAIL. Edit gating
   // lives on the detail page — synced + current viewDate renders read-only
@@ -223,53 +214,6 @@ export const HoldingsComposition = ({ account }: Props) => {
     });
   }, [perSecurityRows]);
 
-  // S&P 500 benchmark (#317): for each non-cash bucket, what the unrealized
-  // G/L% would have been if the same contributions had gone into VOO instead
-  // — each contribution re-priced from its OWN date (dynamic distribution,
-  // no cost-basis/date averaging). The Total row aggregates every non-cash
-  // bucket's contributions. Cash buckets and buckets with no investment-
-  // transaction history render "—".
-  const cashFlowsBySecurity = useMemo(
-    () => extractCashFlowsBySecurity(investmentTransactions, holdingSnapshots, account_id),
-    [investmentTransactions, holdingSnapshots, account_id],
-  );
-  const benchmarkAsOf = useMemo(() => {
-    const today = new Date();
-    return toDateString(viewEndDate > today ? today : viewEndDate);
-  }, [viewEndDate]);
-  const benchmarkPriceAt = useMemo(
-    () => buildBenchmarkPriceAt(securitySnapshots, vooHistory),
-    [securitySnapshots, vooHistory],
-  );
-  const benchmark = useMemo(() => {
-    const byBucket = new Map<string, number | null>();
-    const allContributions: CashFlow[] = [];
-    tickerRows.forEach((row) => {
-      if (row.isCash) {
-        byBucket.set(row.bucketKey, null);
-        return;
-      }
-      const contributions: CashFlow[] = [];
-      row.securityIds.forEach((sid) => {
-        const flows = cashFlowsBySecurity.get(sid);
-        if (!flows) return;
-        for (const f of flows) {
-          if (f.date > benchmarkAsOf) continue;
-          contributions.push(f);
-          allContributions.push(f);
-        }
-      });
-      const result = computeHoldingBenchmark({ contributions, asOf: benchmarkAsOf, benchmarkPriceAt });
-      byBucket.set(row.bucketKey, result ? result.returnPercent : null);
-    });
-    const totalResult = computeHoldingBenchmark({
-      contributions: allContributions,
-      asOf: benchmarkAsOf,
-      benchmarkPriceAt,
-    });
-    return { byBucket, total: totalResult ? totalResult.returnPercent : null };
-  }, [tickerRows, cashFlowsBySecurity, benchmarkPriceAt, benchmarkAsOf]);
-
   const goToHoldingDetail = (bucketKey?: string) => {
     const params = new URLSearchParams();
     params.set("account_id", account_id);
@@ -317,12 +261,7 @@ export const HoldingsComposition = ({ account }: Props) => {
       : null;
   const totalGain = totalCostBasis !== null ? totalValue - totalCostBasis : null;
 
-  const displayRows = tickerRows
-    .map((r) => ({
-      ...r,
-      benchmarkReturnPercent: benchmark.byBucket.get(r.bucketKey) ?? null,
-    }))
-    .sort((a, b) => b.value - a.value);
+  const displayRows = tickerRows.slice().sort((a, b) => b.value - a.value);
 
   return (
     <>
@@ -332,12 +271,6 @@ export const HoldingsComposition = ({ account }: Props) => {
           <span className="col-name">Security</span>
           <span className="col-value">Value</span>
           <span className="col-gain">Growth</span>
-          <span
-            className="col-bench"
-            title="If the same contributions had gone into the S&P 500 (VOO) instead — each contribution tracked at its own date"
-          >
-            S&amp;P&nbsp;500
-          </span>
         </div>
         {tickerRows.length === 0 && isManualAccount && (
           <div className="holdingsRow holdingsEmpty">
@@ -349,12 +282,6 @@ export const HoldingsComposition = ({ account }: Props) => {
             row.isCash || row.unrealizedGain === null
               ? ""
               : row.unrealizedGain >= 0
-                ? "positive"
-                : "negative";
-          const benchClass =
-            row.benchmarkReturnPercent === null
-              ? ""
-              : row.benchmarkReturnPercent >= 0
                 ? "positive"
                 : "negative";
           const onClickRow = row.clickable ? () => goToHoldingDetail(row.bucketKey) : undefined;
@@ -403,16 +330,6 @@ export const HoldingsComposition = ({ account }: Props) => {
                   </>
                 )}
               </span>
-              <span className={`col-bench ${benchClass}`}>
-                {row.benchmarkReturnPercent === null ? (
-                  <span className="no-data">—</span>
-                ) : (
-                  <>
-                    {row.benchmarkReturnPercent >= 0 ? "+" : ""}
-                    {row.benchmarkReturnPercent.toFixed(1)}%
-                  </>
-                )}
-              </span>
             </div>
           );
         })}
@@ -431,9 +348,6 @@ export const HoldingsComposition = ({ account }: Props) => {
               {currencySymbol}&nbsp;{numberToCommaString(Math.abs(unknownDiff), 0)}
             </span>
             <span className="col-gain">
-              <span className="no-data">—</span>
-            </span>
-            <span className="col-bench">
               <span className="no-data">—</span>
             </span>
           </div>
@@ -456,18 +370,6 @@ export const HoldingsComposition = ({ account }: Props) => {
                 <span className="no-data">—</span>
               )}
             </span>
-            <span
-              className={`col-bench ${benchmark.total === null ? "" : benchmark.total >= 0 ? "positive" : "negative"}`}
-            >
-              {benchmark.total !== null ? (
-                <>
-                  {benchmark.total >= 0 ? "+" : ""}
-                  {benchmark.total.toFixed(1)}%
-                </>
-              ) : (
-                <span className="no-data">—</span>
-              )}
-            </span>
           </div>
         )}
         {isManualAccount && (
@@ -482,13 +384,6 @@ export const HoldingsComposition = ({ account }: Props) => {
         )}
         {tickerRows.some((r) => r.costBasisInferred) && (
           <div className="holdingsFootnote">* Cost basis inferred from transaction history</div>
-        )}
-        {(benchmark.total !== null ||
-          Array.from(benchmark.byBucket.values()).some((v) => v !== null)) && (
-          <div className="holdingsFootnote">
-            S&amp;P&nbsp;500: %-return if the same contributions had gone into VOO instead, each
-            tracked at its own date
-          </div>
         )}
       </div>
     </>

--- a/src/client/components/PerformanceBenchmark/index.css
+++ b/src/client/components/PerformanceBenchmark/index.css
@@ -70,22 +70,34 @@
   font-weight: 600;
 }
 
+.performanceValues .cum.positive {
+  color: #4ade80;
+}
+
+.performanceValues .cum.negative {
+  color: #f87171;
+}
+
 .performanceValues .ann {
   font-size: 0.8em;
   color: rgba(255, 255, 255, 0.55);
 }
 
-.performanceValues.positive {
-  color: #4ade80;
-}
-
-.performanceValues.negative {
-  color: #f87171;
-}
-
 .performanceValues .no-data {
   color: rgba(255, 255, 255, 0.4);
   font-style: italic;
+}
+
+.performanceValues.clickable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.performanceValues.clickable:hover .cum {
+  text-decoration: underline;
+  text-decoration-color: rgba(255, 255, 255, 0.3);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
 }
 
 .performanceFootnote {

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -14,6 +14,7 @@ import {
   extractCashFlows,
   computeMWR,
   computeBenchmarkTWR,
+  computeBenchmarkEndValue,
   valueAt,
   buildPriceAt,
   buildSnapshotPriceAt,
@@ -36,6 +37,12 @@ const toDateString = (d: Date) => d.toISOString().slice(0, 10);
 const formatPct = (n: number | null): string => {
   if (n === null || !Number.isFinite(n)) return "—";
   return `${n >= 0 ? "+" : ""}${(n * 100).toFixed(2)}%`;
+};
+
+const formatSignedDollars = (n: number): string => {
+  const sign = n >= 0 ? "+" : "−";
+  const abs = Math.abs(Math.round(n));
+  return `${sign}$${abs.toLocaleString("en-US")}`;
 };
 
 export const PerformanceBenchmark = ({ accounts }: Props) => {
@@ -145,6 +152,12 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
     const gap =
       mwr.annualized !== null && benchmark ? mwr.annualized - benchmark.annualized : null;
 
+    const vooEndValue =
+      mwr.status === "ok"
+        ? computeBenchmarkEndValue({ vStart, flows, benchmarkPriceAt, windowStart, windowEnd })
+        : null;
+    const gapDollars = vooEndValue !== null ? vEnd - vooEndValue : null;
+
     return {
       windowStart,
       windowEnd,
@@ -154,6 +167,7 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
       mwr,
       benchmark,
       gap,
+      gapDollars,
       suppressAnnualized,
       isClamped,
     };
@@ -210,7 +224,8 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
   }, [computed, securitySnapshots, setData]);
 
   if (!computed) return null;
-  const { windowStart, windowEnd, mwr, benchmark, gap, suppressAnnualized, isClamped } = computed;
+  const { windowStart, windowEnd, mwr, benchmark, gap, gapDollars, suppressAnnualized, isClamped } =
+    computed;
 
   return (
     <>
@@ -266,6 +281,18 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
             <span className="performanceLabel">vs benchmark</span>
             <span className={`performanceValues ${gap >= 0 ? "positive" : "negative"}`}>
               <span className="ann">{formatPct(gap)}/yr</span>
+            </span>
+          </div>
+        )}
+
+        {gapDollars !== null && (
+          <div
+            className="performanceRow gap"
+            title="Difference between your portfolio's current value and what it would be worth if every dollar you put in had gone into the benchmark on the same dates"
+          >
+            <span className="performanceLabel">vs benchmark ($)</span>
+            <span className={`performanceValues ${gapDollars >= 0 ? "positive" : "negative"}`}>
+              <span className="cum">{formatSignedDollars(gapDollars)}</span>
             </span>
           </div>
         )}

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -39,7 +39,8 @@ const formatPct = (n: number | null): string => {
   return `${n >= 0 ? "+" : ""}${(n * 100).toFixed(2)}%`;
 };
 
-const formatSignedDollars = (n: number): string => {
+const formatSignedDollars = (n: number | null): string => {
+  if (n === null || !Number.isFinite(n)) return "—";
   const sign = n >= 0 ? "+" : "−";
   const abs = Math.abs(Math.round(n));
   return `${sign}$${abs.toLocaleString("en-US")}`;
@@ -53,6 +54,9 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
   const { investmentTransactions, holdingSnapshots, securitySnapshots } = data;
 
   const [windowKey, setWindowKey] = useState<WindowKey>("1Y");
+  const [displayMode, setDisplayMode] = useState<"pct" | "dollar">("pct");
+  const toggleDisplayMode = () =>
+    setDisplayMode((m) => (m === "pct" ? "dollar" : "pct"));
   const vooHistory = useVooHistory();
   // Already-attempted (security_id, date) keys for Polygon resolve so
   // retries don't loop on no_data/plan_limit and window-toggle re-renders
@@ -149,14 +153,32 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
       (new Date(windowEnd).getTime() - new Date(windowStart).getTime()) / (1000 * 60 * 60 * 24 * 365);
     const suppressAnnualized = yearsInWindow < 0.5;
 
-    const gap =
-      mwr.annualized !== null && benchmark ? mwr.annualized - benchmark.annualized : null;
+    // Raw dollar counterparts to the percentage returns. Simple accounting:
+    // `netContributed = vStart + Σ flows` is money the user put in over the
+    // window (vStart is the position at window-open, treated as a
+    // windowStart-dated contribution). `gain = vEnd − netContributed` is
+    // what the portfolio ADDED beyond contributions — the raw counterpart
+    // to MWR's cumulative %. Same shape for the VOO counterfactual and the
+    // diff between them.
+    const sumFlows = flows.reduce((s, f) => s + f.amount, 0);
+    const netContributed = vStart + sumFlows;
+    const mwrGain = mwr.status === "ok" ? vEnd - netContributed : null;
 
-    const vooEndValue =
-      mwr.status === "ok"
-        ? computeBenchmarkEndValue({ vStart, flows, benchmarkPriceAt, windowStart, windowEnd })
-        : null;
-    const gapDollars = vooEndValue !== null ? vEnd - vooEndValue : null;
+    const vooEndValue = computeBenchmarkEndValue({
+      vStart,
+      flows,
+      benchmarkPriceAt,
+      windowStart,
+      windowEnd,
+    });
+    const benchmarkGain = vooEndValue !== null ? vooEndValue - netContributed : null;
+
+    const gapPct =
+      mwr.cumulative !== null && benchmark ? mwr.cumulative - benchmark.cumulative : null;
+    const gapPctAnnualized =
+      mwr.annualized !== null && benchmark ? mwr.annualized - benchmark.annualized : null;
+    const gapDollars =
+      mwrGain !== null && benchmarkGain !== null ? mwrGain - benchmarkGain : null;
 
     return {
       windowStart,
@@ -164,9 +186,13 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
       vStart,
       vEnd,
       flowCount: flows.length,
+      yearsInWindow,
       mwr,
+      mwrGain,
       benchmark,
-      gap,
+      benchmarkGain,
+      gapPct,
+      gapPctAnnualized,
       gapDollars,
       suppressAnnualized,
       isClamped,
@@ -224,8 +250,49 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
   }, [computed, securitySnapshots, setData]);
 
   if (!computed) return null;
-  const { windowStart, windowEnd, mwr, benchmark, gap, gapDollars, suppressAnnualized, isClamped } =
-    computed;
+  const {
+    windowStart,
+    windowEnd,
+    yearsInWindow,
+    mwr,
+    mwrGain,
+    benchmark,
+    benchmarkGain,
+    gapPct,
+    gapPctAnnualized,
+    gapDollars,
+    suppressAnnualized,
+    isClamped,
+  } = computed;
+
+  // Every value cell renders the same shape: a "total" line on top and, if
+  // annualization isn't suppressed for short windows, a per-year line under
+  // it in smaller grey. `renderValues` emits both. The diff row passes
+  // `colorBySign` so the total goes green/red; MWR + benchmark stay neutral.
+  const renderValues = (
+    cumulative: number | null,
+    perYear: number | null,
+    fallback: string,
+    formatter: (n: number | null) => string,
+    colorBySign?: number | null,
+  ): JSX.Element => {
+    if (cumulative === null && perYear === null) {
+      return <span className="no-data">{fallback}</span>;
+    }
+    const cumCls =
+      colorBySign == null ? "cum" : `cum ${colorBySign >= 0 ? "positive" : "negative"}`;
+    return (
+      <>
+        {cumulative !== null && <span className={cumCls}>{formatter(cumulative)}</span>}
+        {!suppressAnnualized && perYear !== null && (
+          <span className="ann">{formatter(perYear)}/yr</span>
+        )}
+      </>
+    );
+  };
+
+  const perYear = (total: number | null): number | null =>
+    total !== null && yearsInWindow > 0 ? total / yearsInWindow : null;
 
   return (
     <>
@@ -246,53 +313,69 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
 
         <div className="performanceRow">
           <span className="performanceLabel">Your asset return (MWR)</span>
-          <span className="performanceValues">
-            {mwr.status === "ok" ? (
-              <>
-                <span className="cum">{formatPct(mwr.cumulative)}</span>
-                {!suppressAnnualized && (
-                  <span className="ann">{formatPct(mwr.annualized)}/yr</span>
-                )}
-              </>
-            ) : (
-              <span className="no-data">—</span>
-            )}
+          <span
+            className="performanceValues clickable"
+            onClick={toggleDisplayMode}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") toggleDisplayMode();
+            }}
+          >
+            {displayMode === "pct"
+              ? renderValues(mwr.cumulative, mwr.annualized, "—", formatPct)
+              : renderValues(mwrGain, perYear(mwrGain), "—", formatSignedDollars)}
           </span>
         </div>
 
         <div className="performanceRow">
           <span className="performanceLabel">{BENCHMARK_TICKER} benchmark</span>
-          <span className="performanceValues">
-            {benchmark ? (
-              <>
-                <span className="cum">{formatPct(benchmark.cumulative)}</span>
-                {!suppressAnnualized && (
-                  <span className="ann">{formatPct(benchmark.annualized)}/yr</span>
+          <span
+            className="performanceValues clickable"
+            onClick={toggleDisplayMode}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") toggleDisplayMode();
+            }}
+          >
+            {displayMode === "pct"
+              ? benchmark
+                ? renderValues(benchmark.cumulative, benchmark.annualized, "—", formatPct)
+                : <span className="no-data">{vooHistory ? "no price data" : "loading…"}</span>
+              : renderValues(
+                  benchmarkGain,
+                  perYear(benchmarkGain),
+                  vooHistory ? "no price data" : "loading…",
+                  formatSignedDollars,
                 )}
-              </>
-            ) : (
-              <span className="no-data">{vooHistory ? "no price data" : "loading…"}</span>
-            )}
           </span>
         </div>
 
-        {gap !== null && !suppressAnnualized && (
-          <div className="performanceRow gap">
-            <span className="performanceLabel">vs benchmark</span>
-            <span className={`performanceValues ${gap >= 0 ? "positive" : "negative"}`}>
-              <span className="ann">{formatPct(gap)}/yr</span>
-            </span>
-          </div>
-        )}
-
-        {gapDollars !== null && (
+        {(gapPct !== null || gapDollars !== null) && (
           <div
             className="performanceRow gap"
-            title="Difference between your portfolio's current value and what it would be worth if every dollar you put in had gone into the benchmark on the same dates"
+            title="Difference between your portfolio and the same money invested in the benchmark. Click to toggle % ↔ $"
           >
-            <span className="performanceLabel">vs benchmark ($)</span>
-            <span className={`performanceValues ${gapDollars >= 0 ? "positive" : "negative"}`}>
-              <span className="cum">{formatSignedDollars(gapDollars)}</span>
+            <span className="performanceLabel">Diff</span>
+            <span
+              className="performanceValues clickable"
+              onClick={toggleDisplayMode}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") toggleDisplayMode();
+              }}
+            >
+              {displayMode === "pct"
+                ? renderValues(gapPct, gapPctAnnualized, "—", formatPct, gapPct)
+                : renderValues(
+                    gapDollars,
+                    perYear(gapDollars),
+                    "—",
+                    formatSignedDollars,
+                    gapDollars,
+                  )}
             </span>
           </div>
         )}

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import {
   Account,
   useAppContext,
@@ -57,6 +58,13 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
   const [displayMode, setDisplayMode] = useState<"pct" | "dollar">("pct");
   const toggleDisplayMode = () =>
     setDisplayMode((m) => (m === "pct" ? "dollar" : "pct"));
+  // Space would otherwise scroll the page as well as toggle.
+  const handleToggleKey = (e: ReactKeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      toggleDisplayMode();
+    }
+  };
   const vooHistory = useVooHistory();
   // Already-attempted (security_id, date) keys for Polygon resolve so
   // retries don't loop on no_data/plan_limit and window-toggle re-renders
@@ -318,9 +326,7 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
             onClick={toggleDisplayMode}
             role="button"
             tabIndex={0}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") toggleDisplayMode();
-            }}
+            onKeyDown={handleToggleKey}
           >
             {displayMode === "pct"
               ? renderValues(mwr.cumulative, mwr.annualized, "—", formatPct)
@@ -335,9 +341,7 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
             onClick={toggleDisplayMode}
             role="button"
             tabIndex={0}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") toggleDisplayMode();
-            }}
+            onKeyDown={handleToggleKey}
           >
             {displayMode === "pct"
               ? benchmark
@@ -363,9 +367,7 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
               onClick={toggleDisplayMode}
               role="button"
               tabIndex={0}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") toggleDisplayMode();
-              }}
+              onKeyDown={handleToggleKey}
             >
               {displayMode === "pct"
                 ? renderValues(gapPct, gapPctAnnualized, "—", formatPct, gapPct)

--- a/src/client/lib/hooks/calculation/benchmark.test.ts
+++ b/src/client/lib/hooks/calculation/benchmark.test.ts
@@ -7,6 +7,7 @@ import {
   extractCashFlowsBySecurity,
   computeMWR,
   computeBenchmarkTWR,
+  computeBenchmarkEndValue,
   valueAt,
   buildPriceAt,
   priceAtIn,
@@ -241,6 +242,127 @@ describe("computeBenchmarkTWR", () => {
     });
     expect(r.cumulative).toBeCloseTo(0.10, 6);
     expect(r.annualized).toBeCloseTo(0.21, 1);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+describe("computeBenchmarkEndValue (dollar counterfactual)", () => {
+  const priceAt = (points: Record<string, number>) => (date: string) => points[date] ?? null;
+
+  test("vStart only, no flows: replays as windowStart-dated contribution × priceEnd/priceStart", () => {
+    // $10k parked at windowStart; benchmark doubles by windowEnd → $20k end value.
+    const r = computeBenchmarkEndValue({
+      vStart: 10_000,
+      flows: [],
+      benchmarkPriceAt: priceAt({ "2026-01-01": 100, "2026-12-31": 200 }),
+      windowStart: "2026-01-01",
+      windowEnd: "2026-12-31",
+    });
+    expect(r).toBeCloseTo(20_000, 6);
+  });
+
+  test("flows re-priced at their OWN date, not windowStart", () => {
+    // $10k at windowStart (price 100 → 200 = 2x), $5k at mid-window (price 150 → 200 = 1.33x).
+    // End value = 20,000 + 6,666.67 ≈ 26,666.67
+    const r = computeBenchmarkEndValue({
+      vStart: 10_000,
+      flows: [{ date: "2026-07-01", amount: 5_000 }],
+      benchmarkPriceAt: priceAt({
+        "2026-01-01": 100,
+        "2026-07-01": 150,
+        "2026-12-31": 200,
+      }),
+      windowStart: "2026-01-01",
+      windowEnd: "2026-12-31",
+    });
+    expect(r).toBeCloseTo(20_000 + 5_000 * (200 / 150), 4);
+  });
+
+  test("negative flow (withdrawal) subtracts at its date's price", () => {
+    // $10k in at windowStart, −$2k out at mid.
+    const r = computeBenchmarkEndValue({
+      vStart: 10_000,
+      flows: [{ date: "2026-07-01", amount: -2_000 }],
+      benchmarkPriceAt: priceAt({
+        "2026-01-01": 100,
+        "2026-07-01": 150,
+        "2026-12-31": 200,
+      }),
+      windowStart: "2026-01-01",
+      windowEnd: "2026-12-31",
+    });
+    expect(r).toBeCloseTo(20_000 - 2_000 * (200 / 150), 4);
+  });
+
+  test("vStart = 0 (clamped-to-earliest-data window): still valid; end value = flows-only replay", () => {
+    const r = computeBenchmarkEndValue({
+      vStart: 0,
+      flows: [{ date: "2026-07-01", amount: 5_000 }],
+      benchmarkPriceAt: priceAt({
+        "2026-01-01": 100,
+        "2026-07-01": 150,
+        "2026-12-31": 200,
+      }),
+      windowStart: "2026-01-01",
+      windowEnd: "2026-12-31",
+    });
+    expect(r).toBeCloseTo(5_000 * (200 / 150), 4);
+  });
+
+  test("returns null when windowStart price is missing (partial answer would be misleading)", () => {
+    const r = computeBenchmarkEndValue({
+      vStart: 10_000,
+      flows: [],
+      benchmarkPriceAt: priceAt({ "2026-12-31": 200 }),
+      windowStart: "2026-01-01",
+      windowEnd: "2026-12-31",
+    });
+    expect(r).toBeNull();
+  });
+
+  test("returns null when windowEnd price is missing", () => {
+    const r = computeBenchmarkEndValue({
+      vStart: 10_000,
+      flows: [],
+      benchmarkPriceAt: priceAt({ "2026-01-01": 100 }),
+      windowStart: "2026-01-01",
+      windowEnd: "2026-12-31",
+    });
+    expect(r).toBeNull();
+  });
+
+  test("returns null when any flow date has no price", () => {
+    const r = computeBenchmarkEndValue({
+      vStart: 10_000,
+      flows: [
+        { date: "2026-07-01", amount: 5_000 },
+        { date: "2026-09-01", amount: 5_000 },
+      ],
+      benchmarkPriceAt: priceAt({
+        "2026-01-01": 100,
+        "2026-07-01": 150,
+        "2026-12-31": 200,
+        // 2026-09-01 missing
+      }),
+      windowStart: "2026-01-01",
+      windowEnd: "2026-12-31",
+    });
+    expect(r).toBeNull();
+  });
+
+  test("flat benchmark: end value equals net cash in (vStart + Σ flows)", () => {
+    const r = computeBenchmarkEndValue({
+      vStart: 10_000,
+      flows: [{ date: "2026-07-01", amount: 5_000 }],
+      benchmarkPriceAt: priceAt({
+        "2026-01-01": 100,
+        "2026-07-01": 100,
+        "2026-12-31": 100,
+      }),
+      windowStart: "2026-01-01",
+      windowEnd: "2026-12-31",
+    });
+    expect(r).toBeCloseTo(15_000, 6);
   });
 });
 

--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -245,11 +245,11 @@ export const computeBenchmarkEndValue = (params: {
   const { vStart, flows, benchmarkPriceAt, windowStart, windowEnd } = params;
   const priceStart = benchmarkPriceAt(windowStart);
   const priceEnd = benchmarkPriceAt(windowEnd);
-  if (!priceStart || !priceEnd) return null;
+  if (priceStart == null || priceStart <= 0 || priceEnd == null || priceEnd <= 0) return null;
   let value = vStart * (priceEnd / priceStart);
   for (const f of flows) {
     const p = benchmarkPriceAt(f.date);
-    if (!p) return null;
+    if (p == null || p <= 0) return null;
     value += f.amount * (priceEnd / p);
   }
   return value;

--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -227,6 +227,35 @@ export const computeBenchmarkTWR = (params: {
 };
 
 /**
+ * What the portfolio would be worth right now if every dollar the user put
+ * in had gone into the benchmark instead. `vStart` is replayed as a
+ * windowStart-dated contribution (it represents money already invested at
+ * window open); each in-window flow is re-priced at its OWN date — same
+ * dynamic-distribution shape `computeHoldingBenchmark` uses for the
+ * per-holding what-if. Returns null when `benchmarkPriceAt` can't price
+ * windowStart or any flow date, since a partial answer would be misleading.
+ */
+export const computeBenchmarkEndValue = (params: {
+  vStart: number;
+  flows: CashFlow[];
+  benchmarkPriceAt: (date: string) => number | null;
+  windowStart: string;
+  windowEnd: string;
+}): number | null => {
+  const { vStart, flows, benchmarkPriceAt, windowStart, windowEnd } = params;
+  const priceStart = benchmarkPriceAt(windowStart);
+  const priceEnd = benchmarkPriceAt(windowEnd);
+  if (!priceStart || !priceEnd) return null;
+  let value = vStart * (priceEnd / priceStart);
+  for (const f of flows) {
+    const p = benchmarkPriceAt(f.date);
+    if (!p) return null;
+    value += f.amount * (priceEnd / p);
+  }
+  return value;
+};
+
+/**
  * Non-cash asset value at a given date: Σ(non_cash_security_id) qty(t) × price(t).
  *
  * Cash-shape holdings (per `isCashShapeHolding`) are excluded — the


### PR DESCRIPTION
## Summary

Consolidates the two S&P 500 benchmark surfaces on the Accounts page. The **per-row S&P 500 column** on Holdings Composition was showing the same benchmark comparison as the Investment Performance widget just below it, in a redundant framing (per-row what-if simulation vs portfolio-level dollar-weighted return). Hoie's call: drop the column, keep the widget, and add a dollar row to the widget answering "how much would I have if I invested in the S&P 500 instead."

## Changes

1. **Holdings Composition — drop the S&P 500 column.** Removes the column header, the per-row cell, the Total-row cell, the Unknown-row cell, the footnote, the `useMemo` that computed per-bucket contributions, the benchmark-history import, the `benchmarkPriceAt` builder, and the corresponding CSS grid track. Table narrows from 4 columns to 3 (better on the narrow-screen layout).

2. **Investment Performance — new "vs benchmark (\$)" row.** Renders `vEnd − benchmarkEndValue`, signed. Positive (green) = your portfolio beat the benchmark by \$X. Negative (red) = benchmark beat you by \$X. Sits directly under the existing "vs benchmark" %/yr row so the picture is: % over the window + \$ counterfactual.

3. **`computeBenchmarkEndValue` extracted** to `benchmark.ts`. Given `vStart` + `flows` + a benchmark-priceAt fn + the window, returns the end value of the counterfactual portfolio (each contribution — including `vStart` treated as a windowStart-dated contribution — re-priced at its OWN date). Returns `null` when any input date has no benchmark price (partial answer would mislead).

4. **8 new unit tests** for `computeBenchmarkEndValue` covering every case the name implies: vStart-only, vStart + flows, negative flow (withdrawal), clamped `vStart=0`, missing windowStart/windowEnd/flow prices (all → null), and flat-benchmark identity (`vStart + Σ flows`).

## Related

- Follow-up to #544 (which added the column) — supersedes it. The per-security benchmark math is preserved via `computeHoldingBenchmark` in case future work needs it (holding-detail page, e.g.).
- Issue #387 (Investment Performance follow-ups) — dropping the column also removes the surface where the "one holding renders `—`" data-quality issue showed up. Left a comment on #387 documenting the specific reconstruction case (zero holding_snapshots + only a Sell txn) so the underlying fix can absorb it.

## Test plan

- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean.
- [x] `bun test src/client/lib/hooks/calculation/benchmark.test.ts` → 43/0 (35 pre-existing + 8 new).
- [ ] E2E: open Accounts → an investment account → confirm Holdings Composition has 3 columns (Security / Value / Growth), Investment Performance shows the new "vs benchmark (\$)" row under the existing "vs benchmark" %/yr row, both 1Y and 3Y and All windows render correctly, dollar formatting is `+$X,XXX` / `−$X,XXX`.
