### PR TITLE
fix(accounts): surface failed DB write in post-split-transaction

### DIFF
--- a/src/server/routes/accounts/post-split-transaction.ts
+++ b/src/server/routes/accounts/post-split-transaction.ts
@@ -40,7 +40,7 @@ export const postSplitTransactionRoute = new Route<SplitTransactionPostResponse>
       if (!result || result.status >= 400) {
         throw new Error("Database responded with an error.");
       }
-      const split_transaction_id = result.update?._id || "";
+      const split_transaction_id = result.update._id || "";
       return { status: "success", body: { split_transaction_id } };
     } catch (error: unknown) {
       logger.error("Failed to update split transaction", { splitTransactionId: idResult.data }, error);

--- a/src/server/routes/accounts/post-split-transaction.ts
+++ b/src/server/routes/accounts/post-split-transaction.ts
@@ -36,7 +36,11 @@ export const postSplitTransactionRoute = new Route<SplitTransactionPostResponse>
     try {
       const split = inferLabelConfidence(body as PartialSplitTransaction);
       const response = await updateSplitTransactions(user, [split]);
-      const split_transaction_id = response[0].update?._id || "";
+      const result = response[0];
+      if (!result || result.status >= 400) {
+        throw new Error("Database responded with an error.");
+      }
+      const split_transaction_id = result.update?._id || "";
       return { status: "success", body: { split_transaction_id } };
     } catch (error: unknown) {
       logger.error("Failed to update split transaction", { splitTransactionId: idResult.data }, error);

--- a/src/server/routes/accounts/post-transaction-routes.test.ts
+++ b/src/server/routes/accounts/post-transaction-routes.test.ts
@@ -270,12 +270,11 @@ describe("post-split-transaction route", () => {
     expect(boundValue(upd!, "label_category_confidence")).toBe(0.7);
   });
 
-  test("does NOT surface a DB error — returns success despite the failed write (known divergence, budget #572)", async () => {
-    // Unlike post-transaction and post-investment-transaction, this handler
-    // reads `response[0].update?._id` without checking `result.status`, so the
-    // repo's errorResult(500) flows through as a "success" with the id echoed
-    // back. Pinned here as current behavior; the asymmetry is tracked in
-    // budget #572 rather than fixed in this test-only PR.
+  test("surfaces a DB error as a failed response", async () => {
+    // Matches its sibling routes: updateSplitTransactions swallows the write
+    // failure into an errorResult(500), the route's `result.status >= 400`
+    // check rethrows, and Route.execute converts the throw into an error
+    // response (it does not reject).
     failQueries = true;
     const result = await postSplitTransactionRoute.execute(
       makeReq(
@@ -285,8 +284,7 @@ describe("post-split-transaction route", () => {
       ),
       fakeRes(),
     );
-    expect(result?.status).toBe("success");
-    expect(result?.body).toEqual({ split_transaction_id: "s-1" });
+    expect(result?.status).toBe("error");
   });
 });
 


### PR DESCRIPTION
## Problem

`post-split-transaction.ts` reported a failed DB write as `status: "success"`. `updateSplitTransactions` catches its own errors and returns `errorResult(...)` (status 500) instead of throwing, so `response[0].update?._id` was still populated on failure and the route echoed it back as success — the split-transaction edit rendered as saved in the UI while nothing was persisted.

Its two sibling routes in the same FE→DB label-write trio (`post-transaction.ts`, `post-investment-transaction.ts`) both guard on `result.status >= 400` and rethrow. This route was the lone diverger.

## Fix

Add the same `result.status >= 400` guard so a failed split-transaction write surfaces as an error, matching the siblings. Single-route change.

## Tests

`src/server/routes/accounts/post-transaction-routes.test.ts` already pinned the divergence with a FakePool DB-failure test (added under #437, referencing this issue). Flipped that assertion from `success` to `error` so the route-test trio is now symmetric — all three surface a DB failure as an error response.

- `bun test post-transaction-routes.test.ts` → 19 pass, 0 fail
- `bun run typecheck` → clean

## E2E

The failure path requires forcing the DB layer to error, which is exercised by the route test rather than the UI. Sandbox happy-path check: editing a split transaction still saves and reflects in the transactions list (regression check that the added guard does not reject successful writes).

Closes #572