### PR TITLE
fix(router): skip scroll-restore on same-path navigation (unblock SectionBar unfold scroll on narrow)

### DIFF
--- a/src/client/lib/hooks/router.ts
+++ b/src/client/lib/hooks/router.ts
@@ -146,8 +146,15 @@ export const useRouter = (): ClientRouter => {
   // setSlideAnchorY(0) / scrollTo fires mid-slide.
   const rafHandle = useRef<number>();
 
+  // `skipScrollRestore` short-circuits the endTransition scroll-restore
+  // rAF loop. Same-path navigation (a control changing query params on
+  // the currently-mounted page) preserves the DOM — the caller usually
+  // wants to control scroll itself (e.g. a section header wanting to
+  // `scrollIntoView` on unfold). Without this, the router's terminal
+  // `window.scrollTo(0, restoredY=0)` fires 16× across 250ms and
+  // clobbers any scroll the caller set up.
   const transition = useCallback(
-    (newPath: PATH, newParams: URLSearchParams) => {
+    (newPath: PATH, newParams: URLSearchParams, skipScrollRestore = false) => {
       // Supersede any in-flight transition tail before starting a new
       // one: cancel the pending animated endTransition AND the
       // scroll-restore rAF loop. Without this, a rapid re-navigation
@@ -204,6 +211,11 @@ export const useRouter = (): ClientRouter => {
         setPath(newPath);
         setParams(newParams);
 
+        if (skipScrollRestore) {
+          isAnimationEnabled.current = false;
+          return;
+        }
+
         const startedAt = performance.now();
         let attempts = 0;
         const tryRestore = () => {
@@ -247,7 +259,12 @@ export const useRouter = (): ClientRouter => {
       const { params: newParams, animate = true } = options || {};
       isAnimationEnabled.current = animate;
       setDirection("forward");
-      transition(target, newParams || new URLSearchParams());
+      // Same-path navigation (control changes query params on the
+      // currently-mounted page) preserves DOM state. Let the caller
+      // handle scroll — see the `skipScrollRestore` comment on
+      // `transition` above.
+      const skipScrollRestore = target === currentPathRef.current;
+      transition(target, newParams || new URLSearchParams(), skipScrollRestore);
       window.history.pushState("", "", getURLString(target, newParams));
     },
     [transition],


### PR DESCRIPTION
## Summary

Follow-up to #568 (which merged but didn't fully fix the reported bug on narrow-screen — Hoie: *"This PR is merged but the issue is persistent"* — 2026-07-02).

**Root cause:** `SectionBar.onClickInfo` calls `router.go(router.path, {params, animate: false})` — same-path navigation (only the query params change; the DOM stays mounted). `router.go` unconditionally runs `endTransition`, which starts a `requestAnimationFrame` loop calling `window.scrollTo(0, restoredY)` up to 16× across 250ms (`src/client/lib/hooks/router.ts:210`). Because the destination `getScrollKey` was never in `scrollMemory` (fresh `section_id` param), `restoredY === 0` and the rAF loop repeatedly resets `<html>`'s scrollTop to 0 — clobbering the smooth `scrollIntoView({block: "start"})` from `SectionBar.tsx:93`. On wide-screen the scroll container is `<main>`, not `<html>`, so `window.scrollTo` is a no-op and the bug doesn't manifest. On narrow-screen (mobile), `<html>` IS the scroll container and the router wins.

## Change

`src/client/lib/hooks/router.ts` — `router.go` now detects same-path navigation (`target === currentPathRef.current`) and passes `skipScrollRestore = true` into `transition`. `endTransition` short-circuits before the rAF loop when the flag is set. Everything else about the transition (state advance, scrollMemory snapshot of the outgoing route, slideAnchor animation on narrow) is unchanged.

**Not affected:**
- **Cross-path navigation** — still restores per-key `scrollMemory`. New pages still land at their remembered scroll position.
- **`popstate` (back/forward)** — uses `transition` directly, not `go`, so browser back/forward still restore scroll.
- **`animate: true` same-path** — no legitimate caller of same-path navigation today wants the router to re-scroll (the DOM survives, the caller usually has its own scroll target). If one shows up later, we add a `preserveScroll: false` opt-out.

## E2E

Narrow viewport (390×400) so `<html>` is the scroll container. Local dev against unscrambled DB, `/budget-detail?budget_id=…` with 2 sections.

| step | before fix (main) | after fix |
|---|---|---|
| scrollTop before click | 280 | 280 |
| section2 box.y before | 132 | 132 |
| scrollTop after click | **0 (snapped to top)** | **280 (preserved)** |
| section2 box.y after | 412 | 132 |

Before the fix, page snaps to top. After the fix, scroll position is preserved; the `SectionBar`'s own `scrollIntoView({block:"start"})` (from #568) handles bringing the section toward the top of the viewport, bounded by document height.

## Test plan

- [x] `bun run typecheck` clean.
- [ ] Sandbox E2E on narrow viewport: scroll down, unfold a section → page does NOT snap to top; section header lands at (or near) the top of the viewport.
- [ ] Regression check: cross-path navigation (e.g. `/budgets` → `/accounts`) still restores scroll position when navigating back.
- [ ] Regression check: browser back/forward still restore scroll position on cross-path history entries.

## Related

- Supersedes/fills the gap left by #568.
- Note in the #568 review comment (`~/claude/memory`) called out this router race as "pre-existing narrow-screen mobile" and said it wasn't blocking — that was wrong; it IS the whole bug on narrow. Won't repeat that mistake.
