### PR TITLE
fix(budgets): read yearly unsorted-items count from year-aware summary

### DIFF
--- a/src/client/lib/models/Calculations.budget.test.ts
+++ b/src/client/lib/models/Calculations.budget.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { BalanceHistory, BalanceData, BudgetHistory, BudgetData } from "./Calculations";
+import { Budget } from "./Budget";
 import { ViewDate } from "../../../common/utils";
 
 // ---------------------------------------------------------------------------
@@ -415,5 +416,37 @@ describe("BudgetData", () => {
     expect(entries.length).toBe(1);
     expect(entries[0][0]).toBe("b1");
     expect(entries[0][1]).toBeInstanceOf(BudgetHistory);
+  });
+
+  // Guards the #582 trap: unsorted items live in per-transaction month
+  // buckets, so for a year view the whole-year count MUST come from the
+  // year-aware getSummary — never from a single end-of-year month read.
+  describe("getSummary number_of_unsorted_items (year vs single-month)", () => {
+    test("year view sums unsorted items across all months, not just December", () => {
+      const data = new BudgetData();
+      const budget = new Budget({ budget_id: "b1" });
+      // Unsorted items in Jan/Feb/Mar, none in December.
+      data.add("b1", new Date(2026, 0, 1), { number_of_unsorted_items: 48 });
+      data.add("b1", new Date(2026, 1, 1), { number_of_unsorted_items: 49 });
+      data.add("b1", new Date(2026, 2, 1), { number_of_unsorted_items: 52 });
+
+      const yearView = new ViewDate("year", new Date(2026, 11, 1));
+
+      // getSummary aggregates the whole year — the value the button must show.
+      expect(data.getSummary(budget, yearView).number_of_unsorted_items).toBe(149);
+
+      // The old accessor read only the end-of-year (December) bucket → 0,
+      // which is exactly why the yearly button was disabled + "no unsorted".
+      expect(data.get("b1", yearView.getEndDate()).number_of_unsorted_items).toBe(0);
+    });
+
+    test("month view reads the single month bucket", () => {
+      const data = new BudgetData();
+      const budget = new Budget({ budget_id: "b1" });
+      data.add("b1", new Date(2026, 2, 1), { number_of_unsorted_items: 59 });
+
+      const marchView = new ViewDate("month", new Date(2026, 2, 1));
+      expect(data.getSummary(budget, marchView).number_of_unsorted_items).toBe(59);
+    });
   });
 });

--- a/src/client/pages/BudgetDetailPage/index.tsx
+++ b/src/client/pages/BudgetDetailPage/index.tsx
@@ -101,7 +101,11 @@ export const BudgetDetailPage = () => {
   const { graphData, graphViewDate } = useBudgetGraph(budget || new Budget());
 
   const date = viewDate.getEndDate();
-  const { number_of_unsorted_items } = budgetData.get(budget_id, date) || {};
+  // Read through the year-aware summary the bar uses (getSummary), not the
+  // raw single-month accessor. For a year view getEndDate() is Dec 31, so
+  // budgetData.get(budget_id, date) would only see December's bucket and
+  // report 0 unsorted items for the whole year (#582).
+  const { number_of_unsorted_items } = budgetData.getSummary(budget || new Budget(), viewDate);
 
   // Don't read `capacity.isInfinite` directly — that checks the stored
   // `month` cache which is stale for synced budgets. Check the derived


### PR DESCRIPTION
## What

Fixes the yearly budget-detail "See N Unsorted Transactions" button, which was disabled and showed **"There is no unsorted transactions"** even for budgets with many unsorted transactions in the year.

Closes #582.

## Root cause

`BudgetDetailPage/index.tsx` read the count from the raw single-month accessor:

```ts
const date = viewDate.getEndDate();
const { number_of_unsorted_items } = budgetData.get(budget_id, date) || {};
```

For a **year** view `viewDate.getEndDate()` is Dec 31, so `budgetData.get(...)` returned only December's month bucket. Unsorted items accrue per transaction month, so a budget whose unsorted transactions land outside December reported `number_of_unsorted_items = 0` for the whole year → button disabled + mislabeled. The bar on the same page draws the correct unsorted segment because it uses the year-aware `getSummary`, so the page contradicted itself.

Same root-cause **family** as #571 (fixed in #577) — a single-month read where a year-wide aggregate is required — but a different consumer (the unsorted button, not the graph line).

## Fix

Read through `budgetData.getSummary(budget, viewDate)`, the same year-aware accessor the bar uses. It aggregates all months for a year interval and reads the single month for a month interval, so no month/year branch is needed here. +1 real line changed.

## Changes

- `src/client/pages/BudgetDetailPage/index.tsx` — swap the raw month read for `getSummary`.
- `src/client/lib/models/Calculations.budget.test.ts` — `getSummary` had zero coverage; add tests pinning the trap (year view sums Jan/Feb/Mar unsorted items → 149 while the December bucket reads 0; month view reads the single month).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test src/client/lib/models/Calculations.budget.test.ts` — 46 pass / 0 fail (new getSummary tests pin get(Dec)=0 vs getSummary(year)=sum).
- [x] **UI E2E — code isolated on identical sandbox data** (one scrambled-clone DB, only the accessor line toggled + client rebuilt, budget `53c90b`, 2026 Yearly view):
  - **Baseline code (raw month read):** unsorted button = **"There is no unsorted transactions"**, `disabled` — while the same page's bar still drew a non-zero dotted unsorted segment and the transactions panel still listed "Accept all 4 suggestions" + unsorted rows (the page contradicting itself, exactly as reported).
  - **Fix code (getSummary):** unsorted button = **"See 5 Unsorted Transactions >>"**, enabled → links to the unsorted list.
  - **Month view unaffected:** the same budget's Monthly button read **"See 4 Unsorted Transactions >>"** on *both* baseline and fix (byte-identical single-month path).
  - Whole-repo scan on the fix build: 6 budgets flipped from disabled to enabled in Yearly (counts 5 / 2 / 48 / 6 / 1 / 4), 3 correctly stayed "no unsorted".
  - Screenshots captured for both states (kept local).

Verified by reviewoie (budget-reviewer) — see PR comment.
