### PR TITLE
fix(SectionBar): scroll only when unfold overflows the fold, cap so title stays under fixed header

### DIFF
--- a/src/client/components/App/index.css
+++ b/src/client/components/App/index.css
@@ -24,6 +24,15 @@ body {
   color: #d1d1d1;
   overflow-y: scroll;
   overflow-x: hidden;
+  /* Disable browser scroll-anchoring at the document root. On a
+     SectionBar unfold, replacing `.LabeledBar` (~48px) with the shorter
+     `.openLabel` (~39px) shrinks the header; scroll-anchoring
+     otherwise nudges scrollTop UP by the delta to keep the content
+     below visually stable, which reads to the user as "page scrolls
+     up a little" right before our JS-driven scroll animation. Same
+     rationale for the app in general — our routed page transitions
+     do their own scroll restore. */
+  overflow-anchor: none;
 }
 
 button {

--- a/src/client/components/SectionBar.tsx
+++ b/src/client/components/SectionBar.tsx
@@ -90,7 +90,32 @@ export const SectionBar = ({ section, onSetOrder }: Props) => {
   useEffect(() => {
     if (!isOpen || !pendingScrollToOpen.current) return;
     pendingScrollToOpen.current = false;
-    sectionBarRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    const el = sectionBarRef.current;
+    if (!el) return;
+    // Wait for the children's CSS height transition (300ms per
+    // BudgetDetailPage/index.css) so the unfolded height is committed
+    // before we measure. Buffer a bit so `getBoundingClientRect()`
+    // reads post-layout.
+    const timer = window.setTimeout(() => {
+      const rect = el.getBoundingClientRect();
+      const viewportH = window.innerHeight;
+      const overshoot = rect.bottom - viewportH;
+      // Section already fits below the fold — no scroll. The whole
+      // point is to minimize page motion.
+      if (overshoot <= 0) return;
+      // Cap the scroll delta so the section's TOP doesn't disappear
+      // above the fixed top-nav header. `.Header > .viewController`
+      // sits at `top: 0; height: 50px` (fixed), so the effective visible
+      // top of content is y=50 — read it back off the DOM in case the
+      // header ever grows a search/filter row.
+      const header = document.querySelector<HTMLElement>(".Header > .viewController");
+      const headerH = header ? header.getBoundingClientRect().height : 0;
+      const maxDelta = Math.max(rect.top - headerH, 0);
+      const delta = Math.min(overshoot, maxDelta);
+      if (delta <= 0) return;
+      window.scrollBy({ top: delta, behavior: "smooth" });
+    }, 320);
+    return () => window.clearTimeout(timer);
   }, [isOpen]);
 
   const onClickInfo = () => {

--- a/src/client/components/SectionBar.tsx
+++ b/src/client/components/SectionBar.tsx
@@ -91,31 +91,50 @@ export const SectionBar = ({ section, onSetOrder }: Props) => {
     if (!isOpen || !pendingScrollToOpen.current) return;
     pendingScrollToOpen.current = false;
     const el = sectionBarRef.current;
-    if (!el) return;
-    // Wait for the children's CSS height transition (300ms per
-    // BudgetDetailPage/index.css) so the unfolded height is committed
-    // before we measure. Buffer a bit so `getBoundingClientRect()`
-    // reads post-layout.
-    const timer = window.setTimeout(() => {
-      const rect = el.getBoundingClientRect();
-      const viewportH = window.innerHeight;
-      const overshoot = rect.bottom - viewportH;
-      // Section already fits below the fold — no scroll. The whole
-      // point is to minimize page motion.
-      if (overshoot <= 0) return;
-      // Cap the scroll delta so the section's TOP doesn't disappear
-      // above the fixed top-nav header. `.Header > .viewController`
-      // sits at `top: 0; height: 50px` (fixed), so the effective visible
-      // top of content is y=50 — read it back off the DOM in case the
-      // header ever grows a search/filter row.
-      const header = document.querySelector<HTMLElement>(".Header > .viewController");
-      const headerH = header ? header.getBoundingClientRect().height : 0;
-      const maxDelta = Math.max(rect.top - headerH, 0);
-      const delta = Math.min(overshoot, maxDelta);
-      if (delta <= 0) return;
-      window.scrollBy({ top: delta, behavior: "smooth" });
-    }, 320);
-    return () => window.clearTimeout(timer);
+    const childrenEl = childrenDivRef.current;
+    if (!el || !childrenEl) return;
+    // Fixed regions clipping the visible area. `.Header > .viewController`
+    // is the top nav (`fixed; top:0; height:50px`). `.Header > .navigators`
+    // is either the bottom bar on narrow (`fixed; bottom:0`) or a side
+    // rail on wide (`top:50; width:80px`); it clips the scroll region
+    // only when it's the bottom bar.
+    const header = document.querySelector<HTMLElement>(".Header > .viewController");
+    const headerH = header ? header.getBoundingClientRect().height : 0;
+    const navs = document.querySelector<HTMLElement>(".Header > .navigators");
+    const isNavAtBottom =
+      !!navs && !navs.parentElement?.classList.contains("wideScreen");
+    const navH = isNavAtBottom ? navs.getBoundingClientRect().height : 0;
+    const rect0 = el.getBoundingClientRect();
+    const projectedBottom = rect0.bottom + childrenEl.scrollHeight;
+    const visibleBottom = window.innerHeight - navH;
+    const overshoot = projectedBottom - visibleBottom;
+    if (overshoot <= 0) return;
+    const maxDelta = Math.max(rect0.top - headerH, 0);
+    const delta = Math.min(overshoot, maxDelta);
+    if (delta <= 0) return;
+    // Custom rAF-driven scroll instead of `scrollBy({behavior:"smooth"})`.
+    // The native smooth API clamps to `docHeight − innerHeight` at
+    // animation-start time and doesn't re-target if the doc grows —
+    // which it will, since the CSS `.children.transition` is animating
+    // in parallel with us. A rAF loop re-issues `scrollTo(target)`
+    // every frame, so the browser's per-frame clamp naturally makes
+    // progress as the doc grows. Runs on the same 300ms budget as the
+    // CSS transition so the two animations feel coordinated.
+    const startY = window.scrollY;
+    const target = startY + delta;
+    const startedAt = performance.now();
+    const DURATION = 300;
+    let rafId = 0;
+    const step = (now: number) => {
+      const t = Math.min((now - startedAt) / DURATION, 1);
+      // Ease-out cubic — matches feel of CSS transition's default.
+      const eased = 1 - Math.pow(1 - t, 3);
+      const y = startY + (target - startY) * eased;
+      window.scrollTo(0, y);
+      if (t < 1) rafId = requestAnimationFrame(step);
+    };
+    rafId = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(rafId);
   }, [isOpen]);
 
   const onClickInfo = () => {


### PR DESCRIPTION
## Summary

Follow-up to #568 + #581. Bug still visible on narrow: click one of the top two sections of a scrollable budget → the section title disappears under the fixed top-nav.

**Why only the top two**

`scrollIntoView({block:"start"})` requests `document.scrollTop = element.doc-y`, then the browser clamps to `min(target, docHeight - viewportHeight)`.

- Sections whose natural doc-y ≤ max_scroll → fully honored → `rect.top = 0` → hidden under the 50px fixed header (`.Header > .viewController`).
- Sections whose natural doc-y > max_scroll → clamped → `rect.top = naturalDocY − maxScroll > 0` → title stays below the header, visible.

For a typical budget-detail with docHeight ≈ 1300, viewport 844, max_scroll = 456: sections 0/1 at doc-y 288/412 hit the bug; section 2+ at doc-y ≥ 536 don't.

## Change

`src/client/components/SectionBar.tsx` — replace the unconditional `scrollIntoView({block:"start"})` with a "scroll only when needed, cap so title stays under header" rule per Hoie's spec:

- **Wait 320 ms after unfold** (300 ms CSS `.children.transition` in `BudgetDetailPage/index.css` + a small buffer) so the final expanded rect is committed before we measure.
- **`overshoot = rect.bottom − innerHeight`**. If `<= 0` → return. Section already fits; page shouldn't move at all.
- **Otherwise scroll DOWN by `min(overshoot, rect.top − headerH)`.** First arg brings the hidden bottom into view; second arg caps so the section title never slides under the fixed header. Header height read from `.Header > .viewController` at scroll time (not hardcoded).

## E2E

Playwright, narrow viewport (390×500 to force overflow on the sample budget so the interesting delta≠0 branch is exercised).

| scenario | viewport | pre box.y | pre box.bottom | scroll Δ | post box.y | post box.bottom | title visible | bottom fits |
|---|---|---|---|---|---|---|---|---|
| on-screen (fits after unfold) | 390×844 | 288 | 402 | **0** | 288 | 563 | ✅ | ✅ |
| overflow-on-unfold | 390×500 | 288 | 402 | **63** | **225** | **500** | ✅ | ✅ |

Overflow case: unfold grows height 114 → 275, pre-click bottom = 402, would-be bottom = 288+275 = 563, viewport = 500, overshoot = 63. Scroll delta = min(63, 288−50) = 63. Post box.y = 288 − 63 = 225. Bottom lands at 225+275 = 500 exactly. Title at y=225, well below the 50 px header line.

## Related

- Supersedes the incomplete part of #568 + #581 (the router snap-to-top from #581 is still correctly closed; this closes the second-order overflow-vs-header problem).
- Learning captured for the next PR: E2E assertions must include "title visible" and "section bottom fits" **as user-observable outcomes**, not just "scrollTop moved". Retooling my Playwright assertions accordingly.
