### PR TITLE
cd: switch deploy webhook to Bearer auth + fail on non-2xx

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,5 +37,12 @@ jobs:
 
     steps:
       - name: Trigger deploy
+        env:
+          DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
+          DEPLOY_SECRET: ${{ secrets.DEPLOY_SECRET }}
         run: |
-          curl -X POST ${{ secrets.DEPLOY_URL }} -H "Content-Type: application/json" -d '{"secret": "${{ secrets.DEPLOY_SECRET }}"}'
+          curl --fail-with-body -sS -X POST "$DEPLOY_URL" \
+            -H "Authorization: Bearer $DEPLOY_SECRET" \
+            -H "Content-Type: application/json" \
+            -w '\n---\nstatus: %{http_code}, duration: %{time_total}s\n' \
+            --data "{\"sha\":\"${GITHUB_SHA}\",\"repo\":\"${GITHUB_REPOSITORY}\"}"


### PR DESCRIPTION
## Summary

Prep for the coordinated migration onto `hoiekim/webhook`'s new header-authed, response-informative deploy webhook (hoiekim/webhook#2). Two effects on the deploy step:

- Auth via `Authorization: Bearer $DEPLOY_SECRET` (was body-JSON `{"secret":"…"}`).
- `curl --fail-with-body` — the workflow fails on any non-2xx (500 broken deploy, 401 misconfig, 409 concurrent, 413 body too large) and prints the JSON error body to the run log. Previously the workflow silently succeeded on broken deploys because the old server returned 200 immediately and `curl` had no `-f`.

The body now carries `sha` + `repo` for audit — the webhook logs both alongside the deploy for later grep.

## What DOESN'T change

- `DEPLOY_URL` / `DEPLOY_SECRET` secret names — same values, just used in different headers.
- The rest of the workflow (docker-push) — untouched.
- The webhook target is still the same host + port.

## Coordination — DO NOT MERGE STANDALONE

This PR **breaks CD if merged before `hoiekim/webhook#2` is deployed on `hoie.kim`**, and — corrected per reviewoie's review below — **the break is silent, with no automatic guard**:

The current receiver on `hoiekim/webhook` `main` reads the secret from the JSON **body** and calls `res.end()` unconditionally, so it returns **HTTP 200 on every path** (success, auth-mismatch, and parse error alike) — it never returns 401. Merged standalone, this PR sends `{"sha":…,"repo":…}` with no `secret` key, so the old server:

1. finds `secret === undefined`, `undefined === SECRET` is false → **skips `exec(COMMAND)` → the deploy silently no-ops**, and
2. still returns **200** → `curl --fail-with-body` sees success → **the workflow goes GREEN**.

So the failure mode is a green CI run hiding a dead deploy — strictly worse than an error. `--fail-with-body` provides **no** protection against out-of-order merge; the sequence below must be enforced by hand.

**Required merge sequence** (paired with `hoiekim/inbox#643` — same shape, opened in parallel):

1. Merge `hoiekim/webhook#2` on GitHub.
2. On `hoie.kim`: `cd ~/webhook && git pull && pm2 restart webhook`. Sanity-check with a `curl` from the host that a Bearer POST returns 200 and a wrong-secret POST returns 401.
3. Merge `hoiekim/inbox#643`.
4. Merge THIS PR (`hoiekim/budget`).
5. Watch the next push-to-main on each repo trigger a CD run and expect the new "status: 200, duration: X.Ys" line in the deploy step log.

Between step 1 and step 2 there's a window where inbox / budget pushes **silently no-op** (green run, no deploy — for the same 200-on-every-path reason above, once webhook#2 is merged on GitHub but not yet restarted on the host, a Bearer request hits the still-running old process). Either avoid pushing to `main` during that window, or accept a re-run after step 2. The window is bounded by the `pm2 restart` — seconds, not minutes.

## Test plan

- [x] YAML lint (implicit via GH Actions parser — commit will be validated once pushed).
- [x] Manual walk-through of the `curl` invocation locally against the smoke-tested webhook build (matches the six scenarios the webhook PR verified: 200 success, 500 exit-1, 500 timeout with SIGKILL, 401 missing/wrong auth, 405 GET, 413 body too large).
- [ ] Post-deploy: first push to `main` after `pm2 restart webhook` triggers CD; workflow shows the new status line and completes green. If webhook responds 500 (e.g. compose can't pull), the workflow marks the run failed with the stderr tail visible in the log.

## Related

- `hoiekim/webhook#2` — the target-side change (still OPEN; must land + deploy first).
- `hoiekim/inbox#643` — sister PR with the same shape.
