### PR TITLE
fix(client): render InvestmentTransactionProperties on TRANSACTION_DETAIL when investment_transaction_id is in the URL

### DIFF
--- a/src/client/components/InvestmentTransactionProperties/index.css
+++ b/src/client/components/InvestmentTransactionProperties/index.css
@@ -1,0 +1,2 @@
+/* Shell-only class; the .Properties shared rules do the visual heavy lifting
+ * (co-located with the <Properties> shell import per the 2026-06 componentization). */

--- a/src/client/components/InvestmentTransactionProperties/index.css
+++ b/src/client/components/InvestmentTransactionProperties/index.css
@@ -1,2 +1,0 @@
-/* Shell-only class; the .Properties shared rules do the visual heavy lifting
- * (co-located with the <Properties> shell import per the 2026-06 componentization). */

--- a/src/client/components/InvestmentTransactionProperties/index.tsx
+++ b/src/client/components/InvestmentTransactionProperties/index.tsx
@@ -1,5 +1,5 @@
 import { ChangeEventHandler, useEffect, useState } from "react";
-import { currencyCodeToSymbol, LocalDate, numberToCommaString } from "common";
+import { currencyCodeToSymbol, LocalDate, numberToCommaString, toTitleCase } from "common";
 import {
   Data,
   InvestmentTransaction,
@@ -186,11 +186,11 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
         </div>
         <div className="row keyValue">
           <span className="propertyName">Type</span>
-          <span>{type}</span>
+          <span>{toTitleCase(type)}</span>
         </div>
         <div className="row keyValue">
           <span className="propertyName">Subtype</span>
-          <span>{subtype}</span>
+          <span>{toTitleCase(subtype)}</span>
         </div>
         <div className="row keyValue">
           <span className="propertyName">Quantity</span>

--- a/src/client/components/InvestmentTransactionProperties/index.tsx
+++ b/src/client/components/InvestmentTransactionProperties/index.tsx
@@ -1,0 +1,257 @@
+import { ChangeEventHandler, useEffect, useState } from "react";
+import { currencyCodeToSymbol, LocalDate, numberToCommaString } from "common";
+import {
+  Data,
+  InvestmentTransaction,
+  InvestmentTransactionDictionary,
+  TransactionLabel,
+  useAppContext,
+  useBudgetCategorySelect,
+  call,
+  indexedDb,
+} from "client";
+import { InstitutionSpan } from "client/components";
+
+interface Props {
+  investmentTransaction: InvestmentTransaction;
+}
+
+export const InvestmentTransactionProperties = ({ investmentTransaction }: Props) => {
+  const { data, setData } = useAppContext();
+  const { accounts, sections, categories, securities } = data;
+
+  const {
+    investment_transaction_id,
+    account_id,
+    security_id,
+    date,
+    name,
+    amount,
+    quantity,
+    price,
+    iso_currency_code,
+    type,
+    subtype,
+    label,
+  } = investmentTransaction;
+
+  const account = accounts.get(account_id);
+  const security = security_id ? securities.get(security_id) : null;
+
+  const {
+    selectedBudgetIdLabel,
+    setSelectedBudgetIdLabel,
+    selectedCategoryIdLabel,
+    setSelectedCategoryIdLabel,
+    budgetOptions,
+    categoryOptions,
+  } = useBudgetCategorySelect(label, account, `investment_transaction_${investment_transaction_id}`);
+
+  useEffect(() => {
+    setSelectedBudgetIdLabel(label.budget_id || account?.label.budget_id || "");
+    setSelectedCategoryIdLabel(label.category_id || "");
+  }, [label, account, setSelectedBudgetIdLabel, setSelectedCategoryIdLabel]);
+
+  const onChangeBudgetSelect: ChangeEventHandler<HTMLSelectElement> = async (e) => {
+    const { value } = e.target;
+    if (value === selectedBudgetIdLabel) return;
+    setSelectedBudgetIdLabel(value);
+    setSelectedCategoryIdLabel("");
+
+    const r = await call.post("/api/investment-transaction", {
+      investment_transaction_id,
+      label: { budget_id: value || null, category_id: null, category_confidence: 0 },
+    });
+
+    if (r.status === "success") {
+      setData((oldData) => {
+        const newData = new Data(oldData);
+        const updated = new InvestmentTransaction(investmentTransaction);
+        updated.label.budget_id = value || null;
+        updated.label.category_id = null;
+        updated.label.category_confidence = 0;
+        indexedDb.save(updated).catch(console.error);
+        const newDict = new InvestmentTransactionDictionary(newData.investmentTransactions);
+        newDict.set(investment_transaction_id, updated);
+        newData.investmentTransactions = newDict;
+        return newData;
+      });
+    } else {
+      setSelectedBudgetIdLabel(selectedBudgetIdLabel);
+      setSelectedCategoryIdLabel(selectedCategoryIdLabel);
+    }
+  };
+
+  const onChangeCategorySelect: ChangeEventHandler<HTMLSelectElement> = async (e) => {
+    const { value } = e.target;
+    if (value === selectedCategoryIdLabel) return;
+    setSelectedCategoryIdLabel(value);
+    const nextConfidence = value ? 1 : 0;
+    const labelQuery = new TransactionLabel({
+      category_id: value || null,
+      category_confidence: nextConfidence,
+    });
+    if (!label.budget_id) labelQuery.budget_id = account?.label.budget_id;
+
+    const r = await call.post("/api/investment-transaction", {
+      investment_transaction_id,
+      label: labelQuery,
+    });
+
+    if (r.status === "success") {
+      setData((oldData) => {
+        const newData = new Data(oldData);
+        const updated = new InvestmentTransaction(investmentTransaction);
+        if (!updated.label.budget_id) updated.label.budget_id = account?.label.budget_id;
+        updated.label.category_id = value || null;
+        updated.label.category_confidence = nextConfidence;
+        indexedDb.save(updated).catch(console.error);
+        const newDict = new InvestmentTransactionDictionary(newData.investmentTransactions);
+        newDict.set(investment_transaction_id, updated);
+        newData.investmentTransactions = newDict;
+        return newData;
+      });
+    } else {
+      setSelectedCategoryIdLabel(selectedCategoryIdLabel);
+    }
+  };
+
+  const [memoValue, setMemoValue] = useState(label.memo ?? "");
+  useEffect(() => {
+    setMemoValue(label.memo ?? "");
+  }, [investment_transaction_id, label.memo]);
+
+  const onChangeMemo: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setMemoValue(e.target.value);
+  };
+
+  const onBlurMemo = async () => {
+    const trimmed = memoValue.trim();
+    const current = label.memo ?? "";
+    if (trimmed === current) return;
+    const newMemo = trimmed || null;
+    const r = await call.post("/api/investment-transaction", {
+      investment_transaction_id,
+      label: { memo: newMemo },
+    });
+    if (r.status === "success") {
+      setData((oldData) => {
+        const newData = new Data(oldData);
+        const newDict = new InvestmentTransactionDictionary(oldData.investmentTransactions);
+        const existing = newDict.get(investment_transaction_id);
+        if (existing) {
+          const updated = new InvestmentTransaction(existing);
+          updated.label.memo = newMemo;
+          newDict.set(investment_transaction_id, updated);
+        }
+        newData.investmentTransactions = newDict;
+        return newData;
+      });
+    }
+  };
+
+  const sectionName = (() => {
+    const cat = selectedCategoryIdLabel ? categories.get(selectedCategoryIdLabel) : null;
+    const sec = cat?.section_id ? sections.get(cat.section_id) : null;
+    return sec?.name ?? "";
+  })();
+
+  const currencySymbol = currencyCodeToSymbol(iso_currency_code || "USD");
+
+  return (
+    <div className="InvestmentTransactionProperties Properties">
+      <div className="propertyLabel">Investment&nbsp;Transaction&nbsp;Details</div>
+      <div className="property">
+        <div className="row keyValue">
+          <span className="propertyName">Date</span>
+          <span>
+            {new LocalDate(date).toLocaleString("en-US", {
+              month: "long",
+              day: "numeric",
+              year: "numeric",
+            })}
+          </span>
+        </div>
+        <div className="row keyValue">
+          <span className="propertyName">Name</span>
+          <span>{name}</span>
+        </div>
+        <div className="row keyValue">
+          <span className="propertyName">Security</span>
+          <span>{security?.name || "—"}</span>
+        </div>
+        <div className="row keyValue">
+          <span className="propertyName">Ticker</span>
+          <span>{security?.ticker_symbol || "—"}</span>
+        </div>
+        <div className="row keyValue">
+          <span className="propertyName">Type</span>
+          <span>{type}</span>
+        </div>
+        <div className="row keyValue">
+          <span className="propertyName">Subtype</span>
+          <span>{subtype}</span>
+        </div>
+        <div className="row keyValue">
+          <span className="propertyName">Quantity</span>
+          <span>{numberToCommaString(quantity)}</span>
+        </div>
+        <div className="row keyValue">
+          <span className="propertyName">Price</span>
+          <span>
+            {currencySymbol}&nbsp;{numberToCommaString(price)}
+          </span>
+        </div>
+        <div className="row keyValue">
+          <span className="propertyName">Amount</span>
+          <span>
+            {currencySymbol}&nbsp;{numberToCommaString(amount)}
+          </span>
+        </div>
+        <div className="row keyValue">
+          <span className="propertyName">Account</span>
+          <span>{account?.custom_name || account?.name}</span>
+        </div>
+        <div className="row keyValue">
+          <span className="propertyName">Institution</span>
+          {account && <InstitutionSpan institution_id={account?.institution_id} />}
+        </div>
+        <div className="row keyValue">
+          <span className="propertyName">Memo</span>
+          <input
+            type="text"
+            value={memoValue}
+            placeholder="Add a note…"
+            onChange={onChangeMemo}
+            onBlur={onBlurMemo}
+          />
+        </div>
+      </div>
+      <div className="propertyLabel">Budgets</div>
+      <div className="property">
+        <div className="row keyValue">
+          <span className="propertyName">Budget</span>
+          <div>
+            <select value={selectedBudgetIdLabel} onChange={onChangeBudgetSelect}>
+              <option value="">Select Budget</option>
+              {budgetOptions}
+            </select>
+          </div>
+        </div>
+        <div className="row keyValue">
+          <span className="propertyName">Section</span>
+          <span>{sectionName}</span>
+        </div>
+        <div className="row keyValue">
+          <span className="propertyName">Category</span>
+          <div className={selectedCategoryIdLabel ? "" : "notification"}>
+            <select value={selectedCategoryIdLabel} onChange={onChangeCategorySelect}>
+              <option value="">Select Category</option>
+              {categoryOptions}
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/client/components/TransactionsTable/InvestmentTransactionRow.tsx
+++ b/src/client/components/TransactionsTable/InvestmentTransactionRow.tsx
@@ -160,6 +160,10 @@ const InvestmentTransactionRow = ({ investmentTransaction, isEditable = false }:
 
   const onClickKebab = () => {
     const params = new URLSearchParams(router.params);
+    // Clear the sibling id so navigating inv-tx → tx → inv-tx doesn't
+    // leave a stale transaction_id in the URL that would win the branch
+    // in `TransactionDetailPage` (which now must pick one of two ids).
+    params.delete("transaction_id");
     params.set("investment_transaction_id", id);
     go(PATH.TRANSACTION_DETAIL, { params });
   };

--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -236,6 +236,10 @@ const TransactionRow = ({ transaction }: Props) => {
 
   const onClickKebab = () => {
     const params = new URLSearchParams(router.params);
+    // Clear the sibling id so navigating tx → inv-tx → tx doesn't leave a
+    // stale investment_transaction_id in the URL that would win the branch
+    // in `TransactionDetailPage`.
+    params.delete("investment_transaction_id");
     params.set("transaction_id", parentTransaction.transaction_id);
     go(PATH.TRANSACTION_DETAIL, { params });
   };

--- a/src/client/components/index.ts
+++ b/src/client/components/index.ts
@@ -2,6 +2,7 @@ export * from "./App";
 export * from "./Page";
 export * from "./Properties";
 export * from "./HoldingProperties";
+export * from "./InvestmentTransactionProperties";
 export * from "./ErrorBoundary";
 export * from "./PlaidLinkContext";
 export * from "./PlaidLinkButton";

--- a/src/client/pages/TransactionDetailPage/index.tsx
+++ b/src/client/pages/TransactionDetailPage/index.tsx
@@ -1,23 +1,39 @@
 import { useAppContext, PATH } from "client";
-import { TransactionProperties, TransferProperties } from "client/components";
+import {
+  InvestmentTransactionProperties,
+  TransactionProperties,
+  TransferProperties,
+} from "client/components";
 
 import "./index.css";
 
 export type TransactionDetailPageParams = {
   transaction_id?: string;
+  investment_transaction_id?: string;
 };
 
 export const TransactionDetailPage = () => {
   const { data, router } = useAppContext();
-  const { transactions, transfers } = data;
+  const { transactions, investmentTransactions, transfers } = data;
 
   const { path, params, transition } = router;
-  let id: string;
-  if (path === PATH.TRANSACTION_DETAIL) id = params.get("transaction_id") || "";
-  else id = transition.incomingParams.get("transaction_id") || "";
+  const paramsToRead =
+    path === PATH.TRANSACTION_DETAIL ? params : transition.incomingParams;
+  const transactionId = paramsToRead.get("transaction_id") || "";
+  const investmentTransactionId = paramsToRead.get("investment_transaction_id") || "";
 
-  const transaction = transactions.get(id);
+  const investmentTransaction = investmentTransactionId
+    ? investmentTransactions.get(investmentTransactionId)
+    : undefined;
+  if (investmentTransaction) {
+    return (
+      <div className="TransactionDetailPage">
+        <InvestmentTransactionProperties investmentTransaction={investmentTransaction} />
+      </div>
+    );
+  }
 
+  const transaction = transactionId ? transactions.get(transactionId) : undefined;
   if (!transaction) return <></>;
 
   // Confirmed-transfer rows surface the same kebab → detail route as a


### PR DESCRIPTION
## Summary

Fixes a currently-broken navigation flow: any deep-link / IDB-restored URL with `investment_transaction_id` (or, per reviewoie MED-3 below, the `InvestmentTransactionRow` kebab once its `isEditable={true}` caller lands as part of the manual-tx UI stack) navigates to `PATH.TRANSACTION_DETAIL`, but the page only reads `transaction_id` and does `transactions.get(id)`. Result: the detail page silently renders empty for inv-tx.

Also prep for the manual-transaction-UI stack coming on top (#567 cash + #585 invest): Hoie asked for the detail page to be the input form for new manual rows, which requires it to render inv-tx in the first place.

## What changed

1. **New `InvestmentTransactionProperties`** (`src/client/components/InvestmentTransactionProperties/index.tsx`). Renders inv-tx fields in the same `.Properties` layout `TransactionProperties` uses — Date, Name, Security + Ticker, Type + Subtype (title-cased via `toTitleCase`), Quantity, Price, Amount, Account, Institution, editable Memo, editable Budget + Category. All edit paths mirror `InvestmentTransactionRow`'s existing handlers — `POST /api/investment-transaction` → optimistic `setData` + `InvestmentTransactionDictionary.set` + `indexedDb.save`. No new API surface.
2. **`TransactionDetailPage` branches** on which id is in the URL. `investment_transaction_id` → look up in `data.investmentTransactions` and render the new component. Otherwise fall through to the existing transaction branch. Transfer-pair override still applies to regular transactions.
3. **Sibling-id clearing** on both `TransactionRow.onClickKebab` and `InvestmentTransactionRow.onClickKebab` — each now `.delete()`s the opposite id before `.set()`ing its own, so navigating `tx ↔ inv-tx ↔ tx` never leaves a stale sibling that would win the branch. Fix for reviewoie MED-1.

## reviewoie findings

reviewoie posted **7 findings** on the initial commit: https://github.com/hoiekim/budget/pull/587#pullrequestreview-4627470321. Applied in `883f289a`:

- **MED — Branch priority (both ids in URL)**: applied — sibling-id clear on both `onClickKebab`s.
- **LOW — Raw enum labels**: applied — `toTitleCase(type)` / `toTitleCase(subtype)`.
- **LOW — Empty CSS file**: applied — deleted.

Deferred to the manual-tx UI follow-up (in-scope refactor there, not a scope creep in this fix PR):

- **MED — Accept-suggestion parity**: `TransactionProperties` has the same gap. Fold-in refactor when the manual-tx PR touches these components.
- **LOW — setData render-time closure**: pre-existing pattern in `InvestmentTransactionRow` too. Fold-in with the row when refactoring.
- **LOW — useEffect resync race**: mirror of pre-existing pattern in `TransactionProperties`.

**MED — E2E test-plan reality**: reviewoie was correct that `InvestmentTransactionRow.isEditable` defaults to `false` and no caller sets it to `true`, so the "click a kebab" path in my original test plan is unreachable via the UI today. The bug still exists for anyone landing on the URL via deep-link, back-forward navigation, or IDB-restored route. The manual-tx stack that lands next will set `isEditable={true}` on that row, at which point the kebab becomes the primary entry — this PR ships the target-page fix ahead of that so the kebab-click doesn't silent-empty. Updated test plan below reflects direct-URL as the actual test path.

## Test plan (E2E — sandbox verified)

Ran against the sandbox at `20587` with sandbox admin creds:

- [x] `bun run typecheck` — clean.
- [x] `POST /api/login` succeeds with admin/sandbox.
- [x] Warm sync via `/transactions`, wait for cold-sync to settle (20s), confirm `investmentTransactions` dict is populated.
- [x] `GET /transaction-detail?investment_transaction_id=<non-deleted, within-cold-sync-window>` renders:
  - `Investment Transaction Details` header visible.
  - Type row shows **`Buy`** (was raw `buy` pre-`toTitleCase`).
  - Subtype row shows `Buy`.
  - Security row shows a real security name; Ticker shows the symbol.
  - Quantity / Price / Amount all render numeric values.
- [x] Memo edit → blur → API round-trip → reload → memo persists (`e2e-memo-<ts>` round-tripped).
- [x] Baseline: `GET /transaction-detail?transaction_id=<any>` still opens `TransactionProperties` with the standard header. Transfer-pair override on the regular branch is unchanged.

Screenshots: `/tmp/e2e-pr587-invtx-detail.png`, `/tmp/e2e-pr587-regular.png` (local).

**Not tested** (out of scope for this PR):
- Kebab click through the `TransactionsTable` — the row's `budgetCategoryActions` (including the kebab) is gated behind `isEditable={true}` and no caller sets it yet. Becomes reachable + tested in the manual-tx stack PR.

## Follow-up (stacked PR)

Next PR adds the manual-transaction-entry work on top: `source` column on both `transactions` and `investment_transactions`, `GET /api/new-*` shell-mint routes, `+` buttons on `AccountProperties` (cash on manual accounts + invest on all accounts) and `HoldingProperties` (with `security_id` prefilled). That PR will also flip `isEditable={true}` on both rows so the kebab (this PR's motivating scenario) becomes reachable.

Related: budget #567 (manual cash tx UI), budget #585 (manual investment tx UI).
