### PR TITLE
feat: manual transaction UI on account + holding detail (#567 cash + #585 investment)

### DIFF
--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -1,4 +1,4 @@
-import { AccountType } from "plaid";
+import { AccountType, InvestmentTransactionType, InvestmentTransactionSubtype } from "plaid";
 import { useMemo } from "react";
 import {
   currencyCodeToSymbol,
@@ -7,7 +7,24 @@ import {
   toTitleCase,
   ViewDate,
 } from "common";
-import { Account, PATH, ScreenType, useAccountGraph, useAppContext } from "client";
+import type {
+  NewTransactionGetResponse,
+  NewInvestmentTransactionGetResponse,
+} from "server";
+import {
+  Account,
+  call,
+  Data,
+  indexedDb,
+  InvestmentTransaction,
+  InvestmentTransactionDictionary,
+  PATH,
+  ScreenType,
+  Transaction,
+  TransactionDictionary,
+  useAccountGraph,
+  useAppContext,
+} from "client";
 import {
   DateLabel,
   DynamicCapacityInput,
@@ -32,7 +49,7 @@ export const AccountProperties = ({ account }: Props) => {
 
   const { graphViewDate, graphData, cursorAmount } = useAccountGraph([account]);
 
-  const { data, viewDate, router, screenType } = useAppContext();
+  const { data, setData, viewDate, router, screenType } = useAppContext();
   const { budgets, items } = data;
 
   const {
@@ -92,6 +109,87 @@ export const AccountProperties = ({ account }: Props) => {
     const params = new URLSearchParams();
     params.append("account_id", account_id);
     router.go(PATH.TRANSACTIONS, { params });
+  };
+
+  /**
+   * `+ Add Transaction` on a manual account (#567). Mints a shell row
+   * server-side via `GET /api/new-transaction`, optimistically inserts
+   * it into `data.transactions` so the detail page picks it up
+   * immediately without waiting for the next sync, then navigates.
+   */
+  const onClickAddTransaction = async () => {
+    const query = new URLSearchParams({ account_id }).toString();
+    const response = await call.get<NewTransactionGetResponse>(
+      "/api/new-transaction?" + query,
+    );
+    if (!response.body) {
+      console.error("Failed to mint new transaction:", response.message);
+      return;
+    }
+    const { transaction_id } = response.body;
+    const shell = new Transaction({
+      transaction_id,
+      account_id,
+      name: "",
+      amount: 0,
+      iso_currency_code: iso_currency_code ?? null,
+      date: new Date().toISOString().split("T")[0],
+      pending: false,
+    });
+    setData((oldData) => {
+      const next = new Data(oldData);
+      const dict = new TransactionDictionary(oldData.transactions);
+      dict.set(transaction_id, shell);
+      next.transactions = dict;
+      indexedDb.save(shell).catch(console.error);
+      return next;
+    });
+    router.go(PATH.TRANSACTION_DETAIL, {
+      params: new URLSearchParams({ transaction_id }),
+    });
+  };
+
+  /**
+   * `+ Add Investment Transaction` on any investment account (#585).
+   * NOT gated on `isManualAccount` — the motivating case is RSU/ESPP
+   * grants on a Plaid-connected brokerage that pre-date Plaid's 24-mo
+   * window. Server marks the row `source='manual'` so it survives
+   * future Plaid syncs.
+   */
+  const onClickAddInvestmentTransaction = async (security_id?: string) => {
+    const params: Record<string, string> = { account_id };
+    if (security_id) params.security_id = security_id;
+    const response = await call.get<NewInvestmentTransactionGetResponse>(
+      "/api/new-investment-transaction?" + new URLSearchParams(params).toString(),
+    );
+    if (!response.body) {
+      console.error("Failed to mint new investment transaction:", response.message);
+      return;
+    }
+    const { investment_transaction_id } = response.body;
+    const shell = new InvestmentTransaction({
+      investment_transaction_id,
+      account_id,
+      security_id: security_id ?? null,
+      date: new Date().toISOString().split("T")[0],
+      name: "",
+      amount: 0,
+      quantity: 0,
+      price: 0,
+      type: InvestmentTransactionType.Buy,
+      subtype: InvestmentTransactionSubtype.Buy,
+    });
+    setData((oldData) => {
+      const next = new Data(oldData);
+      const dict = new InvestmentTransactionDictionary(oldData.investmentTransactions);
+      dict.set(investment_transaction_id, shell);
+      next.investmentTransactions = dict;
+      indexedDb.save(shell).catch(console.error);
+      return next;
+    });
+    router.go(PATH.TRANSACTION_DETAIL, {
+      params: new URLSearchParams({ investment_transaction_id }),
+    });
   };
 
   const onClickConnectionDetail = () => {
@@ -243,6 +341,27 @@ export const AccountProperties = ({ account }: Props) => {
             <ToggleInput checked={isArchived} onChange={onClickArchive} />
           </div>
         </div>
+      )}
+      {(isManualAccount || type === AccountType.Investment) && (
+        <>
+          <div className="propertyLabel">Add</div>
+          <div className="property">
+            {isManualAccount && type !== AccountType.Investment && (
+              <div className="row button">
+                <button onClick={onClickAddTransaction}>
+                  +&nbsp;Add&nbsp;Transaction
+                </button>
+              </div>
+            )}
+            {type === AccountType.Investment && (
+              <div className="row button">
+                <button onClick={() => onClickAddInvestmentTransaction()}>
+                  +&nbsp;Add&nbsp;Investment&nbsp;Transaction
+                </button>
+              </div>
+            )}
+          </div>
+        </>
       )}
       <div className="propertyLabel">Navigate</div>
       <div className="property">

--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -135,6 +135,7 @@ export const AccountProperties = ({ account }: Props) => {
       iso_currency_code: iso_currency_code ?? null,
       date: new Date().toISOString().split("T")[0],
       pending: false,
+      source: "manual",
     });
     setData((oldData) => {
       const next = new Data(oldData);
@@ -156,11 +157,10 @@ export const AccountProperties = ({ account }: Props) => {
    * window. Server marks the row `source='manual'` so it survives
    * future Plaid syncs.
    */
-  const onClickAddInvestmentTransaction = async (security_id?: string) => {
-    const params: Record<string, string> = { account_id };
-    if (security_id) params.security_id = security_id;
+  const onClickAddInvestmentTransaction = async () => {
     const response = await call.get<NewInvestmentTransactionGetResponse>(
-      "/api/new-investment-transaction?" + new URLSearchParams(params).toString(),
+      "/api/new-investment-transaction?" +
+        new URLSearchParams({ account_id }).toString(),
     );
     if (!response.body) {
       console.error("Failed to mint new investment transaction:", response.message);
@@ -170,7 +170,7 @@ export const AccountProperties = ({ account }: Props) => {
     const shell = new InvestmentTransaction({
       investment_transaction_id,
       account_id,
-      security_id: security_id ?? null,
+      security_id: null,
       date: new Date().toISOString().split("T")[0],
       name: "",
       amount: 0,
@@ -178,6 +178,7 @@ export const AccountProperties = ({ account }: Props) => {
       price: 0,
       type: InvestmentTransactionType.Buy,
       subtype: InvestmentTransactionSubtype.Buy,
+      source: "manual",
     });
     setData((oldData) => {
       const next = new Data(oldData);
@@ -346,7 +347,7 @@ export const AccountProperties = ({ account }: Props) => {
         <>
           <div className="propertyLabel">Add</div>
           <div className="property">
-            {isManualAccount && type !== AccountType.Investment && (
+            {isManualAccount && (
               <div className="row button">
                 <button onClick={onClickAddTransaction}>
                   +&nbsp;Add&nbsp;Transaction
@@ -355,7 +356,7 @@ export const AccountProperties = ({ account }: Props) => {
             )}
             {type === AccountType.Investment && (
               <div className="row button">
-                <button onClick={() => onClickAddInvestmentTransaction()}>
+                <button onClick={onClickAddInvestmentTransaction}>
                   +&nbsp;Add&nbsp;Investment&nbsp;Transaction
                 </button>
               </div>

--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -347,7 +347,7 @@ export const AccountProperties = ({ account }: Props) => {
         <>
           <div className="propertyLabel">Add</div>
           <div className="property">
-            {isManualAccount && (
+            {isManualAccount && type !== AccountType.Investment && (
               <div className="row button">
                 <button onClick={onClickAddTransaction}>
                   +&nbsp;Add&nbsp;Transaction

--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -126,11 +126,11 @@ export const AccountProperties = ({ account }: Props) => {
       console.error("Failed to mint new transaction:", response.message);
       return;
     }
-    const { transaction_id } = response.body;
+    const { transaction_id, name } = response.body;
     const shell = new Transaction({
       transaction_id,
       account_id,
-      name: "",
+      name,
       amount: 0,
       iso_currency_code: iso_currency_code ?? null,
       date: new Date().toISOString().split("T")[0],
@@ -166,13 +166,13 @@ export const AccountProperties = ({ account }: Props) => {
       console.error("Failed to mint new investment transaction:", response.message);
       return;
     }
-    const { investment_transaction_id } = response.body;
+    const { investment_transaction_id, name } = response.body;
     const shell = new InvestmentTransaction({
       investment_transaction_id,
       account_id,
       security_id: null,
       date: new Date().toISOString().split("T")[0],
-      name: "",
+      name,
       amount: 0,
       quantity: 0,
       price: 0,

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -281,16 +281,22 @@ export const HoldingProperties = () => {
 
   /**
    * `+ Add Investment Transaction` on the holding — Hoie's ask (#585
-   * design): prefill `security_id` with this holding's primary
-   * security so the user doesn't repeat the lookup. When the bucket
-   * spans multiple securities (rare — merged tickers), use the first
-   * bucket snapshot's security_id.
+   * design): prefill `security_id`, `price` (from the holding's
+   * `institution_price`), and `iso_currency_code` from the holding
+   * context so the user starts with values they can confirm/correct
+   * rather than 0 / null defaults. When the bucket spans multiple
+   * securities (rare — merged tickers), use the first snapshot.
    */
-  const primarySecurityId = bucketSnapshots[0]?.holding.security_id ?? null;
+  const primaryHolding = bucketSnapshots[0]?.holding;
+  const primarySecurityId = primaryHolding?.security_id ?? null;
+  const primaryPrice = primaryHolding?.institution_price ?? null;
+  const primaryCurrency = primaryHolding?.iso_currency_code ?? null;
   const onClickAddInvestmentTransaction = async () => {
     if (!accountId) return;
     const params: Record<string, string> = { account_id: accountId };
     if (primarySecurityId) params.security_id = primarySecurityId;
+    if (primaryPrice !== null && primaryPrice >= 0) params.price = String(primaryPrice);
+    if (primaryCurrency) params.iso_currency_code = primaryCurrency;
     const response = await call.get<NewInvestmentTransactionGetResponse>(
       "/api/new-investment-transaction?" + new URLSearchParams(params).toString(),
     );
@@ -307,7 +313,8 @@ export const HoldingProperties = () => {
       name,
       amount: 0,
       quantity: 0,
-      price: 0,
+      price: primaryPrice ?? 0,
+      iso_currency_code: primaryCurrency,
       type: InvestmentTransactionType.Buy,
       subtype: InvestmentTransactionSubtype.Buy,
       source: "manual",

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -310,6 +310,7 @@ export const HoldingProperties = () => {
       price: 0,
       type: InvestmentTransactionType.Buy,
       subtype: InvestmentTransactionSubtype.Buy,
+      source: "manual",
     });
     setData((oldData) => {
       const next = new Data(oldData);
@@ -758,7 +759,7 @@ export const HoldingProperties = () => {
         );
       })}
 
-      {!isNew && (
+      {!isNew && !isCash && (
         <>
           <PropertyLabel>Add</PropertyLabel>
           <Property>

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -298,13 +298,13 @@ export const HoldingProperties = () => {
       console.error("Failed to mint new investment transaction:", response.message);
       return;
     }
-    const { investment_transaction_id } = response.body;
+    const { investment_transaction_id, name } = response.body;
     const shell = new InvestmentTransaction({
       investment_transaction_id,
       account_id: accountId,
       security_id: primarySecurityId,
       date: new Date().toISOString().split("T")[0],
-      name: "",
+      name,
       amount: 0,
       quantity: 0,
       price: 0,

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -1,4 +1,5 @@
 import { ChangeEventHandler, Fragment, FormEventHandler, useCallback, useEffect, useMemo, useState } from "react";
+import { InvestmentTransactionType, InvestmentTransactionSubtype } from "plaid";
 import { ItemProvider, numberToCommaString, ViewDate, currencyCodeToSymbol } from "common";
 import {
   call,
@@ -9,6 +10,8 @@ import {
   Holding,
   HoldingSnapshot,
   HoldingSnapshotDictionary,
+  InvestmentTransaction,
+  InvestmentTransactionDictionary,
   Properties,
   PropertyLabel,
   Property,
@@ -17,7 +20,11 @@ import {
   StoreName,
 } from "client";
 import { CASH_TICKER } from "../HoldingsComposition";
-import { HoldingSnapshotPostResponse, ValidateTickerResponse } from "server";
+import {
+  HoldingSnapshotPostResponse,
+  NewInvestmentTransactionGetResponse,
+  ValidateTickerResponse,
+} from "server";
 
 import "./index.css";
 
@@ -270,6 +277,51 @@ export const HoldingProperties = () => {
       setTickerStatus("invalid");
       setTickerMessage("Validation failed — check the ticker symbol");
     }
+  };
+
+  /**
+   * `+ Add Investment Transaction` on the holding — Hoie's ask (#585
+   * design): prefill `security_id` with this holding's primary
+   * security so the user doesn't repeat the lookup. When the bucket
+   * spans multiple securities (rare — merged tickers), use the first
+   * bucket snapshot's security_id.
+   */
+  const primarySecurityId = bucketSnapshots[0]?.holding.security_id ?? null;
+  const onClickAddInvestmentTransaction = async () => {
+    if (!accountId) return;
+    const params: Record<string, string> = { account_id: accountId };
+    if (primarySecurityId) params.security_id = primarySecurityId;
+    const response = await call.get<NewInvestmentTransactionGetResponse>(
+      "/api/new-investment-transaction?" + new URLSearchParams(params).toString(),
+    );
+    if (!response.body) {
+      console.error("Failed to mint new investment transaction:", response.message);
+      return;
+    }
+    const { investment_transaction_id } = response.body;
+    const shell = new InvestmentTransaction({
+      investment_transaction_id,
+      account_id: accountId,
+      security_id: primarySecurityId,
+      date: new Date().toISOString().split("T")[0],
+      name: "",
+      amount: 0,
+      quantity: 0,
+      price: 0,
+      type: InvestmentTransactionType.Buy,
+      subtype: InvestmentTransactionSubtype.Buy,
+    });
+    setData((oldData) => {
+      const next = new Data(oldData);
+      const dict = new InvestmentTransactionDictionary(oldData.investmentTransactions);
+      dict.set(investment_transaction_id, shell);
+      next.investmentTransactions = dict;
+      indexedDb.save(shell).catch(console.error);
+      return next;
+    });
+    router.go(PATH.TRANSACTION_DETAIL, {
+      params: new URLSearchParams({ investment_transaction_id }),
+    });
   };
 
   const goBackToAccount = () => {
@@ -705,6 +757,19 @@ export const HoldingProperties = () => {
           </Fragment>
         );
       })}
+
+      {!isNew && (
+        <>
+          <PropertyLabel>Add</PropertyLabel>
+          <Property>
+            <Row className="button">
+              <button type="button" onClick={onClickAddInvestmentTransaction}>
+                +&nbsp;Add&nbsp;Investment&nbsp;Transaction
+              </button>
+            </Row>
+          </Property>
+        </>
+      )}
 
       <PropertyLabel>&nbsp;</PropertyLabel>
       <Property>

--- a/src/client/components/InvestmentTransactionProperties/index.tsx
+++ b/src/client/components/InvestmentTransactionProperties/index.tsx
@@ -12,6 +12,7 @@ import {
   indexedDb,
 } from "client";
 import { InstitutionSpan } from "client/components";
+import type { ValidateTickerResponse } from "server";
 
 interface Props {
   investmentTransaction: InvestmentTransaction;
@@ -211,9 +212,12 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
     await persistInvTxField({ subtype: value });
   };
   // Ticker → security_id resolution mirrors HoldingProperties'
-  // `POST /api/validate-ticker` flow. On blur, if the ticker resolves
-  // to a security, patch `security_id`; otherwise surface a validation
-  // message and leave the field untouched.
+  // `POST /api/validate-ticker` flow. Body field is `ticker_symbol`
+  // (matches the route's requireStringField); response wraps the
+  // security under `body.security` when `body.valid === true`. On
+  // blur, if the ticker resolves, patch `security_id`; otherwise
+  // surface the server's validation message and leave the field
+  // untouched.
   const onBlurTicker = async () => {
     if (!isManual) return;
     const raw = tickerValue.trim();
@@ -221,15 +225,14 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
       setTickerMessage(null);
       return;
     }
-    const r = await call.post<{ security: { security_id: string; name?: string } | null; message?: string }>(
-      "/api/validate-ticker",
-      { ticker: raw },
-    );
-    if (r.status === "success" && r.body?.security) {
+    const r = await call.post<ValidateTickerResponse>("/api/validate-ticker", {
+      ticker_symbol: raw,
+    });
+    if (r.status === "success" && r.body?.valid && r.body.security) {
       setTickerMessage(r.body.security.name ?? "Valid ticker");
       await persistInvTxField({ security_id: r.body.security.security_id });
     } else {
-      setTickerMessage(r.body?.message ?? "Invalid ticker");
+      setTickerMessage(r.body?.message ?? r.message ?? "Invalid ticker");
     }
   };
 

--- a/src/client/components/InvestmentTransactionProperties/index.tsx
+++ b/src/client/components/InvestmentTransactionProperties/index.tsx
@@ -231,7 +231,11 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
       ticker_symbol: raw,
     });
     if (r.status === "success" && r.body?.valid && r.body.security) {
-      setTickerMessage(r.body.security.name ?? "Valid ticker");
+      // Success: the resolved security's name appears in the Security row
+      // above; a "Valid ticker" / echoed-name message here duplicates that
+      // (Hoie 2026-07-05). Clear any prior error text so a subsequent valid
+      // ticker doesn't leave a stale "Invalid ticker" line behind.
+      setTickerMessage(null);
       await persistInvTxField({ security_id: r.body.security.security_id });
     } else {
       setTickerMessage(r.body?.message ?? r.message ?? "Invalid ticker");

--- a/src/client/components/InvestmentTransactionProperties/index.tsx
+++ b/src/client/components/InvestmentTransactionProperties/index.tsx
@@ -5,6 +5,7 @@ import {
   Data,
   InvestmentTransaction,
   InvestmentTransactionDictionary,
+  StoreName,
   TransactionLabel,
   useAppContext,
   useBudgetCategorySelect,
@@ -19,7 +20,7 @@ interface Props {
 }
 
 export const InvestmentTransactionProperties = ({ investmentTransaction }: Props) => {
-  const { data, setData } = useAppContext();
+  const { data, setData, router } = useAppContext();
   const { accounts, sections, categories, securities } = data;
 
   const {
@@ -446,6 +447,39 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
           </div>
         </div>
       </div>
+      {isManual && (
+        <>
+          <br />
+          <div className="property">
+            <div className="row button">
+              <button
+                className="delete colored"
+                onClick={async () => {
+                  if (!window.confirm("Delete this investment transaction? This can't be undone.")) return;
+                  const r = await call.delete(
+                    "/api/investment-transaction?" +
+                      new URLSearchParams({ investment_transaction_id }).toString(),
+                  );
+                  if (r.status !== "success") return;
+                  setData((oldData) => {
+                    const next = new Data(oldData);
+                    const dict = new InvestmentTransactionDictionary(oldData.investmentTransactions);
+                    dict.delete(investment_transaction_id);
+                    next.investmentTransactions = dict;
+                    indexedDb
+                      .remove(StoreName.investmentTransactions, investment_transaction_id)
+                      .catch(console.error);
+                    return next;
+                  });
+                  router.back();
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/client/components/InvestmentTransactionProperties/index.tsx
+++ b/src/client/components/InvestmentTransactionProperties/index.tsx
@@ -132,7 +132,6 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
   const [dateValue, setDateValue] = useState((date || "").slice(0, 10));
   const [quantityValue, setQuantityValue] = useState(String(quantity ?? 0));
   const [priceValue, setPriceValue] = useState(String(price ?? 0));
-  const [amountValue, setAmountValue] = useState(String(amount ?? 0));
   const [tickerValue, setTickerValue] = useState(security?.ticker_symbol ?? "");
   const [tickerMessage, setTickerMessage] = useState<string | null>(null);
   useEffect(() => {
@@ -140,9 +139,8 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
     setDateValue((date || "").slice(0, 10));
     setQuantityValue(String(quantity ?? 0));
     setPriceValue(String(price ?? 0));
-    setAmountValue(String(amount ?? 0));
     setTickerValue(security?.ticker_symbol ?? "");
-  }, [investment_transaction_id, name, date, quantity, price, amount, security?.ticker_symbol]);
+  }, [investment_transaction_id, name, date, quantity, price, security?.ticker_symbol]);
 
   const persistInvTxField = async (patch: Partial<InvestmentTransaction>) => {
     const r = await call.post("/api/investment-transaction", {
@@ -174,6 +172,16 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
     if (!isManual || !dateValue || dateValue === (date || "").slice(0, 10)) return;
     await persistInvTxField({ date: dateValue });
   };
+  // `amount` is DERIVED from `price * quantity` on manual rows — the
+  // MWR / benchmark calc reads `price * quantity` (not `amount`), so
+  // an amount-only entry gets a $0 MWR contribution while the row
+  // still shows a nonzero amount. Autoderive here + render `Amount`
+  // as a read-only span so the two can't diverge. Sign convention
+  // follows the raw multiplication (users typically enter positive
+  // qty + price; a Sell subtype means the CALC layer flips sign, not
+  // the amount value we store).
+  const roundToCents = (n: number) => Math.round(n * 100) / 100;
+
   const onBlurQuantity = async () => {
     if (!isManual) return;
     const parsed = parseFloat(quantityValue);
@@ -181,7 +189,8 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
       setQuantityValue(String(quantity ?? 0));
       return;
     }
-    await persistInvTxField({ quantity: parsed });
+    const derivedAmount = roundToCents(parsed * (price ?? 0));
+    await persistInvTxField({ quantity: parsed, amount: derivedAmount });
   };
   const onBlurPrice = async () => {
     if (!isManual) return;
@@ -190,16 +199,8 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
       setPriceValue(String(price ?? 0));
       return;
     }
-    await persistInvTxField({ price: parsed });
-  };
-  const onBlurAmount = async () => {
-    if (!isManual) return;
-    const parsed = parseFloat(amountValue);
-    if (!Number.isFinite(parsed) || parsed === amount) {
-      setAmountValue(String(amount ?? 0));
-      return;
-    }
-    await persistInvTxField({ amount: parsed });
+    const derivedAmount = roundToCents((quantity ?? 0) * parsed);
+    await persistInvTxField({ price: parsed, amount: derivedAmount });
   };
   const onChangeType: ChangeEventHandler<HTMLSelectElement> = async (e) => {
     if (!isManual) return;
@@ -394,19 +395,12 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
         </div>
         <div className="row keyValue">
           <span className="propertyName">Amount</span>
-          {isManual ? (
-            <input
-              type="number"
-              step="0.01"
-              value={amountValue}
-              onChange={(e) => setAmountValue(e.target.value)}
-              onBlur={onBlurAmount}
-            />
-          ) : (
-            <span>
-              {currencySymbol}&nbsp;{numberToCommaString(amount)}
-            </span>
-          )}
+          {/* Derived from quantity * price on manual rows (both branches
+              render as a span). Plaid rows show the synced amount as
+              before. */}
+          <span>
+            {currencySymbol}&nbsp;{numberToCommaString(amount)}
+          </span>
         </div>
         <div className="row keyValue">
           <span className="propertyName">Account</span>

--- a/src/client/components/InvestmentTransactionProperties/index.tsx
+++ b/src/client/components/InvestmentTransactionProperties/index.tsx
@@ -1,4 +1,5 @@
 import { ChangeEventHandler, useEffect, useState } from "react";
+import { InvestmentTransactionType, InvestmentTransactionSubtype } from "plaid";
 import { currencyCodeToSymbol, LocalDate, numberToCommaString, toTitleCase } from "common";
 import {
   Data,
@@ -33,7 +34,9 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
     type,
     subtype,
     label,
+    source,
   } = investmentTransaction;
+  const isManual = source === "manual";
 
   const account = accounts.get(account_id);
   const security = security_id ? securities.get(security_id) : null;
@@ -121,6 +124,115 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
     setMemoValue(label.memo ?? "");
   }, [investment_transaction_id, label.memo]);
 
+  // Manual-row inline editing (#585). Plaid rows keep the read-only
+  // `<span>` display below; only `source === 'manual'` unlocks these
+  // inputs so we never overwrite a Plaid-synced field.
+  const [nameValue, setNameValue] = useState(name ?? "");
+  const [dateValue, setDateValue] = useState((date || "").slice(0, 10));
+  const [quantityValue, setQuantityValue] = useState(String(quantity ?? 0));
+  const [priceValue, setPriceValue] = useState(String(price ?? 0));
+  const [amountValue, setAmountValue] = useState(String(amount ?? 0));
+  const [tickerValue, setTickerValue] = useState(security?.ticker_symbol ?? "");
+  const [tickerMessage, setTickerMessage] = useState<string | null>(null);
+  useEffect(() => {
+    setNameValue(name ?? "");
+    setDateValue((date || "").slice(0, 10));
+    setQuantityValue(String(quantity ?? 0));
+    setPriceValue(String(price ?? 0));
+    setAmountValue(String(amount ?? 0));
+    setTickerValue(security?.ticker_symbol ?? "");
+  }, [investment_transaction_id, name, date, quantity, price, amount, security?.ticker_symbol]);
+
+  const persistInvTxField = async (patch: Partial<InvestmentTransaction>) => {
+    const r = await call.post("/api/investment-transaction", {
+      investment_transaction_id,
+      ...patch,
+    });
+    if (r.status !== "success") return false;
+    setData((oldData) => {
+      const newData = new Data(oldData);
+      const dict = new InvestmentTransactionDictionary(oldData.investmentTransactions);
+      const existing = dict.get(investment_transaction_id);
+      if (existing) {
+        const updated = new InvestmentTransaction(existing);
+        Object.assign(updated, patch);
+        indexedDb.save(updated).catch(console.error);
+        dict.set(investment_transaction_id, updated);
+      }
+      newData.investmentTransactions = dict;
+      return newData;
+    });
+    return true;
+  };
+
+  const onBlurName = async () => {
+    if (!isManual || nameValue === (name ?? "")) return;
+    await persistInvTxField({ name: nameValue });
+  };
+  const onBlurDate = async () => {
+    if (!isManual || !dateValue || dateValue === (date || "").slice(0, 10)) return;
+    await persistInvTxField({ date: dateValue });
+  };
+  const onBlurQuantity = async () => {
+    if (!isManual) return;
+    const parsed = parseFloat(quantityValue);
+    if (!Number.isFinite(parsed) || parsed === quantity) {
+      setQuantityValue(String(quantity ?? 0));
+      return;
+    }
+    await persistInvTxField({ quantity: parsed });
+  };
+  const onBlurPrice = async () => {
+    if (!isManual) return;
+    const parsed = parseFloat(priceValue);
+    if (!Number.isFinite(parsed) || parsed === price) {
+      setPriceValue(String(price ?? 0));
+      return;
+    }
+    await persistInvTxField({ price: parsed });
+  };
+  const onBlurAmount = async () => {
+    if (!isManual) return;
+    const parsed = parseFloat(amountValue);
+    if (!Number.isFinite(parsed) || parsed === amount) {
+      setAmountValue(String(amount ?? 0));
+      return;
+    }
+    await persistInvTxField({ amount: parsed });
+  };
+  const onChangeType: ChangeEventHandler<HTMLSelectElement> = async (e) => {
+    if (!isManual) return;
+    const value = e.target.value as InvestmentTransactionType;
+    await persistInvTxField({ type: value });
+  };
+  const onChangeSubtype: ChangeEventHandler<HTMLSelectElement> = async (e) => {
+    if (!isManual) return;
+    const value = e.target.value as InvestmentTransactionSubtype;
+    await persistInvTxField({ subtype: value });
+  };
+  // Ticker → security_id resolution mirrors HoldingProperties'
+  // `POST /api/validate-ticker` flow. On blur, if the ticker resolves
+  // to a security, patch `security_id`; otherwise surface a validation
+  // message and leave the field untouched.
+  const onBlurTicker = async () => {
+    if (!isManual) return;
+    const raw = tickerValue.trim();
+    if (!raw || raw === (security?.ticker_symbol ?? "")) {
+      setTickerMessage(null);
+      return;
+    }
+    const r = await call.post<{ security: { security_id: string; name?: string } | null; message?: string }>(
+      "/api/validate-ticker",
+      { ticker: raw },
+    );
+    if (r.status === "success" && r.body?.security) {
+      setTickerMessage(r.body.security.name ?? "Valid ticker");
+      await persistInvTxField({ security_id: r.body.security.security_id });
+    } else {
+      setTickerMessage(r.body?.message ?? "Invalid ticker");
+    }
+  };
+
   const onChangeMemo: ChangeEventHandler<HTMLInputElement> = (e) => {
     setMemoValue(e.target.value);
   };
@@ -164,17 +276,36 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
       <div className="property">
         <div className="row keyValue">
           <span className="propertyName">Date</span>
-          <span>
-            {new LocalDate(date).toLocaleString("en-US", {
-              month: "long",
-              day: "numeric",
-              year: "numeric",
-            })}
-          </span>
+          {isManual ? (
+            <input
+              type="date"
+              value={dateValue}
+              onChange={(e) => setDateValue(e.target.value)}
+              onBlur={onBlurDate}
+            />
+          ) : (
+            <span>
+              {new LocalDate(date).toLocaleString("en-US", {
+                month: "long",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </span>
+          )}
         </div>
         <div className="row keyValue">
           <span className="propertyName">Name</span>
-          <span>{name}</span>
+          {isManual ? (
+            <input
+              type="text"
+              value={nameValue}
+              placeholder="e.g. RSU grant"
+              onChange={(e) => setNameValue(e.target.value)}
+              onBlur={onBlurName}
+            />
+          ) : (
+            <span>{name}</span>
+          )}
         </div>
         <div className="row keyValue">
           <span className="propertyName">Security</span>
@@ -182,31 +313,97 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
         </div>
         <div className="row keyValue">
           <span className="propertyName">Ticker</span>
-          <span>{security?.ticker_symbol || "—"}</span>
+          {isManual ? (
+            <input
+              type="text"
+              value={tickerValue}
+              placeholder="e.g. VOO"
+              onChange={(e) => setTickerValue(e.target.value.toUpperCase())}
+              onBlur={onBlurTicker}
+            />
+          ) : (
+            <span>{security?.ticker_symbol || "—"}</span>
+          )}
         </div>
+        {isManual && tickerMessage && (
+          <div className="row keyValue">
+            <span className="propertyName">&nbsp;</span>
+            <span>{tickerMessage}</span>
+          </div>
+        )}
         <div className="row keyValue">
           <span className="propertyName">Type</span>
-          <span>{toTitleCase(type)}</span>
+          {isManual ? (
+            <select value={type} onChange={onChangeType}>
+              {Object.values(InvestmentTransactionType).map((v) => (
+                <option key={v} value={v}>
+                  {toTitleCase(v)}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <span>{toTitleCase(type)}</span>
+          )}
         </div>
         <div className="row keyValue">
           <span className="propertyName">Subtype</span>
-          <span>{toTitleCase(subtype)}</span>
+          {isManual ? (
+            <select value={subtype} onChange={onChangeSubtype}>
+              {Object.values(InvestmentTransactionSubtype).map((v) => (
+                <option key={v} value={v}>
+                  {toTitleCase(v)}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <span>{toTitleCase(subtype)}</span>
+          )}
         </div>
         <div className="row keyValue">
           <span className="propertyName">Quantity</span>
-          <span>{numberToCommaString(quantity)}</span>
+          {isManual ? (
+            <input
+              type="number"
+              step="any"
+              value={quantityValue}
+              onChange={(e) => setQuantityValue(e.target.value)}
+              onBlur={onBlurQuantity}
+            />
+          ) : (
+            <span>{numberToCommaString(quantity)}</span>
+          )}
         </div>
         <div className="row keyValue">
           <span className="propertyName">Price</span>
-          <span>
-            {currencySymbol}&nbsp;{numberToCommaString(price)}
-          </span>
+          {isManual ? (
+            <input
+              type="number"
+              step="any"
+              value={priceValue}
+              onChange={(e) => setPriceValue(e.target.value)}
+              onBlur={onBlurPrice}
+            />
+          ) : (
+            <span>
+              {currencySymbol}&nbsp;{numberToCommaString(price)}
+            </span>
+          )}
         </div>
         <div className="row keyValue">
           <span className="propertyName">Amount</span>
-          <span>
-            {currencySymbol}&nbsp;{numberToCommaString(amount)}
-          </span>
+          {isManual ? (
+            <input
+              type="number"
+              step="0.01"
+              value={amountValue}
+              onChange={(e) => setAmountValue(e.target.value)}
+              onBlur={onBlurAmount}
+            />
+          ) : (
+            <span>
+              {currencySymbol}&nbsp;{numberToCommaString(amount)}
+            </span>
+          )}
         </div>
         <div className="row keyValue">
           <span className="propertyName">Account</span>

--- a/src/client/components/TransactionProperties/index.tsx
+++ b/src/client/components/TransactionProperties/index.tsx
@@ -10,6 +10,7 @@ import {
   Data,
   SplitTransaction,
   SplitTransactionDictionary,
+  StoreName,
   Transaction,
   TransactionDictionary,
   TransactionLabel,
@@ -35,7 +36,7 @@ interface Props {
 }
 
 export const TransactionProperties = ({ transaction }: Props) => {
-  const { data, setData, calculations } = useAppContext();
+  const { data, setData, calculations, router } = useAppContext();
   const transferActions = useTransfers();
   const { transactionFamilies } = calculations;
   const { accounts, sections, categories, transfers } = data;
@@ -559,6 +560,34 @@ export const TransactionProperties = ({ transaction }: Props) => {
           </>
         )}
       </div>
+      {isManual && (
+        <>
+          <br />
+          <div className="property">
+            <div className="row button">
+              <button
+                className="delete colored"
+                onClick={async () => {
+                  if (!window.confirm("Delete this transaction? This can't be undone.")) return;
+                  const r = await call.delete("/api/transaction?" + new URLSearchParams({ transaction_id }).toString());
+                  if (r.status !== "success") return;
+                  setData((oldData) => {
+                    const next = new Data(oldData);
+                    const dict = new TransactionDictionary(oldData.transactions);
+                    dict.delete(transaction_id);
+                    next.transactions = dict;
+                    indexedDb.remove(StoreName.transactions, transaction_id).catch(console.error);
+                    return next;
+                  });
+                  router.back();
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/client/components/TransactionProperties/index.tsx
+++ b/src/client/components/TransactionProperties/index.tsx
@@ -51,7 +51,9 @@ export const TransactionProperties = ({ transaction }: Props) => {
     label,
     location,
     iso_currency_code,
+    source,
   } = transaction;
+  const isManual = source === "manual";
 
   const account = accounts.get(account_id);
 
@@ -166,6 +168,58 @@ export const TransactionProperties = ({ transaction }: Props) => {
     }
   };
 
+  // Manual-row inline editing (#567). Plaid rows keep the read-only
+  // `<span>` display below; only `source === 'manual'` unlocks these
+  // inputs so we never overwrite a Plaid-synced field. Save-on-blur
+  // matches the existing memo pattern — no explicit save button.
+  const [nameValue, setNameValue] = useState(name ?? "");
+  const [amountValue, setAmountValue] = useState(String(amount ?? 0));
+  const [dateValue, setDateValue] = useState((authorized_date || date || "").slice(0, 10));
+  useEffect(() => {
+    setNameValue(name ?? "");
+    setAmountValue(String(amount ?? 0));
+    setDateValue((authorized_date || date || "").slice(0, 10));
+  }, [transaction_id, name, amount, authorized_date, date]);
+
+  const persistTransactionField = async (patch: Partial<Transaction>) => {
+    const r = await call.post("/api/transaction", { transaction_id, ...patch });
+    if (r.status !== "success") return false;
+    setData((oldData) => {
+      const newData = new Data(oldData);
+      const dict = new TransactionDictionary(oldData.transactions);
+      const existing = dict.get(transaction_id);
+      if (existing) {
+        const updated = new Transaction(existing);
+        Object.assign(updated, patch);
+        indexedDb.save(updated).catch(console.error);
+        dict.set(transaction_id, updated);
+      }
+      newData.transactions = dict;
+      return newData;
+    });
+    return true;
+  };
+
+  const onBlurName = async () => {
+    if (!isManual) return;
+    if (nameValue === (name ?? "")) return;
+    await persistTransactionField({ name: nameValue });
+  };
+  const onBlurAmount = async () => {
+    if (!isManual) return;
+    const parsed = parseFloat(amountValue);
+    if (!Number.isFinite(parsed) || parsed === amount) {
+      setAmountValue(String(amount ?? 0));
+      return;
+    }
+    await persistTransactionField({ amount: parsed });
+  };
+  const onBlurDate = async () => {
+    if (!isManual) return;
+    if (!dateValue || dateValue === (authorized_date || date || "").slice(0, 10)) return;
+    await persistTransactionField({ date: dateValue });
+  };
+
   const remainingAmount = transaction.getRemainingAmount(transactionFamilies);
 
   const onClickAdd = async () => {
@@ -275,13 +329,22 @@ export const TransactionProperties = ({ transaction }: Props) => {
       <div className="property">
         <div className="row keyValue">
           <span className="propertyName">Date</span>
-          <span>
-            {new LocalDate(authorized_date || date).toLocaleString("en-US", {
-              month: "long",
-              day: "numeric",
-              year: "numeric",
-            })}
-          </span>
+          {isManual ? (
+            <input
+              type="date"
+              value={dateValue}
+              onChange={(e) => setDateValue(e.target.value)}
+              onBlur={onBlurDate}
+            />
+          ) : (
+            <span>
+              {new LocalDate(authorized_date || date).toLocaleString("en-US", {
+                month: "long",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </span>
+          )}
         </div>
         <div className="row keyValue">
           <span className="propertyName">Merchant&nbsp;Name</span>
@@ -289,15 +352,35 @@ export const TransactionProperties = ({ transaction }: Props) => {
         </div>
         <div className="row keyValue">
           <span className="propertyName">Name</span>
-          <span>{name}</span>
+          {isManual ? (
+            <input
+              type="text"
+              value={nameValue}
+              placeholder="Transaction name…"
+              onChange={(e) => setNameValue(e.target.value)}
+              onBlur={onBlurName}
+            />
+          ) : (
+            <span>{name}</span>
+          )}
         </div>
         <div className="row keyValue">
           <span className="propertyName">Amount</span>
-          <span>
-            {isIncome && <>+&nbsp;</>}
-            {currencySymbol}&nbsp;
-            {numberToCommaString(Math.abs(amount))}
-          </span>
+          {isManual ? (
+            <input
+              type="number"
+              step="0.01"
+              value={amountValue}
+              onChange={(e) => setAmountValue(e.target.value)}
+              onBlur={onBlurAmount}
+            />
+          ) : (
+            <span>
+              {isIncome && <>+&nbsp;</>}
+              {currencySymbol}&nbsp;
+              {numberToCommaString(Math.abs(amount))}
+            </span>
+          )}
         </div>
         <div className="row keyValue">
           <span className="propertyName">Location</span>

--- a/src/client/components/TransactionsTable/InvestmentTransactionRow.tsx
+++ b/src/client/components/TransactionsTable/InvestmentTransactionRow.tsx
@@ -1,18 +1,6 @@
 import { numberToCommaString, currencyCodeToSymbol, LocalDate } from "common";
-import {
-  call,
-  Data,
-  InvestmentTransaction,
-  InvestmentTransactionDictionary,
-  PATH,
-  TransactionLabel,
-  useAppContext,
-  useBudgetCategorySelect,
-  indexedDb,
-} from "client";
+import { InvestmentTransaction, PATH, useAppContext } from "client";
 import { InstitutionSpan, KebabIcon } from "client/components";
-import { ChangeEventHandler, MouseEventHandler, useEffect, useState } from "react";
-import { ApiResponse } from "server";
 
 interface Props {
   investmentTransaction: InvestmentTransaction;
@@ -20,143 +8,14 @@ interface Props {
 }
 
 const InvestmentTransactionRow = ({ investmentTransaction, isEditable = false }: Props) => {
-  const { id, account_id, date, name, amount, iso_currency_code, label } = investmentTransaction;
+  const { id, account_id, date, name, amount, iso_currency_code } = investmentTransaction;
 
-  const { data, setData, router } = useAppContext();
+  const { data, router } = useAppContext();
   const { accounts } = data;
   const { go } = router;
 
   const account = accounts.get(account_id);
   const institution_id = account?.institution_id;
-
-  const {
-    selectedBudgetIdLabel,
-    setSelectedBudgetIdLabel,
-    selectedCategoryIdLabel,
-    setSelectedCategoryIdLabel,
-    budgetOptions,
-    categoryOptions,
-  } = useBudgetCategorySelect(label, account, `investment_transaction_${id}`);
-  const [selectedConfidence, setSelectedConfidence] = useState<number | null>(
-    () => label.category_confidence ?? null,
-  );
-
-  const isSuggested =
-    !!selectedCategoryIdLabel &&
-    selectedConfidence !== null &&
-    selectedConfidence > 0 &&
-    selectedConfidence < 1;
-  const categoryWrapperClass = !selectedCategoryIdLabel
-    ? "notification"
-    : isSuggested
-      ? "suggested clickable"
-      : "";
-
-  useEffect(() => {
-    if (label.budget_id) return;
-    setSelectedBudgetIdLabel(account?.label.budget_id || "");
-  }, [label.budget_id, account?.label.budget_id, setSelectedBudgetIdLabel]);
-
-  // See TransactionRow — sync confidence from parent-updated transaction
-  // so Accept-All reflects without a reload.
-  useEffect(() => {
-    setSelectedConfidence(label.category_confidence ?? null);
-  }, [label.category_confidence]);
-
-  const onChangeBudgetSelect: ChangeEventHandler<HTMLSelectElement> = async (e) => {
-    const { value } = e.target;
-    if (value === selectedBudgetIdLabel) return;
-
-    setSelectedBudgetIdLabel(value);
-    setSelectedCategoryIdLabel("");
-
-    const response: ApiResponse = await call.post("/api/investment-transaction", {
-      investment_transaction_id: id,
-      label: { budget_id: value || null, category_id: null, category_confidence: 0 },
-    });
-
-    if (response.status === "success") {
-      setSelectedConfidence(0);
-      setData((oldData) => {
-        const newData = new Data(oldData);
-        const newTransaction = new InvestmentTransaction(investmentTransaction);
-        newTransaction.label.budget_id = value || null;
-        newTransaction.label.category_id = null;
-        newTransaction.label.category_confidence = 0;
-        indexedDb.save(newTransaction).catch(console.error);
-        const newTransactions = new InvestmentTransactionDictionary(newData.investmentTransactions);
-        newTransactions.set(id, newTransaction);
-        newData.investmentTransactions = newTransactions;
-        return newData;
-      });
-    } else {
-      setSelectedBudgetIdLabel(selectedBudgetIdLabel);
-      setSelectedCategoryIdLabel(selectedCategoryIdLabel);
-    }
-  };
-
-  const onChangeCategorySelect: ChangeEventHandler<HTMLSelectElement> = async (e) => {
-    const { value } = e.target;
-    if (value === selectedCategoryIdLabel) return;
-
-    setSelectedCategoryIdLabel(value);
-    const nextConfidence = value ? 1 : 0;
-    const labelQuery = new TransactionLabel({
-      category_id: value || null,
-      category_confidence: nextConfidence,
-    });
-    if (!label.budget_id) labelQuery.budget_id = account?.label.budget_id;
-
-    const response: ApiResponse = await call.post("/api/investment-transaction", {
-      investment_transaction_id: id,
-      label: labelQuery,
-    });
-
-    if (response.status === "success") {
-      setSelectedConfidence(nextConfidence);
-      setData((oldData) => {
-        const newData = new Data(oldData);
-        const newTransaction = new InvestmentTransaction(investmentTransaction);
-        if (!newTransaction.label.budget_id) {
-          newTransaction.label.budget_id = account?.label.budget_id;
-        }
-        newTransaction.label.category_id = value || null;
-        newTransaction.label.category_confidence = nextConfidence;
-        indexedDb.save(newTransaction).catch(console.error);
-        const newTransactions = new InvestmentTransactionDictionary(newData.investmentTransactions);
-        newTransactions.set(id, newTransaction);
-        newData.investmentTransactions = newTransactions;
-        return newData;
-      });
-    } else {
-      setSelectedCategoryIdLabel(selectedCategoryIdLabel);
-    }
-  };
-
-  const onAcceptSuggestion = async () => {
-    if (!isSuggested || !selectedCategoryIdLabel) return;
-    const response: ApiResponse = await call.post("/api/investment-transaction", {
-      investment_transaction_id: id,
-      label: { category_confidence: 1 },
-    });
-    if (response.status !== "success") return;
-    setSelectedConfidence(1);
-    setData((oldData) => {
-      const newData = new Data(oldData);
-      const newTransaction = new InvestmentTransaction(investmentTransaction);
-      newTransaction.label.category_confidence = 1;
-      indexedDb.save(newTransaction).catch(console.error);
-      const newTransactions = new InvestmentTransactionDictionary(newData.investmentTransactions);
-      newTransactions.set(id, newTransaction);
-      newData.investmentTransactions = newTransactions;
-      return newData;
-    });
-  };
-
-  const onClickCategoryWrapper: MouseEventHandler<HTMLDivElement> = (e) => {
-    if (e.target !== e.currentTarget) return;
-    if (isSuggested) void onAcceptSuggestion();
-  };
 
   const onClickKebab = () => {
     const params = new URLSearchParams(router.params);
@@ -192,20 +51,6 @@ const InvestmentTransactionRow = ({ investmentTransaction, isEditable = false }:
       </div>
       {isEditable && (
         <div className="budgetCategoryActions">
-          <select value={selectedBudgetIdLabel} onChange={onChangeBudgetSelect}>
-            <option value="">Select Budget</option>
-            {budgetOptions}
-          </select>
-          <div
-            className={categoryWrapperClass}
-            onClick={onClickCategoryWrapper}
-            title={isSuggested ? "Click the yellow dot to accept this suggestion" : undefined}
-          >
-            <select value={selectedCategoryIdLabel} onChange={onChangeCategorySelect}>
-              <option value="">Select Category</option>
-              {categoryOptions}
-            </select>
-          </div>
           <div>
             <button className="kebabButton" onClick={onClickKebab}>
               <KebabIcon size={15} />

--- a/src/client/components/TransactionsTable/index.tsx
+++ b/src/client/components/TransactionsTable/index.tsx
@@ -20,7 +20,13 @@ export const TransactionsTable = ({ transactions }: Props) => {
   const transactionRows = transactions
     .map((e) => {
       if (e instanceof InvestmentTransaction) {
-        return <InvestmentTransactionRow key={e.id} investmentTransaction={e} />;
+        // `isEditable={true}` exposes the row's budget/category selects
+        // and the kebab that navigates to `PATH.TRANSACTION_DETAIL`. Kept
+        // hidden by default in the row's Props for historical reasons;
+        // flipped on here now that the detail page renders inv-tx (PR
+        // #587) and manual entry needs the kebab as its primary reach
+        // for anyone editing a `source='manual'` row post-creation.
+        return <InvestmentTransactionRow key={e.id} investmentTransaction={e} isEditable={true} />;
       }
       // Bundled-pair dedup applies to parent Transaction rows only —
       // SplitTransactions inherit their parent's transaction_id but

--- a/src/client/components/TransactionsTable/index.tsx
+++ b/src/client/components/TransactionsTable/index.tsx
@@ -20,12 +20,11 @@ export const TransactionsTable = ({ transactions }: Props) => {
   const transactionRows = transactions
     .map((e) => {
       if (e instanceof InvestmentTransaction) {
-        // `isEditable={true}` exposes the row's budget/category selects
-        // and the kebab that navigates to `PATH.TRANSACTION_DETAIL`. Kept
-        // hidden by default in the row's Props for historical reasons;
-        // flipped on here now that the detail page renders inv-tx (PR
-        // #587) and manual entry needs the kebab as its primary reach
-        // for anyone editing a `source='manual'` row post-creation.
+        // isEditable surfaces the kebab — the sole entry point to
+        // PATH.TRANSACTION_DETAIL for editing a `source='manual'` inv-tx
+        // after creation — alongside the budget/category selects. Those
+        // selects are inert for investment rows (the calc layer skips
+        // investment labels), so only the kebab is load-bearing here.
         return <InvestmentTransactionRow key={e.id} investmentTransaction={e} isEditable={true} />;
       }
       // Bundled-pair dedup applies to parent Transaction rows only —

--- a/src/client/components/TransactionsTable/index.tsx
+++ b/src/client/components/TransactionsTable/index.tsx
@@ -22,9 +22,7 @@ export const TransactionsTable = ({ transactions }: Props) => {
       if (e instanceof InvestmentTransaction) {
         // isEditable surfaces the kebab — the sole entry point to
         // PATH.TRANSACTION_DETAIL for editing a `source='manual'` inv-tx
-        // after creation — alongside the budget/category selects. Those
-        // selects are inert for investment rows (the calc layer skips
-        // investment labels), so only the kebab is load-bearing here.
+        // after creation.
         return <InvestmentTransactionRow key={e.id} investmentTransaction={e} isEditable={true} />;
       }
       // Bundled-pair dedup applies to parent Transaction rows only —

--- a/src/client/lib/models/InvestmentTransaction.ts
+++ b/src/client/lib/models/InvestmentTransaction.ts
@@ -24,6 +24,12 @@ export class InvestmentTransaction implements JSONInvestmentTransaction {
   iso_currency_code: string | null = null;
   unofficial_currency_code: string | null = null;
   /**
+   * Origin marker — same semantics as `Transaction.source`. FE enables
+   * inline editing of security/quantity/price/type/subtype on the
+   * detail page only when this is `"manual"`.
+   */
+  source: string = "plaid";
+  /**
    * Represents relations by pair of budget_id and category_id
    */
   label: TransactionLabel;

--- a/src/client/lib/models/Transaction.ts
+++ b/src/client/lib/models/Transaction.ts
@@ -88,6 +88,15 @@ export class Transaction implements JSONTransaction {
   transaction_code: TransactionCode | null = null;
   personal_finance_category?: PersonalFinanceCategory | null;
   /**
+   * Origin marker — `"plaid"` for synced rows, `"manual"` for rows the
+   * user created via `GET /api/new-transaction`. FE branches on this to
+   * enable inline editing of the core fields (name/amount/date) on the
+   * detail page — Plaid rows are read-only there because Plaid is the
+   * source of truth. Defaults to `"plaid"` so pre-existing IDB rows
+   * migrate cleanly.
+   */
+  source: string = "plaid";
+  /**
    * Represents relations by pair of budget_id and category_id
    */
   label: TransactionLabel;

--- a/src/common/models/Transaction.ts
+++ b/src/common/models/Transaction.ts
@@ -57,6 +57,12 @@ export interface JSONTransaction extends PlaidTransaction {
    *  route); the FE treats rows with this flag as tombstones for IDB +
    *  dict eviction. */
   is_deleted?: boolean;
+  /** Origin marker — `"plaid"` for Plaid/simple-fin-synced rows,
+   *  `"manual"` for rows the user created via
+   *  `GET /api/new-transaction` on a manual account. Defaults to
+   *  `"plaid"` at the DB layer so pre-existing rows and Plaid inserts
+   *  don't need special-casing. */
+  source?: string;
 }
 
 export type TransferPairStatus = "suggested" | "confirmed" | "rejected";
@@ -78,6 +84,8 @@ export interface JSONInvestmentTransaction extends PlaidInvestmentTransaction {
    *  `JSONTransaction.is_deleted`; always present on rows from
    *  `/api/transactions`. */
   is_deleted?: boolean;
+  /** Origin marker — same semantics as `JSONTransaction.source`. */
+  source?: string;
 }
 
 export interface RemovedTransaction {

--- a/src/server/lib/compute-tools/auto-suggest.test.ts
+++ b/src/server/lib/compute-tools/auto-suggest.test.ts
@@ -66,6 +66,7 @@ const txRow = (overrides: Record<string, unknown> = {}) => ({
   raw: null,
   updated: null,
   is_deleted: false,
+  source: "plaid",
   ...overrides,
 });
 

--- a/src/server/lib/postgres/models/common.ts
+++ b/src/server/lib/postgres/models/common.ts
@@ -25,6 +25,7 @@ export const USER_ID = "user_id";
 export const UPDATED = "updated";
 export const IS_DELETED = "is_deleted";
 export const RAW = "raw";
+export const SOURCE = "source";
 
 export const USERNAME = "username";
 export const PASSWORD = "password";

--- a/src/server/lib/postgres/models/investment_transaction.ts
+++ b/src/server/lib/postgres/models/investment_transaction.ts
@@ -26,6 +26,7 @@ import {
   RAW,
   UPDATED,
   IS_DELETED,
+  SOURCE,
   INVESTMENT_TRANSACTIONS,
   USERS,
 } from "./common";
@@ -50,6 +51,9 @@ const invTxSchema = {
   [RAW]: "JSONB",
   [UPDATED]: "TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP",
   [IS_DELETED]: "BOOLEAN DEFAULT FALSE",
+  // See `transaction.ts` — `plaid` / `manual` origin marker with a safe
+  // default so pre-existing rows and Plaid inserts don't need touching.
+  [SOURCE]: "VARCHAR(20) NOT NULL DEFAULT 'plaid'",
 };
 
 type InvTxSchema = typeof invTxSchema;
@@ -74,6 +78,7 @@ export class InvTxModel extends Model<JSONInvTx, InvTxSchema> implements InvTxRo
   declare raw: object | null;
   declare updated: string | null;
   declare is_deleted: boolean;
+  declare source: string;
 
   static typeChecker = {
     investment_transaction_id: isString,
@@ -94,6 +99,7 @@ export class InvTxModel extends Model<JSONInvTx, InvTxSchema> implements InvTxRo
     raw: isNullableObject,
     updated: isNullableString,
     is_deleted: isNullableBoolean,
+    source: isNullableString,
   };
 
   constructor(data: unknown) {
@@ -121,6 +127,7 @@ export class InvTxModel extends Model<JSONInvTx, InvTxSchema> implements InvTxRo
         memo: this.label_memo,
       },
       is_deleted: this.is_deleted ?? false,
+      source: this.source ?? "plaid",
     };
   }
 
@@ -146,7 +153,8 @@ export class InvTxModel extends Model<JSONInvTx, InvTxSchema> implements InvTxRo
       if (tx.label.category_id !== undefined) r.label_category_id = tx.label.category_id;
       if (tx.label.memo !== undefined) r.label_memo = tx.label.memo;
     }
-    const { label: _label, ...providerData } = tx;
+    if (tx.source !== undefined) r.source = tx.source;
+    const { label: _label, source: _source, ...providerData } = tx;
     r.raw = providerData;
     return r;
   }

--- a/src/server/lib/postgres/models/transaction.ts
+++ b/src/server/lib/postgres/models/transaction.ts
@@ -30,6 +30,7 @@ import {
   RAW,
   UPDATED,
   IS_DELETED,
+  SOURCE,
   TRANSACTIONS,
   USERS,
 } from "./common";
@@ -57,6 +58,14 @@ const txSchema = {
   [RAW]: "JSONB",
   [UPDATED]: "TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP",
   [IS_DELETED]: "BOOLEAN DEFAULT FALSE",
+  // Origin marker. `plaid` for anything synced from Plaid or simple-fin
+  // (safe default so the auto-migration backfills existing rows without
+  // a script). `manual` for rows the user created via
+  // `GET /api/new-transaction` on a manual account (#567) — those rows
+  // are safe from Plaid overwrite because Plaid uses distinct id shapes,
+  // but the column keeps the intent auditable and future-proofs a CSV
+  // import path.
+  [SOURCE]: "VARCHAR(20) NOT NULL DEFAULT 'plaid'",
 };
 
 type TxSchema = typeof txSchema;
@@ -84,6 +93,7 @@ export class TransactionModel extends Model<JSONTransaction, TxSchema> implement
   declare raw: object | null;
   declare updated: string;
   declare is_deleted: boolean;
+  declare source: string;
 
   static typeChecker = {
     transaction_id: isString,
@@ -107,6 +117,7 @@ export class TransactionModel extends Model<JSONTransaction, TxSchema> implement
     raw: isNullableObject,
     updated: isNullableString,
     is_deleted: isNullableBoolean,
+    source: isNullableString,
   };
 
   constructor(data: unknown) {
@@ -160,6 +171,7 @@ export class TransactionModel extends Model<JSONTransaction, TxSchema> implement
       datetime: null,
       transaction_code: null,
       is_deleted: this.is_deleted ?? false,
+      source: this.source ?? "plaid",
     };
   }
 
@@ -190,7 +202,8 @@ export class TransactionModel extends Model<JSONTransaction, TxSchema> implement
       if (!isUndefined(tx.label.memo)) r.label_memo = tx.label.memo;
       if (!isUndefined(tx.label.category_confidence)) r.label_category_confidence = tx.label.category_confidence;
     }
-    const { label: _label, ...providerData } = tx;
+    if (!isUndefined(tx.source)) r.source = tx.source;
+    const { label: _label, source: _source, ...providerData } = tx;
     r.raw = providerData;
     return r;
   }

--- a/src/server/lib/postgres/repositories/investment_transactions.ts
+++ b/src/server/lib/postgres/repositories/investment_transactions.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { InvestmentTransactionType, InvestmentTransactionSubtype } from "plaid";
 import { JSONInvestmentTransaction } from "common";
+import { pool } from "../client";
 import {
   MaskedUser,
   InvTxModel,
@@ -126,18 +127,30 @@ export const updateInvestmentTransactions = async (
  * account. Plaid sync only inserts/updates rows keyed by its own IDs,
  * so a manual UUID-shaped id has no collision surface.
  */
+/** Same shape as `nextUnknownIndex` in `transactions.ts` — see that comment
+ *  for the rationale on the "count soft-deleted" choice. */
+const nextInvUnknownIndex = async (user_id: string): Promise<number> => {
+  const sql =
+    `SELECT COALESCE(MAX(CAST(SUBSTRING(name FROM '^Unknown_(\\d+)$') AS INTEGER)), 0) AS max ` +
+    `FROM investment_transactions WHERE user_id = $1 AND name ~ '^Unknown_[0-9]+$'`;
+  const result = await pool.query<{ max: number }>(sql, [user_id]);
+  const currentMax = Number(result.rows[0]?.max ?? 0);
+  return (Number.isFinite(currentMax) ? currentMax : 0) + 1;
+};
+
 export const createManualInvestmentTransaction = async (
   user: MaskedUser,
   input: { account_id: string; security_id?: string | null },
 ): Promise<JSONInvestmentTransaction | null> => {
   const investment_transaction_id = `manual-${randomUUID()}`;
+  const index = await nextInvUnknownIndex(user.user_id);
   const row = InvTxModel.fromJSON(
     {
       investment_transaction_id,
       account_id: input.account_id,
       security_id: input.security_id ?? null,
       date: new Date().toISOString().split("T")[0],
-      name: "",
+      name: `Unknown_${index}`,
       amount: 0,
       quantity: 0,
       price: 0,

--- a/src/server/lib/postgres/repositories/investment_transactions.ts
+++ b/src/server/lib/postgres/repositories/investment_transactions.ts
@@ -97,7 +97,18 @@ export const updateInvestmentTransactions = async (
       delete row.investment_transaction_id;
       delete row.user_id;
 
-      const updated = await investmentTransactionsTable.update(tx.investment_transaction_id, row);
+      // Scope the update to the caller's user_id — without this a
+       // caller could patch another user's investment transaction by id.
+       // Pre-existing gap on main; the manual-tx UI in this PR widens the
+       // reach of `POST /api/investment-transaction` (kebab now visible on
+       // every inv row per PR #588), so tightening here matches
+       // `updateTransactions` at `transactions.ts:145`.
+      const updated = await investmentTransactionsTable.update(
+        tx.investment_transaction_id,
+        row,
+        undefined,
+        user.user_id,
+      );
       results.push(
         updated
           ? successResult(tx.investment_transaction_id, 1)

--- a/src/server/lib/postgres/repositories/investment_transactions.ts
+++ b/src/server/lib/postgres/repositories/investment_transactions.ts
@@ -98,11 +98,7 @@ export const updateInvestmentTransactions = async (
       delete row.user_id;
 
       // Scope the update to the caller's user_id — without this a
-       // caller could patch another user's investment transaction by id.
-       // Pre-existing gap on main; the manual-tx UI in this PR widens the
-       // reach of `POST /api/investment-transaction` (kebab now visible on
-       // every inv row per PR #588), so tightening here matches
-       // `updateTransactions` at `transactions.ts:145`.
+      // caller could patch another user's investment transaction by id.
       const updated = await investmentTransactionsTable.update(
         tx.investment_transaction_id,
         row,

--- a/src/server/lib/postgres/repositories/investment_transactions.ts
+++ b/src/server/lib/postgres/repositories/investment_transactions.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "crypto";
+import { InvestmentTransactionType, InvestmentTransactionSubtype } from "plaid";
 import { JSONInvestmentTransaction } from "common";
 import {
   MaskedUser,
@@ -120,9 +122,7 @@ export const updateInvestmentTransactions = async (
 export const createManualInvestmentTransaction = async (
   user: MaskedUser,
   input: { account_id: string; security_id?: string | null },
-): Promise<JSONInvestmentTransaction> => {
-  const { randomUUID } = await import("crypto");
-  const { InvestmentTransactionType, InvestmentTransactionSubtype } = await import("plaid");
+): Promise<JSONInvestmentTransaction | null> => {
   const investment_transaction_id = `manual-${randomUUID()}`;
   const row = InvTxModel.fromJSON(
     {
@@ -141,9 +141,14 @@ export const createManualInvestmentTransaction = async (
     },
     user.user_id,
   );
-  const result = await investmentTransactionsTable.insert(row, ["*"]);
-  if (!result) throw new Error("Failed to create manual investment transaction");
-  return new InvTxModel(result).toJSON();
+  try {
+    const result = await investmentTransactionsTable.insert(row, ["*"]);
+    if (!result) return null;
+    return new InvTxModel(result).toJSON();
+  } catch (error) {
+    logger.error("Failed to create manual investment transaction", { investment_transaction_id, account_id: input.account_id }, error);
+    return null;
+  }
 };
 
 export const deleteInvestmentTransactions = async (

--- a/src/server/lib/postgres/repositories/investment_transactions.ts
+++ b/src/server/lib/postgres/repositories/investment_transactions.ts
@@ -140,7 +140,18 @@ const nextInvUnknownIndex = async (user_id: string): Promise<number> => {
 
 export const createManualInvestmentTransaction = async (
   user: MaskedUser,
-  input: { account_id: string; security_id?: string | null },
+  input: {
+    account_id: string;
+    security_id?: string | null;
+    // Holding-derived defaults. When the mint is triggered from the
+    // holding detail page, the caller passes the holding's
+    // `institution_price` and `iso_currency_code` so the shell starts
+    // with a plausible non-zero price the user can confirm/correct.
+    // From the account-level `+` (no holding context) these are
+    // omitted and fall back to 0 / null.
+    price?: number | null;
+    iso_currency_code?: string | null;
+  },
 ): Promise<JSONInvestmentTransaction | null> => {
   const investment_transaction_id = `manual-${randomUUID()}`;
   const index = await nextInvUnknownIndex(user.user_id);
@@ -153,8 +164,8 @@ export const createManualInvestmentTransaction = async (
       name: `Unknown_${index}`,
       amount: 0,
       quantity: 0,
-      price: 0,
-      iso_currency_code: null,
+      price: input.price ?? 0,
+      iso_currency_code: input.iso_currency_code ?? null,
       type: InvestmentTransactionType.Buy,
       subtype: InvestmentTransactionSubtype.Buy,
       source: "manual",

--- a/src/server/lib/postgres/repositories/investment_transactions.ts
+++ b/src/server/lib/postgres/repositories/investment_transactions.ts
@@ -109,6 +109,43 @@ export const updateInvestmentTransactions = async (
   return results;
 };
 
+/**
+ * Insert a shell `investment_transactions` row. Unlike the cash-side
+ * `createManualTransaction`, this is NOT gated on `items.provider ===
+ * MANUAL` — #585's motivating case (RSU/ESPP grants that predate
+ * Plaid's 24-month window) lives on a Plaid-connected brokerage
+ * account. Plaid sync only inserts/updates rows keyed by its own IDs,
+ * so a manual UUID-shaped id has no collision surface.
+ */
+export const createManualInvestmentTransaction = async (
+  user: MaskedUser,
+  input: { account_id: string; security_id?: string | null },
+): Promise<JSONInvestmentTransaction> => {
+  const { randomUUID } = await import("crypto");
+  const { InvestmentTransactionType, InvestmentTransactionSubtype } = await import("plaid");
+  const investment_transaction_id = `manual-${randomUUID()}`;
+  const row = InvTxModel.fromJSON(
+    {
+      investment_transaction_id,
+      account_id: input.account_id,
+      security_id: input.security_id ?? null,
+      date: new Date().toISOString().split("T")[0],
+      name: "",
+      amount: 0,
+      quantity: 0,
+      price: 0,
+      iso_currency_code: null,
+      type: InvestmentTransactionType.Buy,
+      subtype: InvestmentTransactionSubtype.Buy,
+      source: "manual",
+    },
+    user.user_id,
+  );
+  const result = await investmentTransactionsTable.insert(row, ["*"]);
+  if (!result) throw new Error("Failed to create manual investment transaction");
+  return new InvTxModel(result).toJSON();
+};
+
 export const deleteInvestmentTransactions = async (
   user: MaskedUser,
   transaction_ids: string[],

--- a/src/server/lib/postgres/repositories/transactions.test.ts
+++ b/src/server/lib/postgres/repositories/transactions.test.ts
@@ -52,6 +52,7 @@ function makeTxRow(overrides: Record<string, unknown> = {}) {
     raw: null,
     updated: "2026-03-01T00:00:00Z",
     is_deleted: false,
+    source: "plaid",
     ...overrides,
   };
 }

--- a/src/server/lib/postgres/repositories/transactions.ts
+++ b/src/server/lib/postgres/repositories/transactions.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto";
 import { JSONTransaction, JSONInvestmentTransaction } from "common";
+import { pool } from "../client";
 import {
   MaskedUser,
   TransactionModel,
@@ -160,16 +161,32 @@ export const updateTransactions = async (
  * so we don't accidentally create a duplicate manual row against a
  * Plaid-synced account (#567 acceptance criteria).
  */
+/**
+ * Query the highest `Unknown_N` name for the user on `transactions` and
+ * return `N + 1` — the shell mint gets a spot-in-the-list identifier the
+ * user can recognize + clean up later. Soft-deleted rows count too so a
+ * later undelete can't collide. Falls back to `1` on parse error.
+ */
+const nextUnknownTxIndex = async (user_id: string): Promise<number> => {
+  const sql =
+    `SELECT COALESCE(MAX(CAST(SUBSTRING(name FROM '^Unknown_(\\d+)$') AS INTEGER)), 0) AS max ` +
+    `FROM transactions WHERE user_id = $1 AND name ~ '^Unknown_[0-9]+$'`;
+  const result = await pool.query<{ max: number }>(sql, [user_id]);
+  const currentMax = Number(result.rows[0]?.max ?? 0);
+  return (Number.isFinite(currentMax) ? currentMax : 0) + 1;
+};
+
 export const createManualTransaction = async (
   user: MaskedUser,
   input: { account_id: string; iso_currency_code?: string | null },
 ): Promise<JSONTransaction | null> => {
   const transaction_id = `manual-${randomUUID()}`;
+  const index = await nextUnknownTxIndex(user.user_id);
   const row = TransactionModel.fromJSON(
     {
       transaction_id,
       account_id: input.account_id,
-      name: "",
+      name: `Unknown_${index}`,
       amount: 0,
       iso_currency_code: input.iso_currency_code ?? null,
       date: new Date().toISOString().split("T")[0],

--- a/src/server/lib/postgres/repositories/transactions.ts
+++ b/src/server/lib/postgres/repositories/transactions.ts
@@ -153,6 +153,36 @@ export const updateTransactions = async (
   return results;
 };
 
+/**
+ * Insert a shell `transactions` row for the user to fill in on the
+ * detail page. Callers gate `account_id` on `items.provider === MANUAL`
+ * so we don't accidentally create a duplicate manual row against a
+ * Plaid-synced account (#567 acceptance criteria).
+ */
+export const createManualTransaction = async (
+  user: MaskedUser,
+  input: { account_id: string; iso_currency_code?: string | null },
+): Promise<JSONTransaction> => {
+  const { randomUUID } = await import("crypto");
+  const transaction_id = `manual-${randomUUID()}`;
+  const row = TransactionModel.fromJSON(
+    {
+      transaction_id,
+      account_id: input.account_id,
+      name: "",
+      amount: 0,
+      iso_currency_code: input.iso_currency_code ?? null,
+      date: new Date().toISOString().split("T")[0],
+      pending: false,
+      source: "manual",
+    },
+    user.user_id,
+  );
+  const result = await transactionsTable.insert(row, ["*"]);
+  if (!result) throw new Error("Failed to create manual transaction");
+  return new TransactionModel(result).toJSON();
+};
+
 export const deleteTransactions = async (
   user: MaskedUser,
   transaction_ids: string[],

--- a/src/server/lib/postgres/repositories/transactions.ts
+++ b/src/server/lib/postgres/repositories/transactions.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import { JSONTransaction, JSONInvestmentTransaction } from "common";
 import {
   MaskedUser,
@@ -162,8 +163,7 @@ export const updateTransactions = async (
 export const createManualTransaction = async (
   user: MaskedUser,
   input: { account_id: string; iso_currency_code?: string | null },
-): Promise<JSONTransaction> => {
-  const { randomUUID } = await import("crypto");
+): Promise<JSONTransaction | null> => {
   const transaction_id = `manual-${randomUUID()}`;
   const row = TransactionModel.fromJSON(
     {
@@ -178,9 +178,14 @@ export const createManualTransaction = async (
     },
     user.user_id,
   );
-  const result = await transactionsTable.insert(row, ["*"]);
-  if (!result) throw new Error("Failed to create manual transaction");
-  return new TransactionModel(result).toJSON();
+  try {
+    const result = await transactionsTable.insert(row, ["*"]);
+    if (!result) return null;
+    return new TransactionModel(result).toJSON();
+  } catch (error) {
+    logger.error("Failed to create manual transaction", { transaction_id, account_id: input.account_id }, error);
+    return null;
+  }
 };
 
 export const deleteTransactions = async (

--- a/src/server/lib/postgres/repositories/transfers.test.ts
+++ b/src/server/lib/postgres/repositories/transfers.test.ts
@@ -64,6 +64,7 @@ function makeTxRow(overrides: Record<string, unknown> = {}) {
     raw: null,
     updated: "2026-04-01T00:00:00Z",
     is_deleted: false,
+    source: "plaid",
     ...overrides,
   };
 }

--- a/src/server/routes/accounts/delete-investment-transaction.ts
+++ b/src/server/routes/accounts/delete-investment-transaction.ts
@@ -1,0 +1,44 @@
+import {
+  Route,
+  deleteInvestmentTransactions,
+  getInvestmentTransaction,
+  requireQueryString,
+  validationError,
+} from "server";
+
+/**
+ * Soft-delete a single manual investment transaction. Wired to
+ * `InvestmentTransactionProperties`' Delete button on `source='manual'`
+ * rows. Same rationale as `deleteTransactionRoute` — a stray
+ * `+ Add Investment Transaction` click leaves a zero-quantity /
+ * zero-price row that would clutter the transactions list forever
+ * without this.
+ *
+ * Gated to `source='manual'` server-side: Plaid rows are sync-owned;
+ * a manual delete would come back on the next incremental sync.
+ */
+export const deleteInvestmentTransactionRoute = new Route(
+  "DELETE",
+  "/investment-transaction",
+  async (req) => {
+    const { user } = req.session;
+    if (!user) return { status: "failed", message: "Request user is not authenticated." };
+
+    const idResult = requireQueryString(req, "investment_transaction_id");
+    if (!idResult.success) return validationError(idResult.error!);
+    const investment_transaction_id = idResult.data!;
+
+    const tx = await getInvestmentTransaction(user, investment_transaction_id);
+    if (!tx) return { status: "failed", message: "Investment transaction not found." };
+    if (tx.source !== "manual") {
+      return {
+        status: "failed",
+        message: "Only manual investment transactions can be deleted from the detail page.",
+      };
+    }
+
+    const { deleted } = await deleteInvestmentTransactions(user, [investment_transaction_id]);
+    if (!deleted) return { status: "failed", message: "Failed to delete investment transaction." };
+    return { status: "success", body: { investment_transaction_id } };
+  },
+);

--- a/src/server/routes/accounts/delete-transaction.ts
+++ b/src/server/routes/accounts/delete-transaction.ts
@@ -1,0 +1,46 @@
+import {
+  Route,
+  deleteTransactions,
+  getTransaction,
+  requireQueryString,
+  validationError,
+} from "server";
+
+/**
+ * Soft-delete a single manual transaction. Wired to
+ * `TransactionProperties`' Delete button on `source='manual'` rows —
+ * the primary reach for cleaning up an accidentally-minted shell (an
+ * abandoned `+ Add Transaction` click leaves a permanent zero-amount
+ * row without this).
+ *
+ * Gated to `source='manual'` server-side: Plaid-synced rows are owned
+ * by the sync path and shouldn't be user-deletable from the detail
+ * page (a manual delete would resurface on the next sync via upsert-
+ * by-id anyway). Any future need to delete a Plaid row lives on a
+ * separate admin flow.
+ */
+export const deleteTransactionRoute = new Route(
+  "DELETE",
+  "/transaction",
+  async (req) => {
+    const { user } = req.session;
+    if (!user) return { status: "failed", message: "Request user is not authenticated." };
+
+    const idResult = requireQueryString(req, "transaction_id");
+    if (!idResult.success) return validationError(idResult.error!);
+    const transaction_id = idResult.data!;
+
+    const tx = await getTransaction(user, transaction_id);
+    if (!tx) return { status: "failed", message: "Transaction not found." };
+    if (tx.source !== "manual") {
+      return {
+        status: "failed",
+        message: "Only manual transactions can be deleted from the detail page.",
+      };
+    }
+
+    const { deleted } = await deleteTransactions(user, [transaction_id]);
+    if (!deleted) return { status: "failed", message: "Failed to delete transaction." };
+    return { status: "success", body: { transaction_id } };
+  },
+);

--- a/src/server/routes/accounts/get-new-investment-transaction.ts
+++ b/src/server/routes/accounts/get-new-investment-transaction.ts
@@ -2,6 +2,7 @@ import {
   Route,
   createManualInvestmentTransaction,
   getAccount,
+  getSecurity,
   requireQueryString,
   validationError,
 } from "server";
@@ -34,16 +35,31 @@ export const getNewInvestmentTransactionRoute =
 
       // `security_id` is optional — omitted when the user clicks the
       // account-level `+ Add Investment Transaction` button and picks
-      // the security in the detail form. Prefilled when the user clicks
-      // the per-security `+` on the holding detail page.
-      const security_id = req.query?.security_id
+      // the security in the detail form (via ticker-lookup). Prefilled
+      // when the user clicks the per-security `+` on the holding detail
+      // page. When present, validate it resolves to a real security —
+      // without this, a caller could pass a garbage string that
+      // silently inserts and later breaks `data.securities.get()`
+      // lookups on the FE (there's no FK on the column).
+      const security_id_raw = req.query?.security_id
         ? String(req.query.security_id)
         : null;
+      let security_id: string | null = null;
+      if (security_id_raw) {
+        const security = await getSecurity(security_id_raw);
+        if (!security) {
+          return { status: "failed", message: "Security not found." };
+        }
+        security_id = security_id_raw;
+      }
 
       const created = await createManualInvestmentTransaction(user, {
         account_id,
         security_id,
       });
+      if (!created) {
+        return { status: "failed", message: "Failed to create investment transaction." };
+      }
 
       return {
         status: "success",

--- a/src/server/routes/accounts/get-new-investment-transaction.ts
+++ b/src/server/routes/accounts/get-new-investment-transaction.ts
@@ -68,9 +68,22 @@ export const getNewInvestmentTransactionRoute =
         security_id = security_id_raw;
       }
 
+      // Holding-derived defaults from the caller. The FE prefills
+      // `price` with the security's latest `institution_price` and
+      // `iso_currency_code` with the holding's currency, so the
+      // shell starts with values the user can confirm/correct rather
+      // than a 0 that quietly zeroes the MWR calc if abandoned.
+      const priceRaw = req.query?.price ? Number(req.query.price) : NaN;
+      const price = Number.isFinite(priceRaw) && priceRaw >= 0 ? priceRaw : undefined;
+      const iso_currency_code = req.query?.iso_currency_code
+        ? String(req.query.iso_currency_code)
+        : undefined;
+
       const created = await createManualInvestmentTransaction(user, {
         account_id,
         security_id,
+        price,
+        iso_currency_code,
       });
       if (!created) {
         return { status: "failed", message: "Failed to create investment transaction." };

--- a/src/server/routes/accounts/get-new-investment-transaction.ts
+++ b/src/server/routes/accounts/get-new-investment-transaction.ts
@@ -1,0 +1,53 @@
+import {
+  Route,
+  createManualInvestmentTransaction,
+  getAccount,
+  requireQueryString,
+  validationError,
+} from "server";
+
+export type NewInvestmentTransactionGetResponse = { investment_transaction_id: string };
+
+/**
+ * Mint a shell manual `investment_transactions` row. Unlike
+ * `getNewTransactionRoute`, this is NOT gated on
+ * `items.provider === MANUAL` — #585's motivating case (RSU/ESPP
+ * grants that predate Plaid's 24-month window) lives on a
+ * Plaid-connected brokerage account. Plaid sync inserts/updates rows
+ * keyed by its own IDs; the `manual-<uuid>` prefix here has no
+ * collision surface, and `source='manual'` keeps the intent auditable.
+ */
+export const getNewInvestmentTransactionRoute =
+  new Route<NewInvestmentTransactionGetResponse>(
+    "GET",
+    "/new-investment-transaction",
+    async (req) => {
+      const { user } = req.session;
+      if (!user) return { status: "failed", message: "Request user is not authenticated." };
+
+      const accountResult = requireQueryString(req, "account_id");
+      if (!accountResult.success) return validationError(accountResult.error!);
+      const account_id = accountResult.data!;
+
+      const account = await getAccount(user, account_id);
+      if (!account) return { status: "failed", message: "Account not found." };
+
+      // `security_id` is optional — omitted when the user clicks the
+      // account-level `+ Add Investment Transaction` button and picks
+      // the security in the detail form. Prefilled when the user clicks
+      // the per-security `+` on the holding detail page.
+      const security_id = req.query?.security_id
+        ? String(req.query.security_id)
+        : null;
+
+      const created = await createManualInvestmentTransaction(user, {
+        account_id,
+        security_id,
+      });
+
+      return {
+        status: "success",
+        body: { investment_transaction_id: created.investment_transaction_id },
+      };
+    },
+  );

--- a/src/server/routes/accounts/get-new-investment-transaction.ts
+++ b/src/server/routes/accounts/get-new-investment-transaction.ts
@@ -1,3 +1,4 @@
+import { AccountType } from "plaid";
 import {
   Route,
   createManualInvestmentTransaction,
@@ -32,6 +33,17 @@ export const getNewInvestmentTransactionRoute =
 
       const account = await getAccount(user, account_id);
       if (!account) return { status: "failed", message: "Account not found." };
+      // Match the FE gate: the `+ Add Investment Transaction` button
+      // only renders on investment accounts. Enforce the same server-side
+      // so a direct-URL caller can't mint an investment_transactions row
+      // against a depository/credit account (the row wouldn't render as a
+      // holding, but the data is still wrong).
+      if (account.type !== AccountType.Investment) {
+        return {
+          status: "failed",
+          message: "Investment transactions can only be created on investment accounts.",
+        };
+      }
 
       // `security_id` is optional — omitted when the user clicks the
       // account-level `+ Add Investment Transaction` button and picks

--- a/src/server/routes/accounts/get-new-investment-transaction.ts
+++ b/src/server/routes/accounts/get-new-investment-transaction.ts
@@ -8,7 +8,10 @@ import {
   validationError,
 } from "server";
 
-export type NewInvestmentTransactionGetResponse = { investment_transaction_id: string };
+export type NewInvestmentTransactionGetResponse = {
+  investment_transaction_id: string;
+  name: string;
+};
 
 /**
  * Mint a shell manual `investment_transactions` row. Unlike
@@ -75,7 +78,10 @@ export const getNewInvestmentTransactionRoute =
 
       return {
         status: "success",
-        body: { investment_transaction_id: created.investment_transaction_id },
+        body: {
+          investment_transaction_id: created.investment_transaction_id,
+          name: created.name,
+        },
       };
     },
   );

--- a/src/server/routes/accounts/get-new-transaction-routes.test.ts
+++ b/src/server/routes/accounts/get-new-transaction-routes.test.ts
@@ -1,0 +1,488 @@
+// Route + repo coverage for the two manual-transaction mint endpoints
+// (`GET /api/new-transaction` — provider-gated to MANUAL — and
+// `GET /api/new-investment-transaction` — allowed on any investment
+// account for the #585 RSU/ESPP case). The routes read query params,
+// look up account/item/security in the repo layer, then insert a shell
+// row via `createManualTransaction` / `createManualInvestmentTransaction`.
+// The pg-FakePool seam intercepts every DB call; a SQL router dispatches
+// by table so we can seed accounts / items / securities without needing
+// live tables.
+//
+// What we're pinning here:
+//   - unauth / missing-arg / not-found rejections
+//   - provider gate (cash mint refused on Plaid accounts — #567 AC)
+//   - account.type gate (invest mint refused on depository/credit)
+//   - security_id validation (garbage id refused via getSecurity)
+//   - happy paths write `source='manual'` and a `manual-<uuid>` id
+// Without these, dropping any of the guards would pass silently.
+
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+import { restoreLeaves } from "test-helpers";
+
+const mockQuery = mock(async (_sql: string, _values?: unknown[]) => ({
+  rows: [] as unknown[],
+  rowCount: 0 as number | null,
+}));
+
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+}
+
+mock.module("pg", () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {} },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+}));
+
+const { getNewTransactionRoute } = await import("./get-new-transaction");
+const { getNewInvestmentTransactionRoute } = await import("./get-new-investment-transaction");
+
+afterAll(restoreLeaves);
+
+// SQL router state — each test sets which SELECT-per-table returns a row.
+// The mint route calls: SELECT accounts, SELECT items (cash-side only),
+// SELECT securities (when security_id is present), INSERT transactions /
+// investment_transactions.
+type MaybeRow = Record<string, unknown> | null;
+let accountRow: MaybeRow = null;
+let itemRow: MaybeRow = null;
+let securityRow: MaybeRow = null;
+let insertShouldFail = false;
+
+const queryRouter = async (sql: string, _values?: unknown[]) => {
+  const isSelect = /^\s*SELECT\b/i.test(sql);
+  if (isSelect && /\bFROM\s+accounts\b/i.test(sql)) {
+    return accountRow ? { rows: [accountRow], rowCount: 1 } : { rows: [], rowCount: 0 };
+  }
+  if (isSelect && /\bFROM\s+items\b/i.test(sql)) {
+    return itemRow ? { rows: [itemRow], rowCount: 1 } : { rows: [], rowCount: 0 };
+  }
+  if (isSelect && /\bFROM\s+securities\b/i.test(sql)) {
+    return securityRow ? { rows: [securityRow], rowCount: 1 } : { rows: [], rowCount: 0 };
+  }
+  if (/\bINSERT\s+INTO\s+investment_transactions\b/i.test(sql)) {
+    if (insertShouldFail) throw new Error("DB down");
+    return { rows: [insertStub("investment_transactions", _values as unknown[])], rowCount: 1 };
+  }
+  if (/\bINSERT\s+INTO\s+transactions\b/i.test(sql)) {
+    if (insertShouldFail) throw new Error("DB down");
+    return { rows: [insertStub("transactions", _values as unknown[])], rowCount: 1 };
+  }
+  return { rows: [], rowCount: 0 };
+};
+
+/**
+ * Return a model-valid stub row for the INSERT's RETURNING *. The repo
+ * helper does `new TransactionModel(result).toJSON()` after, so the stub
+ * needs every column the typeChecker demands. Column values here are cosmetic
+ * — the actual test assertions read the SQL's bound parameter list via
+ * `findInsert` + `boundValue`, not this stub.
+ */
+function insertStub(table: "transactions" | "investment_transactions", values: unknown[]): Record<string, unknown> {
+  const id = String(values[0]);
+  if (table === "transactions") {
+    return {
+      transaction_id: id,
+      user_id: "u-1",
+      account_id: "acc-x",
+      name: null,
+      merchant_name: null,
+      amount: 0,
+      iso_currency_code: null,
+      date: "2026-01-01",
+      pending: false,
+      pending_transaction_id: null,
+      payment_channel: null,
+      location_country: null,
+      location_region: null,
+      location_city: null,
+      label_budget_id: null,
+      label_category_id: null,
+      label_memo: null,
+      label_category_confidence: null,
+      raw: null,
+      updated: new Date().toISOString(),
+      is_deleted: false,
+      source: "manual",
+    };
+  }
+  return {
+    investment_transaction_id: id,
+    user_id: "u-1",
+    account_id: "acc-x",
+    security_id: null,
+    date: "2026-01-01",
+    name: null,
+    amount: 0,
+    quantity: 0,
+    price: 0,
+    iso_currency_code: null,
+    type: "buy",
+    subtype: "buy",
+    label_budget_id: null,
+    label_category_id: null,
+    label_memo: null,
+    raw: null,
+    updated: new Date().toISOString(),
+    is_deleted: false,
+    source: "manual",
+  };
+}
+
+/** Find the INSERT statement that landed against `table`. Assertions read
+ *  `insert!.values` directly with `toContain(...)` — position-based lookup
+ *  is brittle because `buildInsert` walks `Object.keys(data)` and the model
+ *  layer's key insertion order intersperses `source` + `raw` in ways that
+ *  make a naive column→value lookup unreliable. `toContain` scoped to the
+ *  values array is enough to lock the route's intent (the specific string
+ *  landed on some column). */
+const findInsert = (table: string): { sql: string; values: unknown[] } | null => {
+  const re = new RegExp(`INSERT\\s+INTO\\s+${table}\\b`, "i");
+  for (const call of mockQuery.mock.calls) {
+    const sql = call[0] as string;
+    if (re.test(sql)) return { sql, values: call[1] as unknown[] };
+  }
+  return null;
+};
+
+type AnyRoute = typeof getNewTransactionRoute | typeof getNewInvestmentTransactionRoute;
+
+function makeReq(route: AnyRoute, query: Record<string, string> = {}, userId?: string) {
+  return {
+    method: "GET",
+    path: "/x",
+    url: "http://x/api/x?" + new URLSearchParams(query).toString(),
+    headers: {},
+    query,
+    body: undefined,
+    session: {
+      id: "s-1",
+      user: userId ? { user_id: userId, username: "test" } : undefined,
+      regenerate() {},
+      destroy() {},
+    },
+    ip: "127.0.0.1",
+  } as unknown as Parameters<typeof route.execute>[0];
+}
+
+const fakeRes = () =>
+  ({
+    statusCode: 200,
+    headersSent: false,
+    status() {
+      return this;
+    },
+    write() {
+      return true;
+    },
+    end() {},
+  }) as unknown as Parameters<typeof getNewTransactionRoute.execute>[1];
+
+beforeEach(() => {
+  mockQuery.mockClear();
+  mockQuery.mockImplementation(queryRouter);
+  accountRow = null;
+  itemRow = null;
+  securityRow = null;
+  insertShouldFail = false;
+});
+
+// The AccountModel / ItemModel / SecurityModel constructors run the row through
+// their typeChecker, which distinguishes null (valid for `isNullable*`) from
+// undefined (invalid). Fixtures fill every nullable column with `null` so the
+// model instantiation succeeds when the SELECT router echoes these back.
+const nullFields = (keys: string[]): Record<string, null> =>
+  Object.fromEntries(keys.map((k) => [k, null]));
+
+const ACCOUNT_NULLABLE = [
+  "name",
+  "type",
+  "subtype",
+  "balances_available",
+  "balances_current",
+  "balances_limit",
+  "balances_iso_currency_code",
+  "custom_name",
+  "hide",
+  "archived",
+  "label_budget_id",
+  "graph_options_use_snapshots",
+  "graph_options_use_holding_snapshots",
+  "graph_options_use_transactions",
+  "raw",
+  "updated",
+  "is_deleted",
+];
+const ITEM_NULLABLE = [
+  "access_token",
+  "institution_id",
+  "available_products",
+  "cursor",
+  "status",
+  "provider",
+  "last_sync_status",
+  "last_sync_at",
+  "last_sync_error",
+  "raw",
+  "updated",
+  "is_deleted",
+];
+const SECURITY_NULLABLE = [
+  "name",
+  "ticker_symbol",
+  "type",
+  "close_price",
+  "close_price_as_of",
+  "iso_currency_code",
+  "isin",
+  "cusip",
+  "raw",
+  "updated",
+];
+
+// A depository account owned by u-1 with a MANUAL item (cash-side happy path).
+const manualCashAccount = () => ({
+  ...nullFields(ACCOUNT_NULLABLE),
+  account_id: "acc-manual-cash",
+  user_id: "u-1",
+  item_id: "item-manual",
+  institution_id: "ins-manual",
+  type: "depository",
+  subtype: "checking",
+  balances_iso_currency_code: "USD",
+});
+const manualItem = () => ({
+  ...nullFields(ITEM_NULLABLE),
+  item_id: "item-manual",
+  user_id: "u-1",
+  provider: "manual",
+});
+
+// A Plaid brokerage owned by u-1 (invest-side happy path).
+const plaidInvestAccount = () => ({
+  ...nullFields(ACCOUNT_NULLABLE),
+  account_id: "acc-plaid-invest",
+  user_id: "u-1",
+  item_id: "item-plaid",
+  institution_id: "ins-plaid",
+  type: "investment",
+  subtype: "brokerage",
+  balances_iso_currency_code: "USD",
+});
+const plaidItem = () => ({
+  ...nullFields(ITEM_NULLABLE),
+  item_id: "item-plaid",
+  user_id: "u-1",
+  provider: "plaid",
+});
+
+const someSecurity = () => ({
+  ...nullFields(SECURITY_NULLABLE),
+  security_id: "sec-voo",
+  ticker_symbol: "VOO",
+  name: "Vanguard S&P 500",
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/new-transaction (cash-side, provider-gated to MANUAL)
+// ---------------------------------------------------------------------------
+
+describe("get-new-transaction route", () => {
+  test("rejects unauthenticated requests", async () => {
+    const result = await getNewTransactionRoute.execute(
+      makeReq(getNewTransactionRoute, { account_id: "acc-x" }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/not authenticated/i);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("rejects a missing account_id", async () => {
+    const result = await getNewTransactionRoute.execute(
+      makeReq(getNewTransactionRoute, {}, "u-1"),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/account_id/i);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("rejects when the account isn't found for the caller", async () => {
+    // accountRow left null → getAccount returns null
+    const result = await getNewTransactionRoute.execute(
+      makeReq(getNewTransactionRoute, { account_id: "acc-x" }, "u-1"),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/account not found/i);
+    expect(findInsert("transactions")).toBeNull();
+  });
+
+  test("rejects when the account's item is not MANUAL provider (Plaid/simple-fin) — #567 AC", async () => {
+    accountRow = plaidInvestAccount();
+    itemRow = plaidItem();
+    const result = await getNewTransactionRoute.execute(
+      makeReq(getNewTransactionRoute, { account_id: "acc-plaid-invest" }, "u-1"),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/only allowed on manual accounts/i);
+    // No INSERT — the provider gate short-circuits before the mint.
+    expect(findInsert("transactions")).toBeNull();
+  });
+
+  test("happy path: manual account → INSERT with source='manual' and manual-<uuid> id", async () => {
+    accountRow = manualCashAccount();
+    itemRow = manualItem();
+    const result = await getNewTransactionRoute.execute(
+      makeReq(getNewTransactionRoute, { account_id: "acc-manual-cash" }, "u-1"),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("success");
+    const insert = findInsert("transactions");
+    expect(insert).not.toBeNull();
+    // Position-based `boundValue` is brittle across driver-serialized columns,
+    // so assert `"manual"` shows up in the bound-parameter list directly.
+    expect(insert!.values).toContain("manual");
+    expect(insert!.values).toContain("u-1");
+    expect(insert!.values).toContain("acc-manual-cash");
+    // A `manual-<uuid>` id landed in the INSERT values.
+    const manualIds = insert!.values.filter(
+      (v): v is string => typeof v === "string" && v.startsWith("manual-"),
+    );
+    expect(manualIds.length).toBeGreaterThan(0);
+    // The route body has some transaction_id string (stub returns u-1 here;
+    // the important contract is the SQL wrote a manual-<uuid>, verified above).
+    expect(typeof (result?.body as { transaction_id: string }).transaction_id).toBe("string");
+  });
+
+  test("surfaces a DB error as a failed response (no throw bubbling to the caller)", async () => {
+    accountRow = manualCashAccount();
+    itemRow = manualItem();
+    insertShouldFail = true;
+    const result = await getNewTransactionRoute.execute(
+      makeReq(getNewTransactionRoute, { account_id: "acc-manual-cash" }, "u-1"),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/failed to create/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/new-investment-transaction (NOT provider-gated, but type-gated)
+// ---------------------------------------------------------------------------
+
+describe("get-new-investment-transaction route", () => {
+  test("rejects unauthenticated requests", async () => {
+    const result = await getNewInvestmentTransactionRoute.execute(
+      makeReq(getNewInvestmentTransactionRoute, { account_id: "acc-x" }),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/not authenticated/i);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("rejects a missing account_id", async () => {
+    const result = await getNewInvestmentTransactionRoute.execute(
+      makeReq(getNewInvestmentTransactionRoute, {}, "u-1"),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/account_id/i);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("rejects when the account isn't found for the caller", async () => {
+    const result = await getNewInvestmentTransactionRoute.execute(
+      makeReq(getNewInvestmentTransactionRoute, { account_id: "acc-x" }, "u-1"),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/account not found/i);
+    expect(findInsert("investment_transactions")).toBeNull();
+  });
+
+  test("rejects when the account isn't an investment account (depository/credit)", async () => {
+    // Manual depository account — provider gate wouldn't fire (route allows
+    // any provider), but the type gate catches it.
+    accountRow = manualCashAccount();
+    const result = await getNewInvestmentTransactionRoute.execute(
+      makeReq(getNewInvestmentTransactionRoute, { account_id: "acc-manual-cash" }, "u-1"),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/investment accounts/i);
+    expect(findInsert("investment_transactions")).toBeNull();
+  });
+
+  test("rejects a garbage security_id — server-side validation via getSecurity", async () => {
+    accountRow = plaidInvestAccount();
+    // securityRow left null → getSecurity returns null → route refuses
+    const result = await getNewInvestmentTransactionRoute.execute(
+      makeReq(
+        getNewInvestmentTransactionRoute,
+        { account_id: "acc-plaid-invest", security_id: "not-a-real-security-id" },
+        "u-1",
+      ),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/security not found/i);
+    expect(findInsert("investment_transactions")).toBeNull();
+  });
+
+  test("happy path with security_id: INSERT sets security_id + source='manual' on a Plaid brokerage (#585 case)", async () => {
+    accountRow = plaidInvestAccount();
+    securityRow = someSecurity();
+    const result = await getNewInvestmentTransactionRoute.execute(
+      makeReq(
+        getNewInvestmentTransactionRoute,
+        { account_id: "acc-plaid-invest", security_id: "sec-voo" },
+        "u-1",
+      ),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("success");
+    const insert = findInsert("investment_transactions");
+    expect(insert).not.toBeNull();
+    // Position-based `boundValue` is brittle across driver-serialized columns,
+    // so assert `"manual"` shows up in the bound-parameter list directly.
+    expect(insert!.values).toContain("manual");
+    expect(insert!.values).toContain("sec-voo");
+    expect(insert!.values).toContain("u-1");
+    expect(insert!.values).toContain("acc-plaid-invest");
+    // A `manual-<uuid>` id landed in the INSERT values.
+    const manualIds = insert!.values.filter(
+      (v): v is string => typeof v === "string" && v.startsWith("manual-"),
+    );
+    expect(manualIds.length).toBeGreaterThan(0);
+    expect(typeof (result?.body as { investment_transaction_id: string }).investment_transaction_id).toBe("string");
+  });
+
+  test("happy path without security_id: INSERT still lands with security_id=null", async () => {
+    accountRow = plaidInvestAccount();
+    const result = await getNewInvestmentTransactionRoute.execute(
+      makeReq(
+        getNewInvestmentTransactionRoute,
+        { account_id: "acc-plaid-invest" },
+        "u-1",
+      ),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("success");
+    const insert = findInsert("investment_transactions");
+    expect(insert).not.toBeNull();
+    // Position-based `boundValue` is brittle across driver-serialized columns,
+    // so assert `"manual"` shows up in the bound-parameter list directly.
+    expect(insert!.values).toContain("manual");
+    // security_id absent from query → INSERT should carry null there. The
+    // route's happy path returns success and the mint's raw JSON blob
+    // doesn't carry a security_id key.
+    expect(insert!.values).toContain(null);
+  });
+});

--- a/src/server/routes/accounts/get-new-transaction.ts
+++ b/src/server/routes/accounts/get-new-transaction.ts
@@ -1,0 +1,50 @@
+import { ItemProvider } from "common";
+import {
+  Route,
+  createManualTransaction,
+  getAccount,
+  getItem,
+  requireQueryString,
+  validationError,
+} from "server";
+
+export type NewTransactionGetResponse = { transaction_id: string };
+
+/**
+ * Mint a shell manual `transactions` row on a manual-account. The FE
+ * navigates the user to the transaction detail page for the returned
+ * id; the page's save-on-blur handlers fill in the fields. Gated to
+ * `items.provider === MANUAL` so we don't accidentally create a
+ * duplicate row on a Plaid-synced account (#567 acceptance criteria).
+ */
+export const getNewTransactionRoute = new Route<NewTransactionGetResponse>(
+  "GET",
+  "/new-transaction",
+  async (req) => {
+    const { user } = req.session;
+    if (!user) return { status: "failed", message: "Request user is not authenticated." };
+
+    const accountResult = requireQueryString(req, "account_id");
+    if (!accountResult.success) return validationError(accountResult.error!);
+    const account_id = accountResult.data!;
+
+    const account = await getAccount(user, account_id);
+    if (!account) return { status: "failed", message: "Account not found." };
+
+    const item = await getItem(user, account.item_id);
+    if (!item) return { status: "failed", message: "Item not found." };
+    if (item.provider !== ItemProvider.MANUAL) {
+      return {
+        status: "failed",
+        message: "Manual transaction entry is only allowed on manual accounts.",
+      };
+    }
+
+    const created = await createManualTransaction(user, {
+      account_id,
+      iso_currency_code: account.balances.iso_currency_code,
+    });
+
+    return { status: "success", body: { transaction_id: created.transaction_id } };
+  },
+);

--- a/src/server/routes/accounts/get-new-transaction.ts
+++ b/src/server/routes/accounts/get-new-transaction.ts
@@ -8,7 +8,7 @@ import {
   validationError,
 } from "server";
 
-export type NewTransactionGetResponse = { transaction_id: string };
+export type NewTransactionGetResponse = { transaction_id: string; name: string };
 
 /**
  * Mint a shell manual `transactions` row on a manual-account. The FE
@@ -46,6 +46,9 @@ export const getNewTransactionRoute = new Route<NewTransactionGetResponse>(
     });
     if (!created) return { status: "failed", message: "Failed to create transaction." };
 
-    return { status: "success", body: { transaction_id: created.transaction_id } };
+    return {
+      status: "success",
+      body: { transaction_id: created.transaction_id, name: created.name },
+    };
   },
 );

--- a/src/server/routes/accounts/get-new-transaction.ts
+++ b/src/server/routes/accounts/get-new-transaction.ts
@@ -44,6 +44,7 @@ export const getNewTransactionRoute = new Route<NewTransactionGetResponse>(
       account_id,
       iso_currency_code: account.balances.iso_currency_code,
     });
+    if (!created) return { status: "failed", message: "Failed to create transaction." };
 
     return { status: "success", body: { transaction_id: created.transaction_id } };
   },

--- a/src/server/routes/accounts/index.ts
+++ b/src/server/routes/accounts/index.ts
@@ -4,6 +4,8 @@ export * from "./delete-holding-snapshot";
 export * from "./delete-split-transaction";
 export * from "./get-transactions";
 export * from "./get-new-split-transaction";
+export * from "./get-new-transaction";
+export * from "./get-new-investment-transaction";
 export * from "./get-split-transactions";
 export * from "./get-accounts";
 export * from "./get-institution";

--- a/src/server/routes/accounts/index.ts
+++ b/src/server/routes/accounts/index.ts
@@ -2,6 +2,8 @@ export * from "./delete-account";
 export * from "./delete-snapshot";
 export * from "./delete-holding-snapshot";
 export * from "./delete-split-transaction";
+export * from "./delete-transaction";
+export * from "./delete-investment-transaction";
 export * from "./get-transactions";
 export * from "./get-new-split-transaction";
 export * from "./get-new-transaction";

--- a/src/server/routes/accounts/post-transaction-routes.test.ts
+++ b/src/server/routes/accounts/post-transaction-routes.test.ts
@@ -335,6 +335,11 @@ describe("post-investment-transaction route", () => {
     // The route does not call inferLabelConfidence, so no confidence column is
     // written — distinguishing it from the other two routes in the trio.
     expect(boundValue(upd!, "label_category_confidence")).toBe(SENTINEL);
+    // updateInvestmentTransactions scopes the write to the session user
+    // (4th arg userId). Regression guard: dropping the arg loses the
+    // scope silently.
+    expect(upd!.values).toContain("u-1");
+    expect(upd!.values).toContain("i-1");
   });
 
   test("surfaces a DB error as a failed response", async () => {

--- a/src/server/routes/transfers/get-transfers.test.ts
+++ b/src/server/routes/transfers/get-transfers.test.ts
@@ -107,6 +107,7 @@ describe("get-transfers", () => {
       raw: null,
       updated: "2026-05-01T00:00:00Z",
       is_deleted: false,
+      source: "plaid",
     });
     mockQuery.mockResolvedValueOnce({ rows: [pairRow], rowCount: 1 });
     mockQuery.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

Integrated `+ Add` entry surface for manual transactions across cash (#567) and investment (#585). Both flows reuse `TransactionDetailPage` (landed in #587) as the input form via save-on-blur handlers — no new form component, no save button.

Stack: PR #587 (`InvestmentTransactionProperties` render on the detail page) → this PR (mint routes + editable inputs + `+` buttons + `source` marker).

## What changed

**Schema (auto-migrated):**
- `transactions.source VARCHAR(20) NOT NULL DEFAULT 'plaid'`
- `investment_transactions.source VARCHAR(20) NOT NULL DEFAULT 'plaid'`

Rides through the existing `ALTER TABLE ADD COLUMN IF NOT EXISTS` init path. The `'plaid'` default backfills pre-existing rows; new rows minted via the routes below carry `source='manual'`.

**Server routes:**
- `GET /api/new-transaction?account_id=X` — provider-gated to `items.provider === MANUAL`. Refuses on Plaid-synced accounts (#567 AC).
- `GET /api/new-investment-transaction?account_id=X&security_id=Y` — NOT provider-gated (allows manual entry on Plaid-connected brokerages for #585's RSU/ESPP case). `security_id` is optional but VALIDATED when present via `getSecurity(security_id)` before insert — bogus id 4xx's cleanly instead of persisting a broken row.

Both routes insert a shell (`date=today, amount=0, name=""`, invest defaults to `type/subtype=buy`) and return the fresh id.

**FE — three `+` buttons:**
- `AccountProperties` `+ Add Transaction` — visible on ALL manual accounts (cash + invest — a manual brokerage tracks its cash wires/fees).
- `AccountProperties` `+ Add Investment Transaction` — visible on any investment account.
- `HoldingProperties` `+ Add Investment Transaction` — visible on non-cash holdings, `security_id` prefilled from the primary bucket security.

Each button: `call.get<>()` the mint route → optimistically insert the shell row into `data.transactions` / `data.investmentTransactions` via `setData` + `indexedDb.save` → `router.go` to the detail page.

**Detail-page editable inputs (the load-bearing piece):**
Both `TransactionProperties` and `InvestmentTransactionProperties` now render inline inputs for the core fields when `source === 'manual'`. Plaid rows keep the read-only `<span>` display (unchanged behavior). Save on blur → POST to the existing `/api/transaction` / `/api/investment-transaction` update route.

- Cash editable: `name`, `amount`, `date`.
- Investment editable: `name`, `date`, `quantity`, `price`, `amount`, `type` (Buy/Sell/… via select), `subtype` (full-subtype coverage via select), `security_id` via ticker input that hooks `POST /api/validate-ticker` on blur.

**Common models:**
- `JSONTransaction.source?` / `JSONInvestmentTransaction.source?` optional string on the type. FE `Transaction` / `InvestmentTransaction` classes default `source = "plaid"` so pre-existing IDB-cached rows migrate cleanly.

## Sync-survival design

- `manual-<uuid>` id prefix (randomUUID from `crypto`) means Plaid can't collide (all Plaid IDs are opaque tokens of a distinct shape).
- Plaid sync already early-returns on `item.provider !== PLAID` for manual items, and deletes are strictly Plaid-returned-id-scoped, so manual rows are safe from Plaid overwrite by construction.
- `source='manual'` is the auditable marker for any future dedupe report.

## reviewoie findings

reviewoie posted 11 findings on the initial commit: https://github.com/hoiekim/budget/pull/588#pullrequestreview-4628982207. Applied in `6d111d7a`:

- **HIGH-1 & HIGH-2 (dead-on-arrival — no editable inputs)** — added inline inputs on both properties components, gated by `source === 'manual'`. Load-bearing fix. `TransactionProperties` gains name/amount/date; `InvestmentTransactionProperties` gains name/date/quantity/price/amount/type/subtype/ticker→security_id.
- **HIGH-3 (unvalidated `security_id`)** — route now calls `getSecurity(security_id)` before insert.
- **MED — Shell missing `source='manual'` in FE constructor** — added to all three shell inserters.
- **MED — Manual investment accounts had no cash-tx affordance** — removed the `type !== Investment` gate on the cash `+` button so a manual brokerage can record cash wires/fees.
- **MED — `+` button on cash holding pages** — added `!isCash` guard.
- **LOW — Dead `security_id` param on `AccountProperties.onClickAddInvestmentTransaction`** — removed.
- **LOW — Dynamic `await import`** — replaced with top-level static imports.
- **LOW — Repo helpers throwing** — switched to `null`-return + `logger.error` + route surfaces a proper `{ status: "failed" }` response.

Deferred to a follow-up refactor:
- **MED — Duplicate mint handler between `AccountProperties` and `HoldingProperties`** — extract into `useManualTransactionMint` hook, next PR.
- **MED — Server-route tests** — landing with next-round claoie work.

## E2E — sandbox verified

Ran against `budget-pr-588` at `:20588` with admin/sandbox creds:

- [x] `bun run typecheck` — clean.
- [x] Cash `+ Add Transaction` on a manual account (`CustomName 50931`): navigates to `/transaction-detail?transaction_id=manual-<uuid>` → name/amount/date inputs render → fill `name="e2e-cash-<ts>"` + `amount="42.50"` + blur → reload → both persist round-trip.
- [x] Investment `+ Add Investment Transaction` on a Plaid brokerage (`CustomName QY6XDv`): navigates to `/transaction-detail?investment_transaction_id=manual-<uuid>` → name/qty/price/type-select render → fill `name="e2e-rsu-grant"` + `qty=100` + `price=50` + blur → reload → all three persist.
- [x] Server: cash-mint on a Plaid account returns `{ status: "failed", message: "Manual transaction entry is only allowed on manual accounts." }`.
- [x] Server: invest-mint with `security_id=garbage-string` refused (route gates on account first; garbage id would 4xx on the security lookup once accounts pass).

Screenshots: `/tmp/e2e-pr588-cash.png`, `/tmp/e2e-pr588-invest.png` (local).

**Not tested** (out of scope for this PR):
- CSV / bulk-paste import.
- Delete affordance for manual rows.
- Sync-round-trip test (Plaid resyncing a manual row's id).

## Follow-up (later PR)

- Full CRUD delete affordance on manual rows.
- Extract `useManualTransactionMint` hook to fold the two duplicate handlers.
- Server-route tests for the two mint endpoints.
- CSV / bulk-paste import for pre-Plaid-window backfill.

Related: budget #567 (manual cash tx UI), budget #585 (manual investment tx UI), PR #587 (inv-tx detail page render — pre-req, already merged).
