### PR TITLE
feat(performance): flag holdings-vs-transactions qty divergence in MWR widget

### DIFF
--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -4,7 +4,9 @@ import {
   call,
   PATH,
   useAppContext,
+  useHoldingDivergence,
   useTransactionEntry,
+  buildPriceAt,
   Data,
   Snapshot,
   Holding,
@@ -277,7 +279,8 @@ export const HoldingProperties = () => {
   };
 
   /**
-   * Prefill `security_id`, `price` (from the holding's
+   * `+ Add Investment Transaction` on the holding — Hoie's ask (#585
+   * design): prefill `security_id`, `price` (from the holding's
    * `institution_price`), and `iso_currency_code` from the holding
    * context so the user starts with values they can confirm/correct
    * rather than 0 / null defaults. When the bucket spans multiple
@@ -295,6 +298,100 @@ export const HoldingProperties = () => {
       security_id: primarySecurityId,
       price: primaryPrice,
       iso_currency_code: primaryCurrency,
+    });
+  };
+
+  // Divergence action: if this holding's security_id has a
+  // holdings-vs-transactions mismatch, offer a one-tap mint prefilled
+  // with the missing units so the user can reconcile without hunting
+  // for the security or typing the qty. Direction A ("holdings > txn")
+  // → a Buy for the missing units. Direction B ("txn > holdings")
+  // suggests a Sell — but this branch only exposes the Buy action
+  // for now because the "holding page" surface is only reached from
+  // holdings the user actually owns.
+  const divergence = useHoldingDivergence(
+    accountId ? [accountId] : [],
+    { holdingSnapshots: data.holdingSnapshots, investmentTransactions: data.investmentTransactions, securitySnapshots: data.securitySnapshots },
+    viewEndDate.toISOString().slice(0, 10),
+  );
+  // Second computation at TODAY — the button's presence tracks the
+  // security's LATEST unreconciled surplus, not just the current view's
+  // window. This lets the user reach the reconcile action from any
+  // past view (Hoie 2026-07-06: "buttons exist in June but not in May
+  // or April"). Reason for the mismatch: divergence at a past view can
+  // fire for a DIFFERENT security than the one the user is inspecting
+  // (widget footnote aggregates across the account), or the current
+  // holding's snapshot history might not extend that far back — either
+  // way the per-viewDate map wouldn't include the security. Using the
+  // today-anchored divergence gates the button on "does this security
+  // still have unreconciled shares", which is a property of the data
+  // rather than the viewDate.
+  const divergenceNow = useHoldingDivergence(
+    accountId ? [accountId] : [],
+    { holdingSnapshots: data.holdingSnapshots, investmentTransactions: data.investmentTransactions, securitySnapshots: data.securitySnapshots },
+    undefined,
+  );
+  const divergentEntry = primarySecurityId
+    ? divergenceNow.bySecurity.get(primarySecurityId)
+    : undefined;
+  // `divergence` (per-viewDate) is retained for a future "you're
+  // looking at a divergent past window" indicator; today it's unused
+  // beyond parity with HoldingsComposition's dot.
+  void divergence;
+  const missingUnits = divergentEntry && divergentEntry.direction === "holdingExcess"
+    ? divergentEntry.deltaQty
+    : 0;
+  // Reconciliation date: the earliest holdings snapshot where the qty
+  // FIRST reached the current owned value — i.e. where the surplus
+  // "arrived". Backdating there clears the divergence at every window
+  // whose end date is at-or-after that point. Naive "earliest snap"
+  // dating fails because `txnDerivedQtyBySecurity` anchors from the
+  // latest snap ≤ windowStart AND excludes txns dated ≤ windowStart
+  // (they'd double-count with the anchor). So a txn dated at the earliest
+  // snap falls BEHIND the anchor for every window whose windowStart is
+  // later than that — including the current 1Y view. Result: seen stays
+  // at the anchor value and divergence still fires. Dating at the
+  // qty-jump point puts the txn STRICTLY BETWEEN the "before" and
+  // "after" anchor eras, so it's in-walk for every window ending at-or-
+  // after the jump. (Hoie 2026-07-06 report: added missing invtx and
+  // warnings didn't clear for any view dates.)
+  const reconcileDate = useMemo(() => {
+    if (!primarySecurityId || !accountId) return undefined;
+    const snaps: { date: string; qty: number }[] = [];
+    data.holdingSnapshots.forEach((snap) => {
+      if (snap.holding.account_id !== accountId) return;
+      if (snap.holding.security_id !== primarySecurityId) return;
+      snaps.push({
+        date: snap.snapshot.date.slice(0, 10),
+        qty: snap.holding.quantity ?? 0,
+      });
+    });
+    if (!snaps.length) return undefined;
+    snaps.sort((a, b) => (a.date < b.date ? -1 : 1));
+    const currentOwned = snaps[snaps.length - 1].qty;
+    // First snapshot where qty >= currentOwned = when the jump completed.
+    // Fall back to the earliest snapshot if no snap reaches that (only
+    // possible on floating-point rounding across the array).
+    const jump = snaps.find((s) => s.qty >= currentOwned - Math.abs(currentOwned) * 1e-6);
+    return jump?.date ?? snaps[0].date;
+  }, [data.holdingSnapshots, accountId, primarySecurityId]);
+  const onClickAddDivergentTransaction = () => {
+    if (!accountId) return;
+    // Price the mint at its own historical date via the shared
+    // `buildPriceAt` helper (security_snapshots close series + txn-
+    // embedded buy/sell prices merged, latest ≤ query date). Falls
+    // back to `primaryPrice` if no history covers the reconcile date.
+    const priceAt = buildPriceAt(data.securitySnapshots, data.investmentTransactions);
+    const pricedAt = primarySecurityId && reconcileDate
+      ? priceAt(primarySecurityId, reconcileDate)
+      : null;
+    return addInvestmentTransaction({
+      account_id: accountId,
+      security_id: primarySecurityId,
+      price: pricedAt ?? primaryPrice,
+      iso_currency_code: primaryCurrency,
+      quantity: missingUnits,
+      date: reconcileDate,
     });
   };
 
@@ -741,6 +838,18 @@ export const HoldingProperties = () => {
                 +&nbsp;Add&nbsp;Investment&nbsp;Transaction
               </button>
             </Row>
+            {missingUnits > 0 && (
+              <Row className="button">
+                <button
+                  type="button"
+                  className="divergenceAction"
+                  onClick={onClickAddDivergentTransaction}
+                >
+                  +&nbsp;Add&nbsp;transaction&nbsp;for&nbsp;
+                  {numberToCommaString(missingUnits, 4)}&nbsp;missing&nbsp;units
+                </button>
+              </Row>
+            )}
           </Property>
         </>
       )}

--- a/src/client/components/HoldingsComposition/index.css
+++ b/src/client/components/HoldingsComposition/index.css
@@ -136,3 +136,17 @@
   background: rgba(255, 255, 255, 0.08);
   color: rgba(255, 255, 255, 0.9);
 }
+
+/* Divergence indicator on holding rows: a small red dot to the left of the
+ * ticker/label when the row's holdings vs transactions disagree. Tap the
+ * row to reach the detail page, which surfaces the per-security action
+ * ("Add transaction for N missing units"). */
+.holdingsTable .divergenceDot {
+  display: inline-block;
+  width: 0.5em;
+  height: 0.5em;
+  border-radius: 50%;
+  background-color: var(--darkRed);
+  margin-right: 0.4em;
+  vertical-align: middle;
+}

--- a/src/client/components/HoldingsComposition/index.tsx
+++ b/src/client/components/HoldingsComposition/index.tsx
@@ -1,6 +1,6 @@
 import { KeyboardEvent, useMemo } from "react";
 import { currencyCodeToSymbol, ItemProvider, numberToCommaString, ViewDate } from "common";
-import { Account, PATH, useAppContext } from "client";
+import { Account, PATH, useAppContext, useHoldingDivergence } from "client";
 import "./index.css";
 
 interface Props {
@@ -28,6 +28,9 @@ interface PerSecurityRow {
 }
 
 interface TickerRow {
+  /** Security_ids contributing to this bucket. Used by the divergence-dot
+   *  overlay (a bucket flags if ANY contributing security is divergent). */
+  contributingSecurityIds: string[];
   /** Aggregation key: real `ticker_symbol` when present (case-folded upper),
    *  otherwise `CASH_TICKER` for `isCash` rows, otherwise the truncated
    *  security_id. URL param for the detail page click target. */
@@ -59,7 +62,7 @@ export const HoldingsComposition = ({ accounts }: Props) => {
 
   const { calculations, router, viewDate, data } = useAppContext();
   const { holdingsValueData, balanceData } = calculations;
-  const { items, securitySnapshots } = data;
+  const { items, securitySnapshots, holdingSnapshots, investmentTransactions } = data;
 
   // "Add Holding" and manual-account visibility only apply when a single
   // manual account is shown; multi-account aggregation has no single target.
@@ -71,6 +74,19 @@ export const HoldingsComposition = ({ accounts }: Props) => {
   const viewEndDate = viewDate.getEndDate();
   const latestViewDate = new ViewDate(viewDate.getInterval());
   const isCurrentViewDate = viewEndDate >= latestViewDate.getEndDate();
+
+  // Holdings-vs-transactions divergence per security_id — mirrors the
+  // detection that drives the PerformanceBenchmark widget's footnote so
+  // the same set of securities are flagged in both surfaces. Pinned to
+  // `viewEndDate` so a red dot appears (or disappears) for the same
+  // window the widget is looking at — running at `today` here while the
+  // widget runs at the user-selected past month caused the "widget says
+  // check the red flag / there's no red flag" mismatch (Hoie 2026-07-06).
+  const divergence = useHoldingDivergence(
+    accounts.map((a) => a.account_id),
+    { holdingSnapshots, investmentTransactions, securitySnapshots },
+    viewEndDate.toISOString().slice(0, 10),
+  );
 
   // First pass: one row per (account, security) at the current viewDate —
   // the calculation hook's per-holding summary. Same shape as before; the
@@ -142,6 +158,9 @@ export const HoldingsComposition = ({ accounts }: Props) => {
       name: string | null;
       ticker: string | null;
       securityId: string;
+      /** All security_ids that landed in this bucket — the divergence-dot
+       *  overlay checks each against the divergence map. */
+      contributingSecurityIds: Set<string>;
     }
     const buckets = new Map<string, Acc>();
 
@@ -169,6 +188,7 @@ export const HoldingsComposition = ({ accounts }: Props) => {
           name: row.name,
           ticker: row.ticker,
           securityId: row.securityId,
+          contributingSecurityIds: new Set([row.securityId]),
         });
       } else {
         existing.quantity += row.quantity;
@@ -184,6 +204,7 @@ export const HoldingsComposition = ({ accounts }: Props) => {
         existing.costBasisInferred = existing.costBasisInferred || row.costBasisInferred;
         if (!existing.name && row.name) existing.name = row.name;
         if (!existing.ticker && row.ticker) existing.ticker = row.ticker;
+        existing.contributingSecurityIds.add(row.securityId);
       }
     });
 
@@ -205,6 +226,7 @@ export const HoldingsComposition = ({ accounts }: Props) => {
         costBasisInferred: b.costBasisInferred,
         isCash: b.isCash,
         clickable: true,
+        contributingSecurityIds: Array.from(b.contributingSecurityIds),
       };
     });
   }, [perSecurityRows]);
@@ -307,6 +329,16 @@ export const HoldingsComposition = ({ accounts }: Props) => {
             >
               <span className="col-name">
                 <span className="security-name" title={row.titleLabel}>
+                  {/* Red dot when ANY of the securities aggregated into
+                      this ticker bucket has a holdings-vs-transactions
+                      divergence flagged. Click through opens the holding
+                      detail page, which surfaces per-security actions. */}
+                  {row.contributingSecurityIds.some((sid) => divergence.bySecurity.has(sid)) && (
+                    <span
+                      className="divergenceDot"
+                      aria-label="Holdings and transactions don't match — see detail page"
+                    />
+                  )}
                   {row.primaryLabel}
                 </span>
                 {row.secondaryLabel && (

--- a/src/client/components/PerformanceBenchmark/index.css
+++ b/src/client/components/PerformanceBenchmark/index.css
@@ -106,3 +106,8 @@
   font-style: italic;
   margin-top: 0.3em;
 }
+
+.performanceDivergence {
+  color: #fbbf24;
+  cursor: help;
+}

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -17,6 +17,7 @@ import {
   computeBenchmarkTWR,
   computeBenchmarkEndValue,
   valueAt,
+  computeQtyDivergence,
   buildPriceAt,
   buildSnapshotPriceAt,
   buildBenchmarkPriceAt,
@@ -188,6 +189,37 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
     const gapDollars =
       mwrGain !== null && benchmarkGain !== null ? mwrGain - benchmarkGain : null;
 
+    // Holdings-vs-transactions reconciliation: shares the user owns per the
+    // latest holdings snapshot but that the txn stream can't explain are
+    // excluded from valueAt/the MWR (the phantom-holding guard). Surface the
+    // count so a low/odd return on an incomplete-txn account is explained
+    // rather than silently reported off a partial position.
+    let divergentSecurityCount = 0;
+    let excludedValue = 0;
+    let txnExcessSecurityCount = 0;
+    let txnExcessValue = 0;
+    const divergentSecurities: { security_id: string; deltaQty: number; deltaValue: number }[] = [];
+    const txnExcessSecurities: { security_id: string; deltaQty: number; deltaValue: number }[] = [];
+    for (const id of ids) {
+      const d = computeQtyDivergence({
+        date: windowEnd,
+        windowStart,
+        accountId: id,
+        holdingSnapshots,
+        investmentTransactions,
+        priceAt,
+      });
+      divergentSecurityCount += d.divergentSecurityCount;
+      excludedValue += d.excludedValue;
+      txnExcessSecurityCount += d.txnExcessSecurityCount;
+      txnExcessValue += d.txnExcessValue;
+      divergentSecurities.push(...d.divergentSecurities);
+      txnExcessSecurities.push(...d.txnExcessSecurities);
+    }
+    // Aggregate re-sort in case multiple accounts contributed.
+    divergentSecurities.sort((a, b) => b.deltaValue - a.deltaValue);
+    txnExcessSecurities.sort((a, b) => b.deltaValue - a.deltaValue);
+
     return {
       windowStart,
       windowEnd,
@@ -204,6 +236,12 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
       gapDollars,
       suppressAnnualized,
       isClamped,
+      divergentSecurityCount,
+      excludedValue,
+      divergentSecurities,
+      txnExcessSecurityCount,
+      txnExcessValue,
+      txnExcessSecurities,
     };
   }, [
     accountIdsKey,
@@ -271,6 +309,8 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
     gapDollars,
     suppressAnnualized,
     isClamped,
+    divergentSecurityCount,
+    txnExcessSecurityCount,
   } = computed;
 
   // Every value cell renders the same shape: a "total" line on top and, if
@@ -386,6 +426,25 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
           Showing {windowStart} → {windowEnd} · asset positions only (cash excluded)
           {isClamped && " · clamped to earliest data"}
           {suppressAnnualized && " · annualized hidden (window <6mo)"}
+          {/* Aggregate flag only — per-security detail lives on the
+              HoldingsComposition table (red dot on affected rows) and
+              the holding detail page's "Add transaction for N missing
+              units" button. No tooltip; mobile-first, hover doesn't
+              exist on touch. Hoie 2026-07-06. */}
+          {divergentSecurityCount > 0 && (
+            <span className="performanceDivergence">
+              {` · ${divergentSecurityCount} holding${
+                divergentSecurityCount > 1 ? "s" : ""
+              } excluded from return — see the red-flagged rows above`}
+            </span>
+          )}
+          {txnExcessSecurityCount > 0 && (
+            <span className="performanceDivergence">
+              {` · ${txnExcessSecurityCount} securit${
+                txnExcessSecurityCount > 1 ? "ies" : "y"
+              } in transactions but not holdings`}
+            </span>
+          )}
         </div>
       </div>
     </>

--- a/src/client/lib/hooks/calculation/benchmark.test.ts
+++ b/src/client/lib/hooks/calculation/benchmark.test.ts
@@ -9,6 +9,7 @@ import {
   computeBenchmarkTWR,
   computeBenchmarkEndValue,
   valueAt,
+  computeQtyDivergence,
   buildPriceAt,
   priceAtIn,
   buildBenchmarkPriceAt,
@@ -587,6 +588,342 @@ describe("valueAt (asset-only, txn-derived qty)", () => {
     const ss = new SecuritySnapshotDictionary();
     const priceAt = buildPriceAt(ss, itxns);
     expect(priceAt(VOO, "2024-06-01")).toBeNull();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+describe("computeQtyDivergence (holdings-vs-transactions reconciliation)", () => {
+  test("flags a holding whose snapshot qty exceeds the txn-derived qty", () => {
+    // Mirrors the valueAt phantom-holding case: 10 anchor + 5 buys = 15 seen,
+    // latest snapshot shows 100 → 85 surplus shares excluded from the MWR.
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
+    hs.set("h2", mkHoldingSnap(VOO, 100, 600, 60000, "2026-06-01")); // phantom +90
+    const itxns = new InvestmentTransactionDictionary();
+    ["2026-02-10", "2026-03-10", "2026-04-10", "2026-05-10", "2026-05-25"].forEach((date, i) => {
+      itxns.set(`t${i}`, mkTxn({ date, type: InvestmentTransactionType.Buy, security_id: VOO, amount: 600, quantity: 1 }));
+    });
+    const ss = new SecuritySnapshotDictionary();
+    const priceAt = buildPriceAt(ss, itxns);
+
+    const d = computeQtyDivergence({
+      date: "2026-06-01",
+      windowStart: "2026-01-01",
+      accountId: ACCT,
+      holdingSnapshots: hs,
+      investmentTransactions: itxns,
+      priceAt,
+    });
+    expect(d.divergentSecurityCount).toBe(1);
+    expect(d.excludedValue).toBe(85 * 600); // (100 owned − 15 seen) × $600
+  });
+
+  test("no divergence when holdings and transactions agree", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
+    hs.set("h2", mkHoldingSnap(VOO, 15, 600, 9000, "2026-06-01")); // matches 10 + 5 buys
+    const itxns = new InvestmentTransactionDictionary();
+    ["2026-02-10", "2026-03-10", "2026-04-10", "2026-05-10", "2026-05-25"].forEach((date, i) => {
+      itxns.set(`t${i}`, mkTxn({ date, type: InvestmentTransactionType.Buy, security_id: VOO, amount: 600, quantity: 1 }));
+    });
+    const priceAt = buildPriceAt(new SecuritySnapshotDictionary(), itxns);
+    const d = computeQtyDivergence({
+      date: "2026-06-01",
+      windowStart: "2026-01-01",
+      accountId: ACCT,
+      holdingSnapshots: hs,
+      investmentTransactions: itxns,
+      priceAt,
+    });
+    expect(d.divergentSecurityCount).toBe(0);
+    expect(d.excludedValue).toBe(0);
+  });
+
+  test("ignores sub-0.1%-of-owned drift (fractional-share reinvestment noise)", () => {
+    const hs = new HoldingSnapshotDictionary();
+    // Owned 1000.5, txns explain 1000 → 0.5 surplus is <0.1% of 1000.5 → ignored.
+    hs.set("h1", mkHoldingSnap(VOO, 1000, 500, 500000, "2026-01-01"));
+    hs.set("h2", mkHoldingSnap(VOO, 1000.5, 600, 600300, "2026-06-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    const priceAt = buildPriceAt(new SecuritySnapshotDictionary(), itxns);
+    const d = computeQtyDivergence({
+      date: "2026-06-01",
+      windowStart: "2026-01-01",
+      accountId: ACCT,
+      holdingSnapshots: hs,
+      investmentTransactions: itxns,
+      priceAt,
+    });
+    expect(d.divergentSecurityCount).toBe(0);
+  });
+
+  test("does not flag the reverse case (txns exceed the snapshot qty)", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(VOO, 10, 500, 5000, "2026-01-01"));
+    // Snapshot at end shows 8 (a sale not yet reflected? still — no under-count).
+    hs.set("h2", mkHoldingSnap(VOO, 8, 600, 4800, "2026-06-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    ["2026-02-10", "2026-03-10"].forEach((date, i) => {
+      itxns.set(`t${i}`, mkTxn({ date, type: InvestmentTransactionType.Buy, security_id: VOO, amount: 600, quantity: 1 }));
+    });
+    const priceAt = buildPriceAt(new SecuritySnapshotDictionary(), itxns);
+    const d = computeQtyDivergence({
+      date: "2026-06-01",
+      windowStart: "2026-01-01",
+      accountId: ACCT,
+      holdingSnapshots: hs,
+      investmentTransactions: itxns,
+      priceAt,
+    });
+    expect(d.divergentSecurityCount).toBe(0); // owned 8 < seen 12, no exclusion
+  });
+
+  test("clamps the txn baseline at 0 when the walk goes net-short (matches valueAt)", () => {
+    // Anchor 5 shares, then 8 shares sold within window → txn-derived qty
+    // walks to −3. valueAt contributes 0 for this security (its qty<=0
+    // guard), so it excludes the full owned position (10), not 10−(−3)=13.
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(VOO, 5, 500, 2500, "2026-01-01"));
+    hs.set("h2", mkHoldingSnap(VOO, 10, 600, 6000, "2026-06-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("s1", mkTxn({ date: "2026-03-01", type: InvestmentTransactionType.Sell, security_id: VOO, amount: 4800, quantity: 8, price: 600 } as Parameters<typeof mkTxn>[0]));
+    const priceAt = buildPriceAt(new SecuritySnapshotDictionary(), itxns);
+    const d = computeQtyDivergence({
+      date: "2026-06-01",
+      windowStart: "2026-01-01",
+      accountId: ACCT,
+      holdingSnapshots: hs,
+      investmentTransactions: itxns,
+      priceAt,
+    });
+    expect(d.divergentSecurityCount).toBe(1);
+    expect(d.excludedValue).toBe(10 * 600); // owned − max(0, −3) = 10, NOT 13
+  });
+
+  test("excludes cash-shape holdings from the reconciliation", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(CASH, 5000, 1, null, "2026-06-01")); // cash-shape
+    const itxns = new InvestmentTransactionDictionary();
+    const priceAt = buildPriceAt(new SecuritySnapshotDictionary(), itxns);
+    const d = computeQtyDivergence({
+      date: "2026-06-01",
+      windowStart: "2026-01-01",
+      accountId: ACCT,
+      holdingSnapshots: hs,
+      investmentTransactions: itxns,
+      priceAt,
+    });
+    expect(d.divergentSecurityCount).toBe(0);
+  });
+
+  test("counts excluded value as 0 when no price is available for the surplus", () => {
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(VOO, 100, 600, 60000, "2026-06-01"));
+    // No txns for VOO → seen qty 0, surplus 100, but priceAt returns null.
+    const itxns = new InvestmentTransactionDictionary();
+    const priceAt = buildPriceAt(new SecuritySnapshotDictionary(), itxns);
+    const d = computeQtyDivergence({
+      date: "2026-06-01",
+      windowStart: "2026-01-01",
+      accountId: ACCT,
+      holdingSnapshots: hs,
+      investmentTransactions: itxns,
+      priceAt,
+    });
+    expect(d.divergentSecurityCount).toBe(1);
+    expect(d.excludedValue).toBe(0); // flagged, but no price to value the surplus
+  });
+
+  // ── Direction B: txn-explained > holdings snapshot (transactions ahead) ──
+  // Covers gap 1 of #593: user records a manual invtx for a security not in
+  // any holdings snapshot, OR a sale txn arrives before the snapshot reflects
+  // the smaller position.
+
+  test("txnExcess: manual invtx for a security with no matching holdings row", () => {
+    // Manual mint scenario: user posts /api/new-investment-transaction on a
+    // Plaid brokerage for a security that Plaid never tracks (or hasn't yet).
+    // No holdings snapshot exists for (ACCT, VOO), but a Buy txn does.
+    // Expected: flagged under txnExcess so the widget can surface the gap.
+    const hs = new HoldingSnapshotDictionary(); // empty — no holdings for VOO
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("t1", mkTxn({
+      date: "2026-03-10",
+      type: InvestmentTransactionType.Buy,
+      security_id: VOO,
+      amount: 600,
+      quantity: 5,
+      price: 120,
+    } as Parameters<typeof mkTxn>[0]));
+    const priceAt = buildPriceAt(new SecuritySnapshotDictionary(), itxns);
+
+    const d = computeQtyDivergence({
+      date: "2026-06-01",
+      windowStart: "2026-01-01",
+      accountId: ACCT,
+      holdingSnapshots: hs,
+      investmentTransactions: itxns,
+      priceAt,
+    });
+    expect(d.txnExcessSecurityCount).toBe(1);
+    // 5 shares × $120 (priceAt's fallback to the txn's own price when no
+    // snapshot chain exists).
+    expect(d.txnExcessValue).toBe(5 * 120);
+    // Direction A untouched.
+    expect(d.divergentSecurityCount).toBe(0);
+    expect(d.excludedValue).toBe(0);
+  });
+
+  test("txnExcess: sale txn arrives before the snapshot reflects the smaller position", () => {
+    // Reverse Plaid-lag: txn stream shows a Sell that hasn't rolled into
+    // the holdings snapshot yet — snapshot still shows the pre-sale qty.
+    // Here: anchor 20, txn Sell of 12 → seen=8, but snapshot at date shows
+    // still 20. That is a HOLDINGS-EXCESS (direction A) case, not B. Include
+    // this test only to pin that we DON'T double-count under direction B.
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(VOO, 20, 500, 10000, "2026-01-01"));
+    hs.set("h2", mkHoldingSnap(VOO, 20, 600, 12000, "2026-06-01")); // still 20
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("s1", mkTxn({
+      date: "2026-03-01",
+      type: InvestmentTransactionType.Sell,
+      security_id: VOO,
+      amount: 7200,
+      quantity: 12,
+      price: 600,
+    } as Parameters<typeof mkTxn>[0]));
+    const priceAt = buildPriceAt(new SecuritySnapshotDictionary(), itxns);
+
+    const d = computeQtyDivergence({
+      date: "2026-06-01",
+      windowStart: "2026-01-01",
+      accountId: ACCT,
+      holdingSnapshots: hs,
+      investmentTransactions: itxns,
+      priceAt,
+    });
+    // Direction A: 20 owned − 8 seen = 12 surplus → flagged.
+    expect(d.divergentSecurityCount).toBe(1);
+    expect(d.excludedValue).toBe(12 * 600);
+    // Direction B: seen (8) < owned (20) → NOT txn-excess. No double count.
+    expect(d.txnExcessSecurityCount).toBe(0);
+    expect(d.txnExcessValue).toBe(0);
+  });
+
+  test("txnExcess: no flag when txn-derived qty is 0 or negative (walked-net-short)", () => {
+    // If the txn walk goes ≤ 0, there's no "held" position to flag —
+    // symmetric with direction A's clamp.
+    const hs = new HoldingSnapshotDictionary(); // no holdings
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("s1", mkTxn({
+      date: "2026-03-01",
+      type: InvestmentTransactionType.Sell,
+      security_id: VOO,
+      amount: 600,
+      quantity: 1,
+      price: 600,
+    } as Parameters<typeof mkTxn>[0]));
+    const priceAt = buildPriceAt(new SecuritySnapshotDictionary(), itxns);
+
+    const d = computeQtyDivergence({
+      date: "2026-06-01",
+      windowStart: "2026-01-01",
+      accountId: ACCT,
+      holdingSnapshots: hs,
+      investmentTransactions: itxns,
+      priceAt,
+    });
+    expect(d.txnExcessSecurityCount).toBe(0);
+    expect(d.txnExcessValue).toBe(0);
+  });
+
+  test("txnExcess: sub-0.1% drift is ignored (fractional-share reinvestment)", () => {
+    // seen=1000.5, owned=1000 → excess 0.5 which is 0.05% of seen. Below
+    // the 0.1%-of-seen threshold. Should NOT flag.
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(VOO, 1000, 500, 500000, "2026-01-01"));
+    hs.set("h2", mkHoldingSnap(VOO, 1000, 600, 600000, "2026-06-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    // A tiny reinvestment buy of 0.5 that pushes seen to 1000.5.
+    itxns.set("t1", mkTxn({
+      date: "2026-03-10",
+      type: InvestmentTransactionType.Buy,
+      security_id: VOO,
+      amount: 300,
+      quantity: 0.5,
+      price: 600,
+    } as Parameters<typeof mkTxn>[0]));
+    const priceAt = buildPriceAt(new SecuritySnapshotDictionary(), itxns);
+
+    const d = computeQtyDivergence({
+      date: "2026-06-01",
+      windowStart: "2026-01-01",
+      accountId: ACCT,
+      holdingSnapshots: hs,
+      investmentTransactions: itxns,
+      priceAt,
+    });
+    // Neither direction flags — direction A is 0 excess, direction B is
+    // below threshold.
+    expect(d.divergentSecurityCount).toBe(0);
+    expect(d.txnExcessSecurityCount).toBe(0);
+  });
+
+  test("txnExcess: cash-shape holdings excluded from the reconciliation", () => {
+    // Symmetric with the direction-A cash-exclusion test — a manual invtx
+    // for a cash-shape security shouldn't flag under direction B either.
+    const hs = new HoldingSnapshotDictionary();
+    hs.set("h1", mkHoldingSnap(CASH, 5000, 1, null, "2026-06-01"));
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("t1", mkTxn({
+      date: "2026-03-10",
+      type: InvestmentTransactionType.Buy,
+      security_id: CASH,
+      amount: 500,
+      quantity: 500,
+      price: 1,
+    } as Parameters<typeof mkTxn>[0]));
+    const priceAt = buildPriceAt(new SecuritySnapshotDictionary(), itxns);
+
+    const d = computeQtyDivergence({
+      date: "2026-06-01",
+      windowStart: "2026-01-01",
+      accountId: ACCT,
+      holdingSnapshots: hs,
+      investmentTransactions: itxns,
+      priceAt,
+    });
+    expect(d.txnExcessSecurityCount).toBe(0);
+    expect(d.txnExcessValue).toBe(0);
+  });
+
+  test("txnExcess: valued at 0 when no price is available for the excess", () => {
+    // Symmetric with direction A's no-price case — flagged but 0 value.
+    const hs = new HoldingSnapshotDictionary(); // no holdings
+    const itxns = new InvestmentTransactionDictionary();
+    itxns.set("t1", mkTxn({
+      // Non-cash security with a buy but no price info anywhere.
+      date: "2026-03-10",
+      type: InvestmentTransactionType.Buy,
+      security_id: "sec-untracked",
+      amount: 100,
+      quantity: 5,
+    }));
+    // priceAt built without any snapshot for sec-untracked and with a txn
+    // whose price we may not preserve → check that valueless flag path works.
+    const priceAt = buildPriceAt(new SecuritySnapshotDictionary(), itxns);
+
+    const d = computeQtyDivergence({
+      date: "2026-06-01",
+      windowStart: "2026-01-01",
+      accountId: ACCT,
+      holdingSnapshots: hs,
+      investmentTransactions: itxns,
+      priceAt,
+    });
+    // Still flagged even without a price.
+    expect(d.txnExcessSecurityCount).toBe(1);
+    // Note: `buildPriceAt` falls back to the txn's amount/quantity when
+    // no snapshot exists, so value may not be 0 — assert flag only.
   });
 });
 

--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -256,12 +256,12 @@ export const computeBenchmarkEndValue = (params: {
 };
 
 /**
- * Non-cash asset value at a given date: Σ(non_cash_security_id) qty(t) × price(t).
+ * Txn-derived quantity per security at `date`, windowStart-anchored. Shared
+ * by `valueAt` (asset valuation) and `computeQtyDivergence` (the
+ * holdings-vs-transactions reconciliation surface) so both see the identical
+ * qty walk.
  *
- * Cash-shape holdings (per `isCashShapeHolding`) are excluded — the
- * widget's scope is the asset portfolio, not the total account.
- *
- * **`qty(t)` is txn-derived.** For each non-cash security:
+ * **`qty(t)` is txn-derived.** For each security:
  *   qty(t) = qty_from_holding_snapshot_at_windowStart
  *          + Σ(buy.quantity − sell.quantity from txns in (windowStart, t])
  *
@@ -274,29 +274,21 @@ export const computeBenchmarkEndValue = (params: {
  *
  * `windowStart` anchors pre-window history we can't reconstruct from txns
  * (the user may have years of holdings predating the snapshot history we
- * have). For `t = windowStart`, this collapses to "holding snapshot qty"
- * which is what we want for V_start.
+ * have). For `t = windowStart`, this collapses to "holding snapshot qty".
  *
- * Returns 0 when no non-cash holding snapshots have been recorded yet.
+ * The returned map may contain cash-shape securities (from the step-1
+ * anchor); callers filter them via `cashSecs`.
  */
-export const valueAt = (params: {
+const txnDerivedQtyBySecurity = (params: {
   date: string;
   windowStart: string;
   accountId: string;
   holdingSnapshots: HoldingSnapshotDictionary;
   investmentTransactions: InvestmentTransactionDictionary;
-  priceAt: (securityId: string, date: string) => number | null;
-}): number => {
-  const { date, windowStart, accountId, holdingSnapshots, investmentTransactions, priceAt } = params;
+  cashSecs: Set<string>;
+}): Map<string, number> => {
+  const { date, windowStart, accountId, holdingSnapshots, investmentTransactions, cashSecs } = params;
 
-  const cashSecs = cashSecurityIdsForAccount(holdingSnapshots, accountId);
-
-  // qty per security at `date` = Σ(buy.quantity − sell.quantity) over all
-  // txns at-or-before `date` (windowStart-inclusive). Anchor is implicit:
-  // for users with no pre-windowStart txns and no pre-windowStart holding
-  // snapshot, this collapses to "all positions came from observed buys."
-  // The phantom-holding guard from before is preserved: any holding qty in
-  // `holding_snapshots` that exceeds what txns can explain is invisible.
   const qtyBySec = new Map<string, number>();
 
   // 1) Pre-window holdings anchor: take the latest snapshot ≤ windowStart
@@ -346,6 +338,39 @@ export const valueAt = (params: {
     qtyBySec.set(t.security_id, (qtyBySec.get(t.security_id) ?? 0) + signed);
   });
 
+  return qtyBySec;
+};
+
+/**
+ * Non-cash asset value at a given date: Σ(non_cash_security_id) qty(t) × price(t).
+ *
+ * Cash-shape holdings (per `isCashShapeHolding`) are excluded — the
+ * widget's scope is the asset portfolio, not the total account. `qty(t)` is
+ * the txn-derived walk from `txnDerivedQtyBySecurity` (see its docstring for
+ * the phantom-holding guard).
+ *
+ * Returns 0 when no non-cash holding snapshots have been recorded yet.
+ */
+export const valueAt = (params: {
+  date: string;
+  windowStart: string;
+  accountId: string;
+  holdingSnapshots: HoldingSnapshotDictionary;
+  investmentTransactions: InvestmentTransactionDictionary;
+  priceAt: (securityId: string, date: string) => number | null;
+}): number => {
+  const { date, windowStart, accountId, holdingSnapshots, investmentTransactions, priceAt } = params;
+
+  const cashSecs = cashSecurityIdsForAccount(holdingSnapshots, accountId);
+  const qtyBySec = txnDerivedQtyBySecurity({
+    date,
+    windowStart,
+    accountId,
+    holdingSnapshots,
+    investmentTransactions,
+    cashSecs,
+  });
+
   let total = 0;
   qtyBySec.forEach((qty, sid) => {
     if (cashSecs.has(sid)) return;
@@ -355,6 +380,155 @@ export const valueAt = (params: {
     total += qty * price;
   });
   return total;
+};
+
+/**
+ * Holdings-vs-transactions reconciliation for the account, evaluated at
+ * `date`. Flags the non-cash securities whose latest holdings snapshot
+ * (what the user actually owns per Plaid's holdings stream) shows more
+ * shares than the transaction stream can explain (`txnDerivedQtyBySecurity`).
+ *
+ * Those surplus shares are *invisible* to `valueAt`/the MWR — the widget
+ * intentionally values only the txn-explained position (the phantom-holding
+ * guard that prevents IRR inflation). The trade-off is that on accounts
+ * whose Plaid txn stream is genuinely incomplete, the MWR is computed on
+ * fewer shares than the user holds, understating the return. This surface
+ * lets the widget tell the user *why* — rather than silently reporting a
+ * number off the full position. Self-heals once the matching buy txns land.
+ *
+ * Sub-0.1%-of-owned drift is ignored so fractional-share rounding (dividend
+ * reinvestment) doesn't produce false flags.
+ */
+/** One divergent security, in either direction. Per-security detail lets
+ *  the tooltip surface which ticker + how much rather than an aggregate. */
+export interface DivergentEntry {
+  security_id: string;
+  /** Absolute qty delta (positive on both sides — direction is the map key). */
+  deltaQty: number;
+  /** deltaQty × priceAt (0 when no price is available). */
+  deltaValue: number;
+}
+
+export interface QtyDivergence {
+  // ── Direction A: holdings snapshot > txn-explained (Plaid holdings ahead).
+  // "Shares you own that transactions can't explain yet — the MWR excludes
+  // them until matching buy txns land."
+  /** # of non-cash securities the user owns more of than txns explain. */
+  divergentSecurityCount: number;
+  /** Est. market value of the excluded surplus shares at `date`. The MWR
+   *  values the position MINUS this amount. */
+  excludedValue: number;
+  /** Per-security detail sorted by `deltaValue` desc so the tooltip lists
+   *  the load-bearing ones first. */
+  divergentSecurities: DivergentEntry[];
+
+  // ── Direction B: txn-explained > holdings snapshot (transactions ahead).
+  // Covers (i) the manual-mint case (invtx recorded for a security with no
+  // matching holdings row) and (ii) the Plaid-lag reverse case (a sale txn
+  // arrived but the snapshot still shows the pre-sale qty). Symmetric shape
+  // with direction A; sub-0.1% ignore threshold shared. See #593 gap 1.
+  /** # of non-cash securities the txn stream records but that the latest
+   *  holdings snapshot doesn't reflect at full qty (or at all). */
+  txnExcessSecurityCount: number;
+  /** Est. value of the transactions-only shares at `date` (using the same
+   *  `priceAt` fallback used for direction A). */
+  txnExcessValue: number;
+  /** Per-security detail sorted by `deltaValue` desc. */
+  txnExcessSecurities: DivergentEntry[];
+}
+
+export const computeQtyDivergence = (params: {
+  date: string;
+  windowStart: string;
+  accountId: string;
+  holdingSnapshots: HoldingSnapshotDictionary;
+  investmentTransactions: InvestmentTransactionDictionary;
+  priceAt: (securityId: string, date: string) => number | null;
+}): QtyDivergence => {
+  const { date, windowStart, accountId, holdingSnapshots, investmentTransactions, priceAt } = params;
+
+  const cashSecs = cashSecurityIdsForAccount(holdingSnapshots, accountId);
+  const seenQty = txnDerivedQtyBySecurity({
+    date,
+    windowStart,
+    accountId,
+    holdingSnapshots,
+    investmentTransactions,
+    cashSecs,
+  });
+
+  // Latest holdings-snapshot qty at-or-before `date` per non-cash security —
+  // the shares the user actually owns per Plaid's holdings stream.
+  const ownedQty = new Map<string, number>();
+  const ownedDate = new Map<string, string>();
+  holdingSnapshots.forEach((snap) => {
+    if (snap.holding.account_id !== accountId) return;
+    const sid = snap.holding.security_id;
+    if (cashSecs.has(sid)) return;
+    const snapDate = snap.snapshot.date.slice(0, 10);
+    if (snapDate > date) return;
+    const cur = ownedDate.get(sid);
+    if (!cur || snapDate > cur) {
+      ownedDate.set(sid, snapDate);
+      ownedQty.set(sid, snap.holding.quantity ?? 0);
+    }
+  });
+
+  let divergentSecurityCount = 0;
+  let excludedValue = 0;
+  const divergentSecurities: DivergentEntry[] = [];
+  ownedQty.forEach((owned, sid) => {
+    // Clamp the txn-derived baseline at 0 to mirror valueAt's `qty <= 0`
+    // guard: valueAt contributes 0 (not a negative value) for a security
+    // whose walk went net-short, so the shares it actually *excludes* are
+    // `owned − max(0, seen)`, not `owned − seen`.
+    const surplus = owned - Math.max(0, seenQty.get(sid) ?? 0);
+    // Ignore sub-0.1%-of-owned drift (fractional-share reinvestment noise).
+    if (surplus <= 0 || surplus <= Math.abs(owned) * 1e-3) return;
+    divergentSecurityCount += 1;
+    const price = priceAt(sid, date);
+    const deltaValue = price !== null ? surplus * price : 0;
+    excludedValue += deltaValue;
+    divergentSecurities.push({ security_id: sid, deltaQty: surplus, deltaValue });
+  });
+  divergentSecurities.sort((a, b) => b.deltaValue - a.deltaValue);
+
+  // Direction B: txn-explained > holdings snapshot. Walk the seen (txn)
+  // qty map and check each non-cash security against the owned map. A
+  // security appears here when either (i) the txn stream records positive
+  // qty AND the holdings snapshot for the same `(account_id, security_id)`
+  // is missing entirely — the manual-mint case: user recorded a buy but no
+  // holding was ever created; OR (ii) the txn qty > the snapshot qty at
+  // `date` — a Plaid-lag reverse case (sale txn arrived, snapshot still
+  // pre-sale). The ignore threshold is 0.1% of `seen` — symmetric with
+  // direction A's `Math.abs(owned) * 1e-3`.
+  let txnExcessSecurityCount = 0;
+  let txnExcessValue = 0;
+  const txnExcessSecurities: DivergentEntry[] = [];
+  seenQty.forEach((seen, sid) => {
+    if (cashSecs.has(sid)) return;
+    // Only positive-qty holdings are meaningful — a walked-net-short
+    // security isn't "held" from either side's view.
+    if (seen <= 0) return;
+    const owned = ownedQty.get(sid) ?? 0;
+    const excess = seen - owned;
+    if (excess <= 0 || excess <= Math.abs(seen) * 1e-3) return;
+    txnExcessSecurityCount += 1;
+    const price = priceAt(sid, date);
+    const deltaValue = price !== null ? excess * price : 0;
+    txnExcessValue += deltaValue;
+    txnExcessSecurities.push({ security_id: sid, deltaQty: excess, deltaValue });
+  });
+  txnExcessSecurities.sort((a, b) => b.deltaValue - a.deltaValue);
+
+  return {
+    divergentSecurityCount,
+    excludedValue,
+    divergentSecurities,
+    txnExcessSecurityCount,
+    txnExcessValue,
+    txnExcessSecurities,
+  };
 };
 
 /**

--- a/src/client/lib/hooks/calculation/divergence.ts
+++ b/src/client/lib/hooks/calculation/divergence.ts
@@ -1,0 +1,146 @@
+import { useMemo } from "react";
+import {
+  HoldingSnapshotDictionary,
+  InvestmentTransactionDictionary,
+  SecuritySnapshotDictionary,
+} from "../../models/Data";
+import {
+  buildPriceAt,
+  computeQtyDivergence,
+  earliestDataDate,
+  type DivergentEntry,
+} from "./benchmark";
+
+/**
+ * Shared computation surface for the holdings-vs-transactions divergence.
+ * Consumed by `PerformanceBenchmark` (aggregate footnote), by
+ * `HoldingsComposition` (red-dot on affected rows), and by
+ * `HoldingProperties` ("Add transaction for N missing units" action on the
+ * holding detail page). Kept out of the benchmark widget's local memo so
+ * the three consumers stay in lockstep — same window, same detection, no
+ * drift between what the widget flags and what the row / button surface.
+ *
+ * Returns per-security detail keyed by `security_id`, with direction
+ * ("holdingExcess" = MWR-excluded surplus / "txnExcess" = transactions
+ * ahead of the snapshot) so consumers can pick which action fits the row.
+ */
+export type DivergenceDirection = "holdingExcess" | "txnExcess";
+
+export interface DivergenceEntry extends DivergentEntry {
+  direction: DivergenceDirection;
+  /** The account this divergence lives on — needed when the caller
+   *  aggregates across multiple accounts (e.g. `AccountsDetailPage` with
+   *  a combined performance widget). */
+  account_id: string;
+}
+
+export interface DivergenceMap {
+  /** Keyed by `security_id`. When the same security shows divergence on
+   *  more than one account, the entries collapse by summing `deltaQty`
+   *  and `deltaValue` — the FE surfaces don't distinguish the source
+   *  account for the flag, but the underlying account_id list is
+   *  preserved on `.accountIds`. */
+  bySecurity: Map<
+    string,
+    {
+      direction: DivergenceDirection;
+      deltaQty: number;
+      deltaValue: number;
+      accountIds: string[];
+    }
+  >;
+  /** Full ordered list (sorted by `deltaValue` desc) for the summary
+   *  surfaces (widget footnote). */
+  entries: DivergenceEntry[];
+}
+
+/**
+ * `viewEndDate` (YYYY-MM-DD) pins the detection to the same window
+ * boundary the `PerformanceBenchmark` widget is showing. Both surfaces
+ * MUST use the same date — otherwise the widget footnote flags an
+ * excluded holding while the composition table's red dot has already
+ * evaluated at today, cleared it, and shows nothing (Hoie 2026-07-06:
+ * "the yellow warning says check red flag above and there's no red flag
+ * in holdings composition table"). Callers pass
+ * `viewDate.getEndDate()` / `LocalDate` toString. Defaults to today
+ * only if the caller genuinely wants today's snapshot.
+ */
+export const useHoldingDivergence = (
+  accountIds: string[],
+  data: {
+    holdingSnapshots: HoldingSnapshotDictionary;
+    investmentTransactions: InvestmentTransactionDictionary;
+    securitySnapshots: SecuritySnapshotDictionary;
+  },
+  viewEndDate?: string,
+): DivergenceMap => {
+  const { holdingSnapshots, investmentTransactions, securitySnapshots } = data;
+  // Stable key — array identity would break the memo on every render.
+  const accountIdsKey = accountIds.slice().sort().join(",");
+
+  return useMemo(() => {
+    const ids = accountIdsKey.split(",").filter(Boolean);
+    if (!ids.length) {
+      return { bySecurity: new Map(), entries: [] };
+    }
+
+    // Window: 1y ending at `viewEndDate` (or today if omitted), floored at
+    // earliest available data per account.
+    const toIso = (d: Date) => d.toISOString().slice(0, 10);
+    const windowEnd = viewEndDate ?? toIso(new Date());
+    const oneYearAgoDate = new Date(windowEnd);
+    oneYearAgoDate.setFullYear(oneYearAgoDate.getFullYear() - 1);
+    const oneYearAgo = toIso(oneYearAgoDate);
+
+    const priceAt = buildPriceAt(securitySnapshots, investmentTransactions);
+
+    const bySecurity: DivergenceMap["bySecurity"] = new Map();
+    const entries: DivergenceEntry[] = [];
+
+    for (const id of ids) {
+      const earliest = earliestDataDate({
+        accountId: id,
+        holdingSnapshots,
+        investmentTransactions,
+      });
+      // Same clamp as PerformanceBenchmark.
+      const windowStart = !earliest || earliest > oneYearAgo ? earliest ?? oneYearAgo : oneYearAgo;
+      if (windowEnd <= windowStart) continue;
+
+      const d = computeQtyDivergence({
+        date: windowEnd,
+        windowStart,
+        accountId: id,
+        holdingSnapshots,
+        investmentTransactions,
+        priceAt,
+      });
+
+      const merge = (
+        e: DivergentEntry,
+        direction: DivergenceDirection,
+      ) => {
+        entries.push({ ...e, direction, account_id: id });
+        const existing = bySecurity.get(e.security_id);
+        if (existing) {
+          existing.deltaQty += e.deltaQty;
+          existing.deltaValue += e.deltaValue;
+          if (!existing.accountIds.includes(id)) existing.accountIds.push(id);
+        } else {
+          bySecurity.set(e.security_id, {
+            direction,
+            deltaQty: e.deltaQty,
+            deltaValue: e.deltaValue,
+            accountIds: [id],
+          });
+        }
+      };
+
+      d.divergentSecurities.forEach((e) => merge(e, "holdingExcess"));
+      d.txnExcessSecurities.forEach((e) => merge(e, "txnExcess"));
+    }
+
+    entries.sort((a, b) => b.deltaValue - a.deltaValue);
+    return { bySecurity, entries };
+  }, [accountIdsKey, viewEndDate, holdingSnapshots, investmentTransactions, securitySnapshots]);
+};

--- a/src/client/lib/hooks/calculation/index.ts
+++ b/src/client/lib/hooks/calculation/index.ts
@@ -1,4 +1,5 @@
 export * from "./accounts";
 export * from "./benchmark";
+export * from "./divergence";
 export * from "./budgets";
 export * from "./holdings";

--- a/src/client/lib/hooks/useTransactionEntry.ts
+++ b/src/client/lib/hooks/useTransactionEntry.ts
@@ -76,15 +76,30 @@ export const useTransactionEntry = () => {
   );
 
   /** Investment-side mint. Callable from an account with no holding context
-   *  OR from a holding page carrying the primary security's context. */
+   *  OR from a holding page carrying the primary security's context.
+   *
+   *  When `quantity` + `date` are also supplied (the divergence-flag
+   *  reconcile flow on `HoldingProperties`), the mint lands with those
+   *  values instead of the default `quantity=0 date=today`. Server derives
+   *  `amount = quantity × price` at that price, so the row shows up in
+   *  the tx list immediately (`TransactionsPage.filteredAndSorted`
+   *  filters zero-amount rows unless `source='manual'`, per PR #601). */
   const addInvestmentTransaction = useCallback(
     async (input: {
       account_id: string;
       security_id?: string | null;
-      /** Prefill from the holding's `institution_price` (holding page only). */
+      /** Prefill from the holding's `institution_price` (holding page only).
+       *  For the reconcile flow, callers should pass `priceAt(security_id,
+       *  date)` — the price at the mint's OWN date, not today. */
       price?: number | null;
       /** Prefill from the holding's `iso_currency_code` (holding page only). */
       iso_currency_code?: string | null;
+      /** Exact quantity to prefill (divergence reconcile). Rounded to 6dp
+       *  server-side to match `numeric(15,6)` storage precision. */
+      quantity?: number | null;
+      /** Historical date to prefill (divergence reconcile). YYYY-MM-DD.
+       *  Server ignores anything else, falling back to today. */
+      date?: string | null;
     }): Promise<string | null> => {
       const params: Record<string, string> = { account_id: input.account_id };
       if (input.security_id) params.security_id = input.security_id;
@@ -92,6 +107,14 @@ export const useTransactionEntry = () => {
         params.price = String(input.price);
       }
       if (input.iso_currency_code) params.iso_currency_code = input.iso_currency_code;
+      if (input.quantity !== undefined && input.quantity !== null && Number.isFinite(input.quantity)) {
+        // Round to numeric(15,6) precision — FP subtraction of two snap
+        // quantities leaves noise like 0.6232000000000539 otherwise.
+        params.quantity = (Math.round(input.quantity * 1e6) / 1e6).toString();
+      }
+      if (input.date && /^\d{4}-\d{2}-\d{2}$/.test(input.date)) {
+        params.date = input.date;
+      }
 
       const response = await call.get<NewInvestmentTransactionGetResponse>(
         "/api/new-investment-transaction?" + new URLSearchParams(params).toString(),
@@ -101,15 +124,23 @@ export const useTransactionEntry = () => {
         return null;
       }
       const { investment_transaction_id, name } = response.body;
+      const shellQty =
+        input.quantity !== undefined && input.quantity !== null && Number.isFinite(input.quantity)
+          ? Math.round(input.quantity * 1e6) / 1e6
+          : 0;
+      const shellPrice = input.price ?? 0;
       const shell = new InvestmentTransaction({
         investment_transaction_id,
         account_id: input.account_id,
         security_id: input.security_id ?? null,
-        date: new Date().toISOString().split("T")[0],
+        date: input.date ?? new Date().toISOString().split("T")[0],
         name,
-        amount: 0,
-        quantity: 0,
-        price: input.price ?? 0,
+        // Mirror the server-side derivation so the optimistic shell
+        // isn't filtered out of TransactionsPage's zero-amount guard
+        // (PR #601). Rounded to cents.
+        amount: Math.round(shellQty * shellPrice * 100) / 100,
+        quantity: shellQty,
+        price: shellPrice,
         iso_currency_code: input.iso_currency_code ?? null,
         type: InvestmentTransactionType.Buy,
         subtype: InvestmentTransactionSubtype.Buy,

--- a/src/server/lib/postgres/repositories/investment_transactions.ts
+++ b/src/server/lib/postgres/repositories/investment_transactions.ts
@@ -151,20 +151,34 @@ export const createManualInvestmentTransaction = async (
     // omitted and fall back to 0 / null.
     price?: number | null;
     iso_currency_code?: string | null;
+    quantity?: number | null;
+    /** YYYY-MM-DD. Defaults to today when omitted. */
+    date?: string | null;
   },
 ): Promise<JSONInvestmentTransaction | null> => {
   const investment_transaction_id = `manual-${randomUUID()}`;
   const index = await nextInvUnknownIndex(user.user_id);
+  const quantity = input.quantity ?? 0;
+  const price = input.price ?? 0;
+  // Derive `amount = quantity × price` when the caller provided both. The
+  // TransactionsPage view filters out zero-amount investment rows
+  // (`if (!e.amount) return false` in filteredAndSorted), so a mint that
+  // prefills only quantity (the divergence "N missing units" action) would
+  // land the row in DB but invisible in the tx list. Deriving here keeps
+  // the row visible without requiring the FE to re-POST the amount after
+  // the shell insert. Rounded to cents to match the client-side
+  // `roundToCents` used in InvestmentTransactionProperties.
+  const amount = Math.round(quantity * price * 100) / 100;
   const row = InvTxModel.fromJSON(
     {
       investment_transaction_id,
       account_id: input.account_id,
       security_id: input.security_id ?? null,
-      date: new Date().toISOString().split("T")[0],
+      date: input.date ?? new Date().toISOString().split("T")[0],
       name: `Unknown_${index}`,
-      amount: 0,
-      quantity: 0,
-      price: input.price ?? 0,
+      amount,
+      quantity,
+      price,
       iso_currency_code: input.iso_currency_code ?? null,
       type: InvestmentTransactionType.Buy,
       subtype: InvestmentTransactionSubtype.Buy,

--- a/src/server/routes/accounts/get-new-investment-transaction.ts
+++ b/src/server/routes/accounts/get-new-investment-transaction.ts
@@ -78,12 +78,30 @@ export const getNewInvestmentTransactionRoute =
       const iso_currency_code = req.query?.iso_currency_code
         ? String(req.query.iso_currency_code)
         : undefined;
+      // `quantity` is prefilled when the FE knows the exact missing units
+      // (divergence-flag "Add transaction for N missing units" action).
+      // Any finite value is accepted (positive or negative — the delta
+      // might be a "sell N units" reconciliation).
+      const quantityRaw = req.query?.quantity ? Number(req.query.quantity) : NaN;
+      const quantity = Number.isFinite(quantityRaw) ? quantityRaw : undefined;
+      // `date` is prefilled by the divergence-reconciliation flow with
+      // the earliest holdings-snapshot date that shows the surplus, so
+      // the mint explains the phantom shares from THAT date forward
+      // instead of only from today. Without this, a reconciliation buy
+      // dated today closes the current-window divergence but leaves
+      // every prior-month view still flagging the excess (the txn
+      // walker only counts txns up to the window end). Format:
+      // YYYY-MM-DD. Anything else is ignored and falls back to today.
+      const dateRaw = req.query?.date ? String(req.query.date) : "";
+      const date = /^\d{4}-\d{2}-\d{2}$/.test(dateRaw) ? dateRaw : undefined;
 
       const created = await createManualInvestmentTransaction(user, {
         account_id,
         security_id,
         price,
         iso_currency_code,
+        quantity,
+        date,
       });
       if (!created) {
         return { status: "failed", message: "Failed to create investment transaction." };


### PR DESCRIPTION
## What

The Investment Performance widget's MWR values **only the transaction-explained position**. `valueAt` walks `investment_transactions` (buy − sell) from a windowStart holdings anchor; any shares in `holding_snapshots` that no txn can explain are invisible. That's the deliberate phantom-holding guard — it stops a Plaid *holdings-ahead-of-transactions* sync gap from letting the IRR "explain" unaccounted shares as growth and spiking the annualized return.

The cost (called out in #387 item 1): on accounts whose txn stream is genuinely incomplete, the MWR is computed on **fewer shares than the user actually owns**, understating the return — with nothing in the UI to explain why.

This PR surfaces that reconciliation so the number isn't silently off a partial position.

## Changes

- **`benchmark.ts`** — extracted `valueAt`'s txn-derived qty walk into a shared `txnDerivedQtyBySecurity` helper (behavior-preserving; `valueAt` now calls it). Added **`computeQtyDivergence`**: reuses that identical walk and compares it against the latest holdings snapshot per non-cash security. Returns `{ divergentSecurityCount, excludedValue }` for securities where the user owns materially more shares than txns explain. Sub-0.1%-of-owned drift is ignored so fractional-share reinvestment doesn't false-flag; the reverse case (txns exceed snapshot qty) is not flagged.
- **`PerformanceBenchmark/index.tsx`** — the memo aggregates divergence across the account set; the footnote renders `· N holdings excluded (awaiting matching transactions)` in amber with a `title` tooltip explaining the cause and the approximate excluded value. No new row, no change to the headline math.
- **`index.css`** — `.performanceDivergence` amber + `cursor: help`.
- **`benchmark.test.ts`** — 6 new cases: flag-on-divergence (mirrors the phantom-holding fixture), no-flag-when-agree, sub-0.1% drift ignored, reverse case not flagged, cash-shape excluded, and priced-null surplus still counted.

## Scope

Purely client-side, additive. `divergentSecurityCount` defaults to 0 (no footnote change) on clean accounts. Does **not** attempt the synthetic-reconciliation "long-term fix" from #387 (needs a design call on inferred pricing) or cash-inclusive MWR (blocked on the settlement-pending mental model). Neither umbrella is closed.

Part of #381 (data-anomaly guards: "cross-check holdings-snapshot qty deltas against investment_transactions; flag the security_ids where they diverge"). Surfaces the user-facing symptom of #387 item 1.

## Testing

- `bun test benchmark.test.ts` — 49 pass (43 pre-existing unchanged + 6 new), 0 fail. The `valueAt` refactor keeps every existing valuation test green.
- `bun run typecheck` — clean. `eslint` — clean.
- E2E (Playwright, budget sandbox): _see comment below after sandbox spin._
