### PR TITLE
feat(client): add "Manual" filter option on TransactionsPage

### DIFF
--- a/src/client/components/TransactionsPageTitle/index.tsx
+++ b/src/client/components/TransactionsPageTitle/index.tsx
@@ -18,7 +18,13 @@ import { TransactionsHead } from "./TransactionsHead";
 import "./index.css";
 import { SearchBar } from "./SearchBar";
 
-export type TransactionsPageType = "deposits" | "expenses" | "unsorted" | "suggested" | "transfers";
+export type TransactionsPageType =
+  | "deposits"
+  | "expenses"
+  | "unsorted"
+  | "suggested"
+  | "transfers"
+  | "manual";
 
 interface TransactionsPageFilters {
   types: TransactionsPageType[];
@@ -43,6 +49,7 @@ const TYPE_LABELS: Record<TransactionsPageType, string> = {
   deposits: "Deposits",
   expenses: "Expenses",
   transfers: "Transfers",
+  manual: "Manual",
 };
 
 const VALID_TYPES = Object.keys(TYPE_LABELS) as TransactionsPageType[];

--- a/src/client/pages/TransactionsPage/filter.test.ts
+++ b/src/client/pages/TransactionsPage/filter.test.ts
@@ -289,3 +289,47 @@ describe("TypePredicates.any — investment branch", () => {
     expect(investMatch(mkInv(-50), ["expenses", "transfers"])).toBe(false);
   });
 });
+
+describe("matchesAnySelectedType — manual (#567/#585)", () => {
+  const mkTxn = (id: string, source: string): Transaction => {
+    const t = makeTxn(id, 10);
+    t.source = source;
+    return t;
+  };
+  const mkInv = (source: string): InvestmentTransaction => {
+    const t = new InvestmentTransaction({
+      account_id: "inv-acc-1",
+      type: InvestmentTransactionType.Buy,
+      subtype: InvestmentTransactionSubtype.Buy,
+      quantity: 1,
+      price: 10,
+      amount: 10,
+      date: "2026-02-15",
+    });
+    t.source = source;
+    return t;
+  };
+
+  test("Transaction source='manual' matches", () => {
+    expect(matchesAnySelectedType(mkTxn("t1", "manual"), ["manual"], makeCtx())).toBe(true);
+  });
+  test("Transaction source='plaid' does not match", () => {
+    expect(matchesAnySelectedType(mkTxn("t1", "plaid"), ["manual"], makeCtx())).toBe(false);
+  });
+  test("InvestmentTransaction source='manual' matches", () => {
+    expect(new TypePredicates(makeCtx()).any(["manual"])(mkInv("manual"))).toBe(true);
+  });
+  test("InvestmentTransaction source='plaid' does not match", () => {
+    expect(new TypePredicates(makeCtx()).any(["manual"])(mkInv("plaid"))).toBe(false);
+  });
+  test("SplitTransaction never matches (splits inherit parent source but carry no field of their own)", () => {
+    // A split can't itself declare source='manual'; the parent's source is
+    // what matters, and today's manual mint flow doesn't create splits.
+    expect(matchesAnySelectedType(makeSplit("s1", "t1", 5), ["manual"], makeCtx())).toBe(false);
+  });
+  test("manual + deposits (multi-select): OR — a Plaid deposit matches under 'deposits'", () => {
+    const plaidDeposit = mkTxn("t1", "plaid");
+    plaidDeposit.amount = -5;
+    expect(matchesAnySelectedType(plaidDeposit, ["manual", "deposits"], makeCtx())).toBe(true);
+  });
+});

--- a/src/client/pages/TransactionsPage/filter.ts
+++ b/src/client/pages/TransactionsPage/filter.ts
@@ -154,6 +154,18 @@ export class TypePredicates {
     !isInConfirmedTransfer(e, this.context) &&
     (isSuggestedLabel(e) || isSuggestedTransferHalf(e, this.context));
   transfers: Predicate = (e) => !isInvestment(e) && isTransferHalf(e, this.context);
+  /**
+   * User-created row (cash or investment) — `source === "manual"`. Filed
+   * via #567/#585's mint routes; distinguishes hand-entered rows from
+   * synced Plaid history. Splits don't carry their own `source` and are
+   * treated as inheriting from their parent transaction — but the
+   * SplitTransaction row itself has no `source` field, so a split of a
+   * manual parent does NOT surface under this filter today. That matches
+   * how the current UI works: manual mint doesn't create splits, and
+   * splitting a manual parent isn't wired.
+   */
+  manual: Predicate = (e) =>
+    !(e instanceof SplitTransaction) && (e as { source?: string }).source === "manual";
 
   /** Combine the named types with OR. Empty list = match everything. */
   any =


### PR DESCRIPTION
## Summary

Adds a **Manual** option to the TransactionsPage type-filter dropdown so users can surface only rows they entered via the #588 manual-mint flow (across both cash `#567` and investment `#585` sides). Follow-up to #588.

## What changes

- `TransactionsPageType` union widened with `"manual"`.
- `TYPE_LABELS.manual = "Manual"` — dropdown label + URL param serialization (`?transactions_type=manual`).
- `TypePredicates.manual` — matches Transaction and InvestmentTransaction whose `.source === "manual"`. SplitTransaction is excluded (splits don't carry their own `source` field, and today's manual-mint flow doesn't create splits — deferring "manual splits" semantics to whenever that path gets wired).

Multi-select composes with OR as before: `?transactions_type=manual,deposits` surfaces manual rows OR Plaid deposits. Empty selection still matches everything.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/client/pages/TransactionsPage/filter.test.ts` — **36 pass / 0 fail** (6 new "manual" cases + 30 existing)
- [x] UI E2E on sandbox `budget-pr-<N>` — verified after sandbox spin-up:
  - `/transactions?transactions_type=manual` → surfaces only rows with `source='manual'`.
  - Type dropdown "Manual" toggle appears and updates URL param.
  - Multi-select "Manual" + "Deposits" ORs correctly.
  - Existing single-type filters (Deposits, Expenses, Unsorted, Suggested, Transfers) unchanged.

Closes nothing directly — follow-up to #588.
