### PR TITLE
fix(server): scope updateSplitTransactions to user_id (cross-user write guard)

### DIFF
--- a/src/server/lib/postgres/repositories/split_transactions.ts
+++ b/src/server/lib/postgres/repositories/split_transactions.ts
@@ -109,7 +109,15 @@ export const updateSplitTransactions = async (
       delete row.split_transaction_id;
       delete row.user_id;
 
-      const updated = await splitTransactionsTable.update(tx.split_transaction_id, row);
+      // Scope the update to the caller's user_id — without this a caller
+      // could patch another user's split transaction by id. Same class of
+      // gap fixed for `updateInvestmentTransactions` on #588 round 3.
+      const updated = await splitTransactionsTable.update(
+        tx.split_transaction_id,
+        row,
+        undefined,
+        user.user_id,
+      );
       results.push(
         updated
           ? successResult(tx.split_transaction_id, 1)

--- a/src/server/lib/postgres/repositories/split_transactions.ts
+++ b/src/server/lib/postgres/repositories/split_transactions.ts
@@ -110,8 +110,7 @@ export const updateSplitTransactions = async (
       delete row.user_id;
 
       // Scope the update to the caller's user_id — without this a caller
-      // could patch another user's split transaction by id. Same class of
-      // gap fixed for `updateInvestmentTransactions` on #588 round 3.
+      // could patch another user's split transaction by id.
       const updated = await splitTransactionsTable.update(
         tx.split_transaction_id,
         row,

--- a/src/server/routes/accounts/post-transaction-routes.test.ts
+++ b/src/server/routes/accounts/post-transaction-routes.test.ts
@@ -280,13 +280,17 @@ describe("post-split-transaction route", () => {
       fakeRes(),
     );
     expect(result?.status).toBe("success");
-    // The UPDATE's bound-parameter list carries `s-1` (the PK) AND `u-1`
-    // (the caller's user_id). Without `updateSplitTransactions` passing
-    // `user.user_id` as the 4th `Table.update` arg, the WHERE would only
-    // key on the PK — and a caller could patch another user's row by id.
+    // Assert the guard is a WHERE predicate binding the caller's id, not a bare
+    // `values.toContain("u-1")` — the latter passes vacuously for a refactor that
+    // drops the guard but still SETs user_id. Both the PK and the user_id scope
+    // must key the WHERE clause.
     const upd = findUpdate("split_transactions");
-    expect(upd!.values).toContain("s-1");
-    expect(upd!.values).toContain("u-1");
+    const whereUserId = upd!.sql.match(/WHERE[\s\S]*?\buser_id\s*=\s*\$(\d+)/i);
+    const wherePk = upd!.sql.match(/WHERE[\s\S]*?\bsplit_transaction_id\s*=\s*\$(\d+)/i);
+    expect(whereUserId).not.toBeNull();
+    expect(wherePk).not.toBeNull();
+    expect(upd!.values[Number(whereUserId![1]) - 1]).toBe("u-1");
+    expect(upd!.values[Number(wherePk![1]) - 1]).toBe("s-1");
   });
 
   test("surfaces a DB error as a failed response", async () => {

--- a/src/server/routes/accounts/post-transaction-routes.test.ts
+++ b/src/server/routes/accounts/post-transaction-routes.test.ts
@@ -270,6 +270,25 @@ describe("post-split-transaction route", () => {
     expect(boundValue(upd!, "label_category_confidence")).toBe(0.7);
   });
 
+  test("update WHERE is scoped to caller's user_id (cross-user write guard, #591)", async () => {
+    const result = await postSplitTransactionRoute.execute(
+      makeReq(
+        postSplitTransactionRoute,
+        { split_transaction_id: "s-1", label: { category_id: "c-1" } },
+        "u-1",
+      ),
+      fakeRes(),
+    );
+    expect(result?.status).toBe("success");
+    // The UPDATE's bound-parameter list carries `s-1` (the PK) AND `u-1`
+    // (the caller's user_id). Without `updateSplitTransactions` passing
+    // `user.user_id` as the 4th `Table.update` arg, the WHERE would only
+    // key on the PK — and a caller could patch another user's row by id.
+    const upd = findUpdate("split_transactions");
+    expect(upd!.values).toContain("s-1");
+    expect(upd!.values).toContain("u-1");
+  });
+
   test("surfaces a DB error as a failed response", async () => {
     // Matches its sibling routes: updateSplitTransactions swallows the write
     // failure into an errorResult(500), the route's `result.status >= 400`


### PR DESCRIPTION
## Summary

Fixes a cross-user write vulnerability in `updateSplitTransactions`. Closes #591.

Same class of gap as the `updateInvestmentTransactions` fix on #588 (round 3). Any authenticated user could POST `/api/split-transaction` with a body carrying another user's `split_transaction_id` and a label patch — the write landed because the UPDATE keyed only on the PK, not on `user_id`.

## What changes

- `src/server/lib/postgres/repositories/split_transactions.ts`: pass `user.user_id` as the 4th arg to `splitTransactionsTable.update(...)`. `Table.update` ANDs a `user_id = $N` guard onto the WHERE. Cross-user callers now hit the noChange branch instead of writing.
- `post-transaction-routes.test.ts`: regression test that asserts the UPDATE's bound-parameter list carries both the PK (`s-1`) AND the caller's `u-1`, so a future refactor can't silently drop the scope arg.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/server/routes/accounts/post-transaction-routes.test.ts` — **20 pass / 0 fail** (19 pre-existing + 1 new scope regression)
- [x] Root-cause verified against `Table.update`'s signature (`src/server/lib/postgres/models/base.ts`) — the 4th `userId` arg pushes a `{ column: "user_id", value: userId }` predicate onto `additionalWhere`, which `buildUpdate` ANDs into the WHERE.

Closes #591.
