### PR TITLE
refactor(client): extract useTransactionEntry hook to dedupe manual-tx mint handlers

### DIFF
--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -101,21 +101,15 @@ export const AccountProperties = ({ account }: Props) => {
     router.go(PATH.TRANSACTIONS, { params });
   };
 
-  /**
-   * `+ Add Transaction` on a manual account (#567). Delegates to the
-   * shared `useTransactionEntry` hook — same mint flow as
-   * `HoldingProperties.onClickAddInvestmentTransaction`.
-   */
   const { addTransaction, addInvestmentTransaction } = useTransactionEntry();
   const onClickAddTransaction = () =>
     addTransaction({ account_id, iso_currency_code });
 
   /**
-   * `+ Add Investment Transaction` on any investment account (#585).
-   * NOT gated on `isManualAccount` — the motivating case is RSU/ESPP
-   * grants on a Plaid-connected brokerage that pre-date Plaid's 24-mo
-   * window. Server marks the row `source='manual'` so it survives
-   * future Plaid syncs.
+   * NOT gated on `isManualAccount` — the motivating case (#585) is
+   * RSU/ESPP grants on a Plaid-connected brokerage that pre-date
+   * Plaid's 24-mo transaction window. Server marks the row
+   * `source='manual'` so it survives future Plaid syncs.
    */
   const onClickAddInvestmentTransaction = () =>
     addInvestmentTransaction({ account_id });

--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -1,4 +1,4 @@
-import { AccountType, InvestmentTransactionType, InvestmentTransactionSubtype } from "plaid";
+import { AccountType } from "plaid";
 import { useMemo } from "react";
 import {
   currencyCodeToSymbol,
@@ -7,23 +7,13 @@ import {
   toTitleCase,
   ViewDate,
 } from "common";
-import type {
-  NewTransactionGetResponse,
-  NewInvestmentTransactionGetResponse,
-} from "server";
 import {
   Account,
-  call,
-  Data,
-  indexedDb,
-  InvestmentTransaction,
-  InvestmentTransactionDictionary,
   PATH,
   ScreenType,
-  Transaction,
-  TransactionDictionary,
   useAccountGraph,
   useAppContext,
+  useTransactionEntry,
 } from "client";
 import {
   DateLabel,
@@ -49,7 +39,7 @@ export const AccountProperties = ({ account }: Props) => {
 
   const { graphViewDate, graphData, cursorAmount } = useAccountGraph([account]);
 
-  const { data, setData, viewDate, router, screenType } = useAppContext();
+  const { data, viewDate, router, screenType } = useAppContext();
   const { budgets, items } = data;
 
   const {
@@ -112,43 +102,13 @@ export const AccountProperties = ({ account }: Props) => {
   };
 
   /**
-   * `+ Add Transaction` on a manual account (#567). Mints a shell row
-   * server-side via `GET /api/new-transaction`, optimistically inserts
-   * it into `data.transactions` so the detail page picks it up
-   * immediately without waiting for the next sync, then navigates.
+   * `+ Add Transaction` on a manual account (#567). Delegates to the
+   * shared `useTransactionEntry` hook — same mint flow as
+   * `HoldingProperties.onClickAddInvestmentTransaction`.
    */
-  const onClickAddTransaction = async () => {
-    const query = new URLSearchParams({ account_id }).toString();
-    const response = await call.get<NewTransactionGetResponse>(
-      "/api/new-transaction?" + query,
-    );
-    if (!response.body) {
-      console.error("Failed to mint new transaction:", response.message);
-      return;
-    }
-    const { transaction_id, name } = response.body;
-    const shell = new Transaction({
-      transaction_id,
-      account_id,
-      name,
-      amount: 0,
-      iso_currency_code: iso_currency_code ?? null,
-      date: new Date().toISOString().split("T")[0],
-      pending: false,
-      source: "manual",
-    });
-    setData((oldData) => {
-      const next = new Data(oldData);
-      const dict = new TransactionDictionary(oldData.transactions);
-      dict.set(transaction_id, shell);
-      next.transactions = dict;
-      indexedDb.save(shell).catch(console.error);
-      return next;
-    });
-    router.go(PATH.TRANSACTION_DETAIL, {
-      params: new URLSearchParams({ transaction_id }),
-    });
-  };
+  const { addTransaction, addInvestmentTransaction } = useTransactionEntry();
+  const onClickAddTransaction = () =>
+    addTransaction({ account_id, iso_currency_code });
 
   /**
    * `+ Add Investment Transaction` on any investment account (#585).
@@ -157,41 +117,8 @@ export const AccountProperties = ({ account }: Props) => {
    * window. Server marks the row `source='manual'` so it survives
    * future Plaid syncs.
    */
-  const onClickAddInvestmentTransaction = async () => {
-    const response = await call.get<NewInvestmentTransactionGetResponse>(
-      "/api/new-investment-transaction?" +
-        new URLSearchParams({ account_id }).toString(),
-    );
-    if (!response.body) {
-      console.error("Failed to mint new investment transaction:", response.message);
-      return;
-    }
-    const { investment_transaction_id, name } = response.body;
-    const shell = new InvestmentTransaction({
-      investment_transaction_id,
-      account_id,
-      security_id: null,
-      date: new Date().toISOString().split("T")[0],
-      name,
-      amount: 0,
-      quantity: 0,
-      price: 0,
-      type: InvestmentTransactionType.Buy,
-      subtype: InvestmentTransactionSubtype.Buy,
-      source: "manual",
-    });
-    setData((oldData) => {
-      const next = new Data(oldData);
-      const dict = new InvestmentTransactionDictionary(oldData.investmentTransactions);
-      dict.set(investment_transaction_id, shell);
-      next.investmentTransactions = dict;
-      indexedDb.save(shell).catch(console.error);
-      return next;
-    });
-    router.go(PATH.TRANSACTION_DETAIL, {
-      params: new URLSearchParams({ investment_transaction_id }),
-    });
-  };
+  const onClickAddInvestmentTransaction = () =>
+    addInvestmentTransaction({ account_id });
 
   const onClickConnectionDetail = () => {
     if (!item) return;

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -277,14 +277,11 @@ export const HoldingProperties = () => {
   };
 
   /**
-   * `+ Add Investment Transaction` on the holding — Hoie's ask (#585
-   * design): prefill `security_id`, `price` (from the holding's
+   * Prefill `security_id`, `price` (from the holding's
    * `institution_price`), and `iso_currency_code` from the holding
    * context so the user starts with values they can confirm/correct
    * rather than 0 / null defaults. When the bucket spans multiple
    * securities (rare — merged tickers), use the first snapshot.
-   * Delegates to `useTransactionEntry` — same hook the account-level
-   * `+ Add Investment Transaction` calls.
    */
   const primaryHolding = bucketSnapshots[0]?.holding;
   const primarySecurityId = primaryHolding?.security_id ?? null;

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -1,17 +1,15 @@
 import { ChangeEventHandler, Fragment, FormEventHandler, useCallback, useEffect, useMemo, useState } from "react";
-import { InvestmentTransactionType, InvestmentTransactionSubtype } from "plaid";
 import { ItemProvider, numberToCommaString, ViewDate, currencyCodeToSymbol } from "common";
 import {
   call,
   PATH,
   useAppContext,
+  useTransactionEntry,
   Data,
   Snapshot,
   Holding,
   HoldingSnapshot,
   HoldingSnapshotDictionary,
-  InvestmentTransaction,
-  InvestmentTransactionDictionary,
   Properties,
   PropertyLabel,
   Property,
@@ -22,7 +20,6 @@ import {
 import { CASH_TICKER } from "../HoldingsComposition";
 import {
   HoldingSnapshotPostResponse,
-  NewInvestmentTransactionGetResponse,
   ValidateTickerResponse,
 } from "server";
 
@@ -286,49 +283,21 @@ export const HoldingProperties = () => {
    * context so the user starts with values they can confirm/correct
    * rather than 0 / null defaults. When the bucket spans multiple
    * securities (rare — merged tickers), use the first snapshot.
+   * Delegates to `useTransactionEntry` — same hook the account-level
+   * `+ Add Investment Transaction` calls.
    */
   const primaryHolding = bucketSnapshots[0]?.holding;
   const primarySecurityId = primaryHolding?.security_id ?? null;
   const primaryPrice = primaryHolding?.institution_price ?? null;
   const primaryCurrency = primaryHolding?.iso_currency_code ?? null;
-  const onClickAddInvestmentTransaction = async () => {
+  const { addInvestmentTransaction } = useTransactionEntry();
+  const onClickAddInvestmentTransaction = () => {
     if (!accountId) return;
-    const params: Record<string, string> = { account_id: accountId };
-    if (primarySecurityId) params.security_id = primarySecurityId;
-    if (primaryPrice !== null && primaryPrice >= 0) params.price = String(primaryPrice);
-    if (primaryCurrency) params.iso_currency_code = primaryCurrency;
-    const response = await call.get<NewInvestmentTransactionGetResponse>(
-      "/api/new-investment-transaction?" + new URLSearchParams(params).toString(),
-    );
-    if (!response.body) {
-      console.error("Failed to mint new investment transaction:", response.message);
-      return;
-    }
-    const { investment_transaction_id, name } = response.body;
-    const shell = new InvestmentTransaction({
-      investment_transaction_id,
+    return addInvestmentTransaction({
       account_id: accountId,
       security_id: primarySecurityId,
-      date: new Date().toISOString().split("T")[0],
-      name,
-      amount: 0,
-      quantity: 0,
-      price: primaryPrice ?? 0,
+      price: primaryPrice,
       iso_currency_code: primaryCurrency,
-      type: InvestmentTransactionType.Buy,
-      subtype: InvestmentTransactionSubtype.Buy,
-      source: "manual",
-    });
-    setData((oldData) => {
-      const next = new Data(oldData);
-      const dict = new InvestmentTransactionDictionary(oldData.investmentTransactions);
-      dict.set(investment_transaction_id, shell);
-      next.investmentTransactions = dict;
-      indexedDb.save(shell).catch(console.error);
-      return next;
-    });
-    router.go(PATH.TRANSACTION_DETAIL, {
-      params: new URLSearchParams({ investment_transaction_id }),
     });
   };
 

--- a/src/client/lib/hooks/index.ts
+++ b/src/client/lib/hooks/index.ts
@@ -8,3 +8,4 @@ export * from "./sorter";
 export * from "./reorder";
 export * from "./useVooHistory";
 export * from "./useBudgetCategorySelect";
+export * from "./useTransactionEntry";

--- a/src/client/lib/hooks/useTransactionEntry.ts
+++ b/src/client/lib/hooks/useTransactionEntry.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { InvestmentTransactionType, InvestmentTransactionSubtype } from "plaid";
 import type {
   NewTransactionGetResponse,
@@ -36,93 +37,99 @@ export const useTransactionEntry = () => {
   const { setData, router } = useAppContext();
 
   /** Cash-side mint (`+ Add Transaction`, gated on manual accounts). */
-  const addTransaction = async (input: {
-    account_id: string;
-    iso_currency_code?: string | null;
-  }): Promise<string | null> => {
-    const query = new URLSearchParams({ account_id: input.account_id }).toString();
-    const response = await call.get<NewTransactionGetResponse>("/api/new-transaction?" + query);
-    if (!response.body) {
-      console.error("Failed to mint new transaction:", response.message);
-      return null;
-    }
-    const { transaction_id, name } = response.body;
-    const shell = new Transaction({
-      transaction_id,
-      account_id: input.account_id,
-      name,
-      amount: 0,
-      iso_currency_code: input.iso_currency_code ?? null,
-      date: new Date().toISOString().split("T")[0],
-      pending: false,
-      source: "manual",
-    });
-    setData((oldData) => {
-      const next = new Data(oldData);
-      const dict = new TransactionDictionary(oldData.transactions);
-      dict.set(transaction_id, shell);
-      next.transactions = dict;
-      indexedDb.save(shell).catch(console.error);
-      return next;
-    });
-    router.go(PATH.TRANSACTION_DETAIL, {
-      params: new URLSearchParams({ transaction_id }),
-    });
-    return transaction_id;
-  };
+  const addTransaction = useCallback(
+    async (input: {
+      account_id: string;
+      iso_currency_code?: string | null;
+    }): Promise<string | null> => {
+      const query = new URLSearchParams({ account_id: input.account_id }).toString();
+      const response = await call.get<NewTransactionGetResponse>("/api/new-transaction?" + query);
+      if (!response.body) {
+        console.error("Failed to mint new transaction:", response.message);
+        return null;
+      }
+      const { transaction_id, name } = response.body;
+      const shell = new Transaction({
+        transaction_id,
+        account_id: input.account_id,
+        name,
+        amount: 0,
+        iso_currency_code: input.iso_currency_code ?? null,
+        date: new Date().toISOString().split("T")[0],
+        pending: false,
+        source: "manual",
+      });
+      setData((oldData) => {
+        const next = new Data(oldData);
+        const dict = new TransactionDictionary(oldData.transactions);
+        dict.set(transaction_id, shell);
+        next.transactions = dict;
+        indexedDb.save(shell).catch(console.error);
+        return next;
+      });
+      router.go(PATH.TRANSACTION_DETAIL, {
+        params: new URLSearchParams({ transaction_id }),
+      });
+      return transaction_id;
+    },
+    [setData, router],
+  );
 
   /** Investment-side mint. Callable from an account with no holding context
    *  OR from a holding page carrying the primary security's context. */
-  const addInvestmentTransaction = async (input: {
-    account_id: string;
-    security_id?: string | null;
-    /** Prefill from the holding's `institution_price` (holding page only). */
-    price?: number | null;
-    /** Prefill from the holding's `iso_currency_code` (holding page only). */
-    iso_currency_code?: string | null;
-  }): Promise<string | null> => {
-    const params: Record<string, string> = { account_id: input.account_id };
-    if (input.security_id) params.security_id = input.security_id;
-    if (input.price !== undefined && input.price !== null && input.price >= 0) {
-      params.price = String(input.price);
-    }
-    if (input.iso_currency_code) params.iso_currency_code = input.iso_currency_code;
+  const addInvestmentTransaction = useCallback(
+    async (input: {
+      account_id: string;
+      security_id?: string | null;
+      /** Prefill from the holding's `institution_price` (holding page only). */
+      price?: number | null;
+      /** Prefill from the holding's `iso_currency_code` (holding page only). */
+      iso_currency_code?: string | null;
+    }): Promise<string | null> => {
+      const params: Record<string, string> = { account_id: input.account_id };
+      if (input.security_id) params.security_id = input.security_id;
+      if (input.price !== undefined && input.price !== null && input.price >= 0) {
+        params.price = String(input.price);
+      }
+      if (input.iso_currency_code) params.iso_currency_code = input.iso_currency_code;
 
-    const response = await call.get<NewInvestmentTransactionGetResponse>(
-      "/api/new-investment-transaction?" + new URLSearchParams(params).toString(),
-    );
-    if (!response.body) {
-      console.error("Failed to mint new investment transaction:", response.message);
-      return null;
-    }
-    const { investment_transaction_id, name } = response.body;
-    const shell = new InvestmentTransaction({
-      investment_transaction_id,
-      account_id: input.account_id,
-      security_id: input.security_id ?? null,
-      date: new Date().toISOString().split("T")[0],
-      name,
-      amount: 0,
-      quantity: 0,
-      price: input.price ?? 0,
-      iso_currency_code: input.iso_currency_code ?? null,
-      type: InvestmentTransactionType.Buy,
-      subtype: InvestmentTransactionSubtype.Buy,
-      source: "manual",
-    });
-    setData((oldData) => {
-      const next = new Data(oldData);
-      const dict = new InvestmentTransactionDictionary(oldData.investmentTransactions);
-      dict.set(investment_transaction_id, shell);
-      next.investmentTransactions = dict;
-      indexedDb.save(shell).catch(console.error);
-      return next;
-    });
-    router.go(PATH.TRANSACTION_DETAIL, {
-      params: new URLSearchParams({ investment_transaction_id }),
-    });
-    return investment_transaction_id;
-  };
+      const response = await call.get<NewInvestmentTransactionGetResponse>(
+        "/api/new-investment-transaction?" + new URLSearchParams(params).toString(),
+      );
+      if (!response.body) {
+        console.error("Failed to mint new investment transaction:", response.message);
+        return null;
+      }
+      const { investment_transaction_id, name } = response.body;
+      const shell = new InvestmentTransaction({
+        investment_transaction_id,
+        account_id: input.account_id,
+        security_id: input.security_id ?? null,
+        date: new Date().toISOString().split("T")[0],
+        name,
+        amount: 0,
+        quantity: 0,
+        price: input.price ?? 0,
+        iso_currency_code: input.iso_currency_code ?? null,
+        type: InvestmentTransactionType.Buy,
+        subtype: InvestmentTransactionSubtype.Buy,
+        source: "manual",
+      });
+      setData((oldData) => {
+        const next = new Data(oldData);
+        const dict = new InvestmentTransactionDictionary(oldData.investmentTransactions);
+        dict.set(investment_transaction_id, shell);
+        next.investmentTransactions = dict;
+        indexedDb.save(shell).catch(console.error);
+        return next;
+      });
+      router.go(PATH.TRANSACTION_DETAIL, {
+        params: new URLSearchParams({ investment_transaction_id }),
+      });
+      return investment_transaction_id;
+    },
+    [setData, router],
+  );
 
   return { addTransaction, addInvestmentTransaction };
 };

--- a/src/client/lib/hooks/useTransactionEntry.ts
+++ b/src/client/lib/hooks/useTransactionEntry.ts
@@ -72,7 +72,7 @@ export const useTransactionEntry = () => {
       });
       return transaction_id;
     },
-    [setData, router],
+    [setData, router.go],
   );
 
   /** Investment-side mint. Callable from an account with no holding context
@@ -128,7 +128,7 @@ export const useTransactionEntry = () => {
       });
       return investment_transaction_id;
     },
-    [setData, router],
+    [setData, router.go],
   );
 
   return { addTransaction, addInvestmentTransaction };

--- a/src/client/lib/hooks/useTransactionEntry.ts
+++ b/src/client/lib/hooks/useTransactionEntry.ts
@@ -1,0 +1,128 @@
+import { InvestmentTransactionType, InvestmentTransactionSubtype } from "plaid";
+import type {
+  NewTransactionGetResponse,
+  NewInvestmentTransactionGetResponse,
+} from "server";
+import {
+  Data,
+  InvestmentTransaction,
+  InvestmentTransactionDictionary,
+  PATH,
+  Transaction,
+  TransactionDictionary,
+  call,
+  indexedDb,
+} from "client";
+import { useAppContext } from "./context";
+
+/**
+ * Shared entry-point for the "+ Add Transaction" and "+ Add Investment
+ * Transaction" mint flows on `AccountProperties` and `HoldingProperties`.
+ *
+ * Consolidates the previously-duplicated per-component handlers (~90%
+ * identical, called out on hoiekim/budget#588 review round 1) so the
+ * mint flow is one source of truth:
+ *
+ *   GET  /api/new-*transaction?... → mint shell on server (source='manual')
+ *   optimistic shell inserted into data.transactions / .investmentTransactions
+ *   indexedDb.save(shell)
+ *   router.go(PATH.TRANSACTION_DETAIL, { params: { <id> } })
+ *
+ * Callers pass account-level context (`account_id`, `iso_currency_code`)
+ * and holding-level context (`security_id`, `price`) when available;
+ * defaults fall through to the server-side createManual* helpers.
+ */
+export const useTransactionEntry = () => {
+  const { setData, router } = useAppContext();
+
+  /** Cash-side mint (`+ Add Transaction`, gated on manual accounts). */
+  const addTransaction = async (input: {
+    account_id: string;
+    iso_currency_code?: string | null;
+  }): Promise<string | null> => {
+    const query = new URLSearchParams({ account_id: input.account_id }).toString();
+    const response = await call.get<NewTransactionGetResponse>("/api/new-transaction?" + query);
+    if (!response.body) {
+      console.error("Failed to mint new transaction:", response.message);
+      return null;
+    }
+    const { transaction_id, name } = response.body;
+    const shell = new Transaction({
+      transaction_id,
+      account_id: input.account_id,
+      name,
+      amount: 0,
+      iso_currency_code: input.iso_currency_code ?? null,
+      date: new Date().toISOString().split("T")[0],
+      pending: false,
+      source: "manual",
+    });
+    setData((oldData) => {
+      const next = new Data(oldData);
+      const dict = new TransactionDictionary(oldData.transactions);
+      dict.set(transaction_id, shell);
+      next.transactions = dict;
+      indexedDb.save(shell).catch(console.error);
+      return next;
+    });
+    router.go(PATH.TRANSACTION_DETAIL, {
+      params: new URLSearchParams({ transaction_id }),
+    });
+    return transaction_id;
+  };
+
+  /** Investment-side mint. Callable from an account with no holding context
+   *  OR from a holding page carrying the primary security's context. */
+  const addInvestmentTransaction = async (input: {
+    account_id: string;
+    security_id?: string | null;
+    /** Prefill from the holding's `institution_price` (holding page only). */
+    price?: number | null;
+    /** Prefill from the holding's `iso_currency_code` (holding page only). */
+    iso_currency_code?: string | null;
+  }): Promise<string | null> => {
+    const params: Record<string, string> = { account_id: input.account_id };
+    if (input.security_id) params.security_id = input.security_id;
+    if (input.price !== undefined && input.price !== null && input.price >= 0) {
+      params.price = String(input.price);
+    }
+    if (input.iso_currency_code) params.iso_currency_code = input.iso_currency_code;
+
+    const response = await call.get<NewInvestmentTransactionGetResponse>(
+      "/api/new-investment-transaction?" + new URLSearchParams(params).toString(),
+    );
+    if (!response.body) {
+      console.error("Failed to mint new investment transaction:", response.message);
+      return null;
+    }
+    const { investment_transaction_id, name } = response.body;
+    const shell = new InvestmentTransaction({
+      investment_transaction_id,
+      account_id: input.account_id,
+      security_id: input.security_id ?? null,
+      date: new Date().toISOString().split("T")[0],
+      name,
+      amount: 0,
+      quantity: 0,
+      price: input.price ?? 0,
+      iso_currency_code: input.iso_currency_code ?? null,
+      type: InvestmentTransactionType.Buy,
+      subtype: InvestmentTransactionSubtype.Buy,
+      source: "manual",
+    });
+    setData((oldData) => {
+      const next = new Data(oldData);
+      const dict = new InvestmentTransactionDictionary(oldData.investmentTransactions);
+      dict.set(investment_transaction_id, shell);
+      next.investmentTransactions = dict;
+      indexedDb.save(shell).catch(console.error);
+      return next;
+    });
+    router.go(PATH.TRANSACTION_DETAIL, {
+      params: new URLSearchParams({ investment_transaction_id }),
+    });
+    return investment_transaction_id;
+  };
+
+  return { addTransaction, addInvestmentTransaction };
+};


### PR DESCRIPTION
## Summary

Extracts the `useTransactionEntry` hook to dedupe the three-way `+ Add Transaction` / `+ Add Investment Transaction` mint flow across `AccountProperties` and `HoldingProperties`. Closes #592 (reviewoie MED-3 on #588 round 1).

## What changes

Before: three call sites, each ~30 lines, all doing the same thing:

```
GET /api/new-*transaction?... → mint shell on server (source='manual')
optimistic shell → data.transactions / .investmentTransactions
indexedDb.save(shell)
router.go(PATH.TRANSACTION_DETAIL, { params: { <id> } })
```

After: one shared hook, three call sites each ~3 lines:

```tsx
const { addTransaction, addInvestmentTransaction } = useTransactionEntry();
onClickAddTransaction = () => addTransaction({ account_id, iso_currency_code });
onClickAddInvestmentTransaction = () => addInvestmentTransaction({
  account_id, security_id, price, iso_currency_code
});
```

- New `src/client/lib/hooks/useTransactionEntry.ts` — the hook.
- `AccountProperties/index.tsx` — drops both handlers, calls the hook. Removes 5 no-longer-needed imports (`call`, `Data`, `indexedDb`, `Transaction`, `TransactionDictionary`, `InvestmentTransaction`, `InvestmentTransactionDictionary`, `NewTransactionGetResponse`, `NewInvestmentTransactionGetResponse`, `InvestmentTransactionType`, `InvestmentTransactionSubtype`). Drops unused `setData`.
- `HoldingProperties/index.tsx` — drops the handler, calls the hook. Removes `InvestmentTransaction`, `InvestmentTransactionDictionary`, `NewInvestmentTransactionGetResponse`, `InvestmentTransactionType`, `InvestmentTransactionSubtype`.
- `client/lib/hooks/index.ts` — barrel export.

Net **-103 LOC** across consumers, +125 LOC for the hook. Behavior identical.

## Test plan

- [x] `bun run typecheck` — clean
- [x] Existing tests unaffected (no logic changes in the mint flow itself; only relocation)
- [x] UI E2E on sandbox: mint + navigate flow verified on both the account-level `+` (both cash and investment) and the holding-page `+`. Screens still transition to `transaction-detail?transaction_id=...` / `?investment_transaction_id=...`; optimistic shell renders immediately with the server's `Unknown_N` name.

Closes #592.
