### PR TITLE
fix(charts): investment balance graph — cash-only account_balance snapshot no longer overrides the larger holdings total

### DIFF
--- a/src/client/lib/hooks/calculation/accounts.test.ts
+++ b/src/client/lib/hooks/calculation/accounts.test.ts
@@ -1,7 +1,17 @@
 import { describe, test, expect } from "bun:test";
 import { AccountType, AccountSubtype } from "plaid";
-import { getAccountBalance, getDisplayBalance } from "./accounts";
-import { Account, BalanceData } from "client";
+import { getAccountBalance, getDisplayBalance, getBalanceData } from "./accounts";
+import {
+  Account,
+  AccountDictionary,
+  AccountSnapshot,
+  AccountSnapshotDictionary,
+  BalanceData,
+  HoldingSnapshot,
+  HoldingSnapshotDictionary,
+  InvestmentTransactionDictionary,
+  TransactionDictionary,
+} from "client";
 
 describe("getAccountBalance", () => {
   test("should return current balance for depository accounts", () => {
@@ -124,6 +134,90 @@ describe("getDisplayBalance (#510 cold-load past-balance flash)", () => {
   });
 });
 
-// Note: getBalanceData tests require mocking the environment or using integration tests
-// because the Dictionary class disables set() in server/test environments.
-// These tests should be run as part of e2e testing.
+// Regression coverage for the tier-1-vs-tier-2 merge in getBalanceData. For an
+// investment account a Plaid `account_balance` snapshot can report only the
+// settled-cash sleeve while the holdings-inclusive total lives in the same
+// month's `holding` snapshot; tier 1 must not override a larger tier-2 total
+// (a false V-crater on the account balance graph).
+describe("getBalanceData tier-1/tier-2 reconciliation for investment accounts", () => {
+  // getBalanceData internally compares snapshot dates against the real `new
+  // Date()`, so fixtures must sit in the past. BalanceHistory buckets by
+  // year-month, so any day of MONTH is retrievable via a same-month read.
+  const MONTH = "2025-06";
+  const readAt = new Date(`${MONTH}-15`);
+
+  const buildAccountSnapshots = (account: Account, current: number) => {
+    const snapshots = new AccountSnapshotDictionary();
+    const snapshot = new AccountSnapshot({
+      snapshot: { date: `${MONTH}-15T00:00:00.000Z` },
+      account: { ...account, balances: { ...account.balances, current } },
+    });
+    snapshots.set(snapshot.id, snapshot);
+    return snapshots;
+  };
+
+  const buildHoldingSnapshots = (accountId: string, institutionValue: number) => {
+    const snapshots = new HoldingSnapshotDictionary();
+    const snapshot = new HoldingSnapshot({
+      snapshot: { date: `${MONTH}-15T00:00:00.000Z` },
+      holding: {
+        account_id: accountId,
+        security_id: "sec1",
+        holding_id: "hold1",
+        institution_value: institutionValue,
+      },
+    });
+    snapshots.set(snapshot.id, snapshot);
+    return snapshots;
+  };
+
+  const singleAccount = (account: Account) => {
+    const accounts = new AccountDictionary();
+    accounts.set(account.id, account);
+    return accounts;
+  };
+
+  const merge = (
+    accounts: AccountDictionary,
+    accountSnapshots: AccountSnapshotDictionary,
+    holdingSnapshots: HoldingSnapshotDictionary,
+  ) =>
+    getBalanceData(
+      accounts,
+      accountSnapshots,
+      holdingSnapshots,
+      new TransactionDictionary(),
+      new InvestmentTransactionDictionary(),
+    );
+
+  test("investment: a cash-only account_balance snapshot does not override the larger holdings total", () => {
+    const account = new Account({ account_id: "inv1", type: AccountType.Investment });
+    const merged = merge(
+      singleAccount(account),
+      buildAccountSnapshots(account, 500), // cash sleeve only
+      buildHoldingSnapshots(account.id, 100_000), // holdings-inclusive total
+    );
+    // Pre-fix this returned 500 (the cratered cash-only figure).
+    expect(merged.get(account.id, readAt)).toBe(100_000);
+  });
+
+  test("investment: a holdings-inclusive account_balance snapshot still wins when it is the larger figure", () => {
+    const account = new Account({ account_id: "inv2", type: AccountType.Investment });
+    const merged = merge(
+      singleAccount(account),
+      buildAccountSnapshots(account, 100_000), // full portfolio total
+      buildHoldingSnapshots(account.id, 80_000), // stale/partial holdings
+    );
+    expect(merged.get(account.id, readAt)).toBe(100_000);
+  });
+
+  test("depository: account_balance snapshot always wins (holdings reconciliation is investment-only)", () => {
+    const account = new Account({ account_id: "dep1", type: AccountType.Depository });
+    const merged = merge(
+      singleAccount(account),
+      buildAccountSnapshots(account, 500),
+      buildHoldingSnapshots(account.id, 100_000),
+    );
+    expect(merged.get(account.id, readAt)).toBe(500);
+  });
+});

--- a/src/client/lib/hooks/calculation/accounts.ts
+++ b/src/client/lib/hooks/calculation/accounts.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { AccountType } from "plaid";
 import { getYearMonthString, LocalDate, ViewDate } from "common";
 import {
   Account,
@@ -230,7 +231,7 @@ export const getBalanceData = (
 
   const mergedData = new BalanceData();
 
-  accounts.forEach(({ id, graphOptions }) => {
+  accounts.forEach(({ id, type, graphOptions }) => {
     // Collect all available date ranges from all sources
     const ranges: ViewDate[] = [];
     const txHistory = transactionBasedData.get(id);
@@ -271,7 +272,22 @@ export const getBalanceData = (
       // 3-tier fallback: account snapshots → holding snapshots → transactions
       let balance = 0;
       if (useSnapshots && accountSnapshotBasedBalance !== undefined) {
-        balance = accountSnapshotBasedBalance;
+        // For an investment account a Plaid `account_balance` snapshot can
+        // capture only the settled-cash sleeve while the holdings-inclusive
+        // total lives in the same month's `holding` snapshot. Preferring
+        // tier 1 unconditionally lets that cash-only figure override the
+        // larger portfolio total and craters the month, so take whichever is
+        // larger — a cash-only reading must not understate the account.
+        if (
+          type === AccountType.Investment &&
+          useHoldingSnapshots &&
+          holdingSnapshotBasedBalance !== undefined &&
+          holdingSnapshotBasedBalance > accountSnapshotBasedBalance
+        ) {
+          balance = holdingSnapshotBasedBalance;
+        } else {
+          balance = accountSnapshotBasedBalance;
+        }
       } else if (useHoldingSnapshots && holdingSnapshotBasedBalance !== undefined) {
         balance = holdingSnapshotBasedBalance;
       } else if (useTransactions && transactionBasedBalance !== undefined) {

--- a/src/client/lib/hooks/calculation/accounts.ts
+++ b/src/client/lib/hooks/calculation/accounts.ts
@@ -273,11 +273,11 @@ export const getBalanceData = (
       let balance = 0;
       if (useSnapshots && accountSnapshotBasedBalance !== undefined) {
         // For an investment account a Plaid `account_balance` snapshot can
-        // capture only the settled-cash sleeve while the holdings-inclusive
+        // capture only the settled-cash sleeve, while the holdings-inclusive
         // total lives in the same month's `holding` snapshot. Preferring
-        // tier 1 unconditionally lets that cash-only figure override the
-        // larger portfolio total and craters the month, so take whichever is
-        // larger — a cash-only reading must not understate the account.
+        // tier 1 unconditionally would let that cash-only figure override the
+        // larger portfolio total, so take whichever is larger — a cash-only
+        // reading must not understate the account.
         if (
           type === AccountType.Investment &&
           useHoldingSnapshots &&


### PR DESCRIPTION
Closes #599

## Problem

On an investment account's balance graph, a historical month could **crater to a near-empty value** and immediately recover — a false V-dip misrepresenting the account as having lost almost its entire value for one month.

Root cause is the client balance-graph tier merge in `getBalanceData` (`src/client/lib/hooks/calculation/accounts.ts`). It merges three sources per month with a fixed priority — tier 1 `account_balance` snapshot, tier 2 holdings-inclusive `holding` snapshot, tier 3 transaction reconstruction — and tier 1 **always won** when present. For a brokerage, a Plaid `account_balance` snapshot commonly captures only the **settled-cash sleeve** (holdings tracked separately), so that cash-only figure overrode the correct portfolio total for the affected month.

This fires for a normal Plaid data shape (cash-only `balances.current` at snapshot time), so it's filed under the deployable-for-many-users lens (rule 13), not a one-off.

## Fix

For `type === "investment"` accounts, when both a tier-1 `account_balance` and a tier-2 `holding` snapshot exist for the month, use **whichever is larger** rather than unconditionally preferring tier 1 — a cash-only reading can no longer understate the account. Depository/credit/loan accounts are untouched (tier 1 stays authoritative; holdings reconciliation is investment-only). Respects the existing `useHoldingSnapshots` graph toggle. One conditional in the merge loop; no data-model or API change.

Tier 2 sums every holding's `institution_value` including the inferred cash holding, so it is a full portfolio total — `max(cash-only account_balance, full holdings total)` recovers the true value in the bug case and is a no-op otherwise.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx eslint` (changed files) — clean
- [x] `bun run test` — 1052 pass / 0 fail (2 skip)
- [x] **New `getBalanceData` regression coverage** (the merge previously had **zero** tests — the file documented it as "requires mocking the environment"; that note was stale, `environment` resolves to `"unknown"` under the test preload so `Dictionary.set()` works):
  - investment + cash-only tier-1 vs larger tier-2 holdings → merged month = **holdings total** (verified this test **fails on `upstream/main`** returning the cash-only figure, and passes with the fix).
  - investment + holdings-inclusive tier-1 larger than tier-2 → tier-1 still wins (proves "larger", not blind tier-2).
  - depository + both present → tier-1 wins (gate is investment-only).
- [x] **UI E2E — same-DB before/after** (sandbox DB; baseline = `upstream/main` built server pointed at the **same DB** on a spare port; login admin/sandbox; mobile 390×844; real click chain: login form → Accounts nav → the brokerage `.AccountRow` → account-detail balance graph; Jul 2026 viewDate):
  - A Chase brokerage account whose tier-1 `account_balance` snapshot sits **below** its holdings-inclusive total (equity + cash holdings composition).
  - **Baseline:** the account-detail "Jul balance" rendered the understated tier-1 figure, and the account spawned a **phantom negative "Unknown" holdings-reconciliation row** (≈ the cash-vs-holdings gap) to force the composition to match the wrong total.
  - **Fix:** the "Jul balance" renders the **holdings-inclusive total equal to the equity + cash holdings-composition sum**, and the "Unknown" plug collapses to ~`$0`.
  - Both screenshots captured on the identical DB / account / viewDate — only the built code differs. Eye-checked `/tmp/pr600-detail-{baseline,fix}.png`.
- [x] reviewoie (budget-reviewer): **approve**, 0 HIGH / 0 MED / 2 LOW (both addressed/acknowledged below).
