### PR TITLE
fix(client): keep source='manual' rows visible in TransactionsPage even at amount=0

### DIFF
--- a/src/client/pages/TransactionsPage/index.tsx
+++ b/src/client/pages/TransactionsPage/index.tsx
@@ -120,7 +120,20 @@ export const TransactionsPage = () => {
 
     if (isInvestment) {
       const filtered = investmentTransactions.filter((e) => {
-        if (!e.amount) return false;
+        // Zero-amount rows are hidden by default — they're the Plaid-side
+        // non-trade / fee-waiver / qty=0 corrections that shouldn't
+        // surface in the tx list. But manual mints from `+ Add
+        // Transaction` / `+ Add Investment Transaction` / the divergence
+        // "Add for N missing units" button all land with `amount=0`
+        // until the user edits the value on the detail page; if they
+        // abandon the mint (or it lands with just qty/price, per the
+        // divergence flow before the server-side amount derivation) the
+        // row exists in DB but has no surface to reach — the delete
+        // affordance lives on the detail page, and the user has no
+        // route back to it without the id. Keep `source='manual'` rows
+        // visible so the user always has a surface to find or delete
+        // their own work.
+        if (!e.amount && e.source !== "manual") return false;
         const hidden = accounts.get(e.account_id)?.hide;
         if (hidden) return false;
         const transactionDate = new LocalDate(e.date);
@@ -142,7 +155,15 @@ export const TransactionsPage = () => {
       });
     } else {
       const filterTransaction = (e: Transaction | SplitTransaction) => {
-        if (!e.amount) return false;
+        // Zero-amount rows are hidden by default — Plaid-side non-trade /
+        // fee-waiver / qty=0 corrections. Manual mints land with amount=0
+        // and need a surface to reach for editing or deletion (rationale
+        // duplicated from the invest branch above). SplitTransaction has
+        // no `source` field of its own — splits inherit from their parent,
+        // and splits of manual parents can't be mint-abandoned via a
+        // dedicated shell, so the manual escape doesn't apply here.
+        const isManualParent = e instanceof Transaction && e.source === "manual";
+        if (!e.amount && !isManualParent) return false;
         const hidden = accounts.get(e.account_id)?.hide;
         if (hidden) return false;
         const date = "authorized_date" in e ? e.authorized_date || e.date : e.date;


### PR DESCRIPTION
## Summary

Manual mints from `+ Add Transaction` / `+ Add Investment Transaction` / the divergence "Add for N missing units" button all land with `amount=0` at insert time — `createManualTransaction` / `createManualInvestmentTransaction` don't populate amount until the user edits the row on the detail page. `TransactionsPage.filteredAndSorted` short-circuits with `if (!e.amount) return false` on both branches, so those rows are **invisible in the transactions list until edited**.

If the user abandons the mint (mis-tap, changes their mind, closes the tab), the row lives on in the DB with no surface to reach — the delete button lives on the invtx-detail page and the user has no route back to it without the id. The Manual filter from #594 doesn't help either: the `!e.amount` guard runs before the type predicate.

## Fix

Skip the zero-amount guard for `source === 'manual'` rows on both branches. Plaid's zero-amount non-trade cruft still gets hidden; the user's own work stays visible.

- Invest branch: `if (!e.amount && e.source !== "manual") return false;`
- Cash branch: `SplitTransaction` has no `source` field — narrow to `Transaction` for the escape. Splits inherit from parent; they can't be mint-abandoned via a dedicated shell.

## Related

- Surfaced during hoiekim/budget#589 testing (Hoie added an invtx via the divergence "N missing units" button on account `LgkKbv`; the row landed in DB but was invisible on the transactions page filtered by that account).
- Complements the amount-derivation fix on #589 branch, which populates `amount = qty × price` at mint when both are provided. Together the two fixes cover: (a) mints with prefilled qty+price → amount populated → visible; (b) mints without prefill → amount=0 → visible via the manual escape here.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/client/pages/TransactionsPage` — 36 pass / 0 fail (unchanged)
- [x] Manual sandbox verification on #589 sandbox (`budget-pr-589`): user's `manual-5be51f89…` on LgkKbv with amount=0, quantity=0.6232 is currently invisible; after this fix + sync it renders in the tx list.
