### PR TITLE
fix(server): drop securities ticker-collision dedupe (closes #593 gap 2)

### DIFF
--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -661,10 +661,20 @@ export const findBenchmarkSecurityId = (
   securitySnapshots: SecuritySnapshotDictionary,
   ticker: string,
 ): string | null => {
+  // Two rows can share a ticker (user-minted + provider-synced). Pick
+  // the security_id whose snapshot chain has the freshest close so
+  // benchmark math uses the most-updated series. Falls back to first-
+  // iterating for ties on missing date (rare — snapshots always carry
+  // a date).
   let found: string | null = null;
+  let foundDate: string | null = null;
   securitySnapshots.forEach((snap) => {
-    if (found) return;
-    if (snap.security.ticker_symbol === ticker) found = snap.security.security_id;
+    if (snap.security.ticker_symbol !== ticker) return;
+    const d = snap.snapshot.date;
+    if (!found || (d && (!foundDate || d > foundDate))) {
+      found = snap.security.security_id;
+      foundDate = d ?? null;
+    }
   });
   return found;
 };

--- a/src/server/lib/compute-tools/create-snapshots.test.ts
+++ b/src/server/lib/compute-tools/create-snapshots.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+import { restoreLeaves } from "test-helpers";
+import type { JSONSecurity } from "common";
+
+const mockQuery = mock(async (_sql: string, _values?: unknown[]) => ({
+  rows: [] as unknown[],
+  rowCount: 0 as number | null,
+}));
+
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+}
+
+mock.module("pg", () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {} },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+}));
+
+const { upsertSecuritiesWithSnapshots } = await import("./create-snapshots");
+
+afterAll(restoreLeaves);
+
+beforeEach(() => {
+  mockQuery.mockClear();
+});
+
+const mkSecurity = (overrides: Partial<JSONSecurity>): JSONSecurity =>
+  ({
+    security_id: "sec-a",
+    name: "Test Security",
+    ticker_symbol: "TICK",
+    type: "equity",
+    close_price: 100,
+    close_price_as_of: "2026-07-06",
+    iso_currency_code: "USD",
+    isin: null,
+    cusip: null,
+    ...overrides,
+  }) as JSONSecurity;
+
+describe("upsertSecuritiesWithSnapshots — identity-not-ticker semantics (#593 gap 2 fix)", () => {
+  test("two securities with the same ticker but different security_ids BOTH survive", async () => {
+    const result = await upsertSecuritiesWithSnapshots([
+      mkSecurity({ security_id: "manual-voo", ticker_symbol: "VOO" }),
+      mkSecurity({ security_id: "plaid-voo", ticker_symbol: "VOO" }),
+    ]);
+    expect(result.has("manual-voo")).toBe(true);
+    expect(result.has("plaid-voo")).toBe(true);
+    expect(result.size).toBe(2);
+    // No `SELECT ... FROM securities WHERE ticker_symbol` — the caller
+    // must not look up an existing row and rewrite the incoming id.
+    const searchCalls = mockQuery.mock.calls.filter(([sql]) =>
+      /SELECT[\s\S]*FROM securities[\s\S]*ticker_symbol/i.test(sql as string),
+    );
+    expect(searchCalls.length).toBe(0);
+  });
+
+  test("skips securities without a ticker_symbol", async () => {
+    const result = await upsertSecuritiesWithSnapshots([
+      mkSecurity({ security_id: "no-ticker", ticker_symbol: null }),
+      mkSecurity({ security_id: "with-ticker", ticker_symbol: "AAPL" }),
+    ]);
+    expect(result.has("no-ticker")).toBe(false);
+    expect(result.has("with-ticker")).toBe(true);
+    expect(result.size).toBe(1);
+  });
+
+  test("skips securities without a close_price or close_price_as_of", async () => {
+    const result = await upsertSecuritiesWithSnapshots([
+      mkSecurity({ security_id: "no-price", close_price: null }),
+      mkSecurity({ security_id: "no-date", close_price_as_of: null }),
+      mkSecurity({ security_id: "ok" }),
+    ]);
+    expect(result.has("no-price")).toBe(false);
+    expect(result.has("no-date")).toBe(false);
+    expect(result.has("ok")).toBe(true);
+    expect(result.size).toBe(1);
+  });
+
+  test("returns empty set when nothing to upsert", async () => {
+    const result = await upsertSecuritiesWithSnapshots([]);
+    expect(result.size).toBe(0);
+    expect(mockQuery.mock.calls.length).toBe(0);
+  });
+
+  test("returns the same security_id the caller passed in — never rewrites onto an existing row's id", async () => {
+    // Pre-queue what a hypothetical `searchSecurities` would return if the
+    // function still ticker-searched — the collision-branch behavior would
+    // rewrite the incoming id onto whatever this row's id is. The test
+    // asserts we see the INCOMING id back, not this stale id.
+    mockQuery.mockImplementationOnce(async () => ({
+      rows: [{ security_id: "existing-old-id", ticker_symbol: "VOO", close_price_as_of: "2020-01-01" }],
+      rowCount: 1,
+    }));
+    const result = await upsertSecuritiesWithSnapshots([
+      mkSecurity({ security_id: "brand-new-id", ticker_symbol: "VOO" }),
+    ]);
+    expect(result.has("brand-new-id")).toBe(true);
+    expect(result.has("existing-old-id")).toBe(false);
+  });
+});

--- a/src/server/lib/compute-tools/create-snapshots.ts
+++ b/src/server/lib/compute-tools/create-snapshots.ts
@@ -98,26 +98,12 @@ export const upsertAndDeleteHoldingsWithSnapshots = async (
 };
 
 /**
- * Upsert incoming securities from a sync (Plaid, SimpleFin) and write a
- * per-day security snapshot for each. The incoming `security_id` is
- * treated as identity — no ticker-collision dedupe. When a user has
- * previously minted a security row for the same ticker (via
- * `/api/validate-ticker`) and Plaid later syncs its own row for the
- * same ticker, both survive as separate `securities` rows.
- *
- * That's intentional: HoldingsComposition buckets by ticker (not by
- * security_id), so the FE aggregates the two into one visual row and
- * users don't see the internal duplication. The pre-dedupe behavior
- * (`newSecurity.security_id = existingSecurity.security_id`) caused
- * an orphan-reference bug — Plaid's holdings were written with
- * Plaid's raw security_id but the securities table was rewritten
- * against the user-minted id, leaving holdings pointing at a row
- * that no longer existed. Skipping dedupe removes the bug in one
- * line.
- *
- * Returns the set of successfully-upserted `security_id`s so callers
- * (`sync-simple-fin.ts` in particular) can drop holdings whose security
- * was filtered out here (no ticker or no close price).
+ * Upsert incoming securities and write today's snapshot for each.
+ * `security_id` is treated as identity — two rows can share a ticker
+ * (user-minted + provider-synced), and `HoldingsComposition` folds them
+ * by ticker on read. Returns the set of successfully-upserted
+ * `security_id`s so callers can drop holdings whose security was
+ * filtered out here (no ticker or no close price).
  */
 export const upsertSecuritiesWithSnapshots = async (
   securities: JSONSecurity[],

--- a/src/server/lib/compute-tools/create-snapshots.ts
+++ b/src/server/lib/compute-tools/create-snapshots.ts
@@ -1,25 +1,21 @@
 import {
   JSONAccount,
   JSONAccountSnapshot,
-  getDateString,
   getSquashedDateString,
   JSONHolding,
   JSONHoldingSnapshot,
   isEqual,
   JSONSecurity,
   JSONSecuritySnapshot,
-  LocalDate,
 } from "common";
 import {
   deleteHoldings,
   MaskedUser,
-  searchSecurities,
   upsertAccounts,
   upsertHoldings,
   upsertSecurities,
   upsertSnapshots,
 } from "server";
-import { getSecurityForSymbol } from "../polygon";
 
 export const upsertAccountsWithSnapshots = async (
   user: MaskedUser,
@@ -101,60 +97,52 @@ export const upsertAndDeleteHoldingsWithSnapshots = async (
   await deleteHoldings(user, removedHoldingIds);
 };
 
-export const upsertSecuritiesWithSnapshots = async (securities: JSONSecurity[]) => {
+/**
+ * Upsert incoming securities from a sync (Plaid, SimpleFin) and write a
+ * per-day security snapshot for each. The incoming `security_id` is
+ * treated as identity — no ticker-collision dedupe. When a user has
+ * previously minted a security row for the same ticker (via
+ * `/api/validate-ticker`) and Plaid later syncs its own row for the
+ * same ticker, both survive as separate `securities` rows.
+ *
+ * That's intentional: HoldingsComposition buckets by ticker (not by
+ * security_id), so the FE aggregates the two into one visual row and
+ * users don't see the internal duplication. The pre-dedupe behavior
+ * (`newSecurity.security_id = existingSecurity.security_id`) caused
+ * an orphan-reference bug — Plaid's holdings were written with
+ * Plaid's raw security_id but the securities table was rewritten
+ * against the user-minted id, leaving holdings pointing at a row
+ * that no longer existed. Skipping dedupe removes the bug in one
+ * line.
+ *
+ * Returns the set of successfully-upserted `security_id`s so callers
+ * (`sync-simple-fin.ts` in particular) can drop holdings whose security
+ * was filtered out here (no ticker or no close price).
+ */
+export const upsertSecuritiesWithSnapshots = async (
+  securities: JSONSecurity[],
+): Promise<Set<string>> => {
   const newSecurities: JSONSecurity[] = [];
   const snapshots: JSONSecuritySnapshot[] = [];
-  const idMap: { [key: string]: string } = {};
+  const upsertedIds = new Set<string>();
 
-  const promises = securities.map(async (s) => {
-    const { security_id, ticker_symbol, close_price, close_price_as_of } = s;
-    if (!ticker_symbol) return;
-    if (!close_price || !close_price_as_of) return;
+  for (const s of securities) {
+    const { ticker_symbol, close_price, close_price_as_of } = s;
+    if (!ticker_symbol) continue;
+    if (!close_price || !close_price_as_of) continue;
 
     const newSecurity: JSONSecurity = { ...s };
-
-    const storedSecurity = await searchSecurities({ ticker_symbol });
-    if (storedSecurity.length) {
-      const existingSecurity: JSONSecurity = { ...storedSecurity[0] };
-      newSecurity.security_id = existingSecurity.security_id;
-      const snapshot_id = `${existingSecurity.security_id}-${getSquashedDateString()}`;
-
-      const existingDateString = existingSecurity.close_price_as_of;
-      const existingDate = existingDateString && new LocalDate(existingDateString);
-      if (existingDate) {
-        if (existingDate < new LocalDate(close_price_as_of)) {
-          snapshots.push({
-            snapshot: { snapshot_id, date: new Date().toISOString() },
-            security: newSecurity,
-          });
-        } else if (existingDate < new LocalDate(getDateString())) {
-          const todaySecurity = await getSecurityForSymbol(ticker_symbol);
-          if (todaySecurity) {
-            newSecurity.close_price = todaySecurity.close_price;
-            newSecurity.close_price_as_of = todaySecurity.close_price_as_of;
-            snapshots.push({
-              snapshot: { snapshot_id, date: new Date().toISOString() },
-              security: newSecurity,
-            });
-          }
-        }
-      }
-    } else {
-      const snapshot_id = `${newSecurity.security_id}-${getSquashedDateString()}`;
-      snapshots.push({
-        snapshot: { snapshot_id, date: new Date().toISOString() },
-        security: newSecurity,
-      });
-    }
+    const snapshot_id = `${newSecurity.security_id}-${getSquashedDateString()}`;
+    snapshots.push({
+      snapshot: { snapshot_id, date: new Date().toISOString() },
+      security: newSecurity,
+    });
 
     newSecurities.push(newSecurity);
-    idMap[security_id] = newSecurity.security_id;
-    return;
-  });
+    upsertedIds.add(newSecurity.security_id);
+  }
 
-  await Promise.all(promises);
   await upsertSecurities(newSecurities);
   await upsertSnapshots(snapshots);
-
-  return idMap;
+  return upsertedIds;
 };

--- a/src/server/lib/compute-tools/sync-plaid.ts
+++ b/src/server/lib/compute-tools/sync-plaid.ts
@@ -324,8 +324,15 @@ export const syncPlaidAccounts = async (item_id: string) => {
       const allHoldings = inferredCash.length ? [...holdings, ...inferredCash] : holdings;
 
       await upsertAccountsWithSnapshots(user, accounts, storedAccounts);
-      await upsertAndDeleteHoldingsWithSnapshots(user, allHoldings, storedHoldings);
+      // Upsert securities BEFORE holdings so `holdings.security_id`
+      // references a row that already exists in `securities` at every
+      // instant of the sync. `holdings` has no FK on `security_id` so
+      // reversing the order isn't a hard error — just a transient
+      // inconsistency window until `upsertSecuritiesWithSnapshots`
+      // catches up — but the securities-first order matches the
+      // sync-simple-fin.ts shape and closes #593 gap 2.
       await upsertSecuritiesWithSnapshots(securities);
+      await upsertAndDeleteHoldingsWithSnapshots(user, allHoldings, storedHoldings);
 
       return accounts;
     })

--- a/src/server/lib/compute-tools/sync-plaid.ts
+++ b/src/server/lib/compute-tools/sync-plaid.ts
@@ -324,13 +324,8 @@ export const syncPlaidAccounts = async (item_id: string) => {
       const allHoldings = inferredCash.length ? [...holdings, ...inferredCash] : holdings;
 
       await upsertAccountsWithSnapshots(user, accounts, storedAccounts);
-      // Upsert securities BEFORE holdings so `holdings.security_id`
-      // references a row that already exists in `securities` at every
-      // instant of the sync. `holdings` has no FK on `security_id` so
-      // reversing the order isn't a hard error — just a transient
-      // inconsistency window until `upsertSecuritiesWithSnapshots`
-      // catches up — but the securities-first order matches the
-      // sync-simple-fin.ts shape and closes #593 gap 2.
+      // Securities first so holdings never reference a not-yet-written
+      // securities row within the same sync.
       await upsertSecuritiesWithSnapshots(securities);
       await upsertAndDeleteHoldingsWithSnapshots(user, allHoldings, storedHoldings);
 

--- a/src/server/lib/compute-tools/sync-simple-fin.ts
+++ b/src/server/lib/compute-tools/sync-simple-fin.ts
@@ -3,7 +3,6 @@ import {
   JSONAccount,
   getDateString,
   getDateTimeString,
-  JSONHolding,
   JSONInvestmentTransaction,
   JSONItem,
   RemovedInvestmentTransaction,
@@ -66,19 +65,15 @@ export const syncSimpleFinData = async (item_id: string) => {
     startDate,
   );
 
-  // Map SimpleFin holdings onto local security_ids first; the cash
-  // inference + holding upsert run after the investment account list is
-  // built (further below), because the inference needs each account's
-  // balances.current to compute the cash delta.
-  const idMap = await upsertSecuritiesWithSnapshots(securities);
-  const mappedHoldings = holdings
-    .map((h) => {
-      const security_id = idMap[h.security_id];
-      if (!security_id) return undefined;
-      const newHolding: JSONHolding = { ...h, security_id };
-      return newHolding;
-    })
-    .filter((h): h is JSONHolding => !!h);
+  // Upsert securities first so the FE has ticker/name rows to resolve
+  // against; the cash inference + holding upsert run after the
+  // investment account list is built (further below), because the
+  // inference needs each account's balances.current to compute the
+  // cash delta. Holdings whose security was filtered out
+  // (`upsertedIds` doesn't include them — e.g. no ticker_symbol or no
+  // close_price) get dropped so we don't persist orphan references.
+  const upsertedIds = await upsertSecuritiesWithSnapshots(securities);
+  const mappedHoldings = holdings.filter((h) => upsertedIds.has(h.security_id));
 
   const investmentAccounts: JSONAccount[] = [];
   const otherAccounts: JSONAccount[] = [];

--- a/src/server/lib/postgres/repositories/securities.ts
+++ b/src/server/lib/postgres/repositories/securities.ts
@@ -53,7 +53,11 @@ export const searchSecurities = async (
   if (options.ticker_symbol) filters.ticker_symbol = options.ticker_symbol;
   if (options.name) filters.name = options.name;
 
-  const models = await securitiesTable.query(filters);
+  // `updated DESC` gives a stable pick when multiple rows share a
+  // ticker (see `create-snapshots.ts` — `security_id` is identity, not
+  // ticker). Callers that take `.securities[0]` reliably get the most
+  // recently-touched row.
+  const models = await securitiesTable.query(filters, { orderBy: "updated DESC" });
   return models.map((m) => m.toJSON());
 };
 


### PR DESCRIPTION
## Summary

Root cause of #593 gap 2: `upsertSecuritiesWithSnapshots` deduped incoming securities against existing rows on `ticker_symbol`, rewriting the incoming `security_id` to the existing (user-minted) canonical id BEFORE the securities upsert. But holdings were already written with Plaid's raw `security_id`, so `holdings.security_id` referenced a row that no longer existed in `securities` — orphan reference. For any user with a user-minted security (via `/api/validate-ticker`) that later shows up in a Plaid sync, the holding renders with a truncated `security_id` instead of the ticker/name, MWR's snapshot-price lookups miss, and the divergence detection (#589) can't line the holding up with the user's manual invtxs.

## Fix

Skip the dedupe. Every incoming `security_id` becomes its own row. A user-minted row and a provider's row for the same ticker both survive as separate `securities` rows.

Why that's safe:
- `HoldingsComposition` buckets by `ticker_symbol`, not `security_id`. Both rows fold into ONE visible bucket with the aggregate qty and value the user actually holds. No visible duplication.
- MWR's per-security `valueAt` / cash-flow extraction runs independently for each `security_id` and sums into the portfolio total.
- Divergence detection (#589) is per-security. The user-minted row vs user's manual invtxs and the provider's row vs provider invtxs each compute independently.
- No FK on `securities.security_id`; no uniqueness constraint on `ticker_symbol`. The DB allows two rows with the same ticker.

What we accept:
- `securities` denormalized. A query filtered by `ticker_symbol` returns two rows for users hitting this overlap. Not a data-quality issue, just untidy.
- Two parallel `security_snapshots` chains (one per security_id), both refreshed by the scheduled security-snapshot cron.

## Related

- Supersedes closed #598 (which took a heavier approach: DB remap + atomic tx + advisory locks). Discussion in the "Budget holdings UI" Discord thread landed on the simpler drop-dedupe shape.
- Also reorders `sync-plaid.ts` to write securities BEFORE holdings (matches `sync-simple-fin.ts`).
- `upsertSecuritiesWithSnapshots` return shape changed from `{ incomingId → canonicalId }` idMap to `Set<string>` of successfully-upserted security_ids. `sync-simple-fin.ts` filters holdings by that set to drop holdings whose security was skipped (no ticker_symbol / no close_price).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun --bun eslint src` — clean
- [x] `bun test src/server` — 693 pass / 2 skip / 0 fail
- [ ] Sandbox UI verification: cold-load an account with the manual + provider overlap, confirm HoldingsComposition renders one ticker row with the aggregated qty from both, and the widget's MWR / divergence detection resolves the ticker/name correctly.
