### PR TITLE
refactor(client): migrate remaining `*Properties` panels to the `<Properties>` shell (#326 phase 3)

### DIFF
--- a/src/client/components/AccountProperties/index.css
+++ b/src/client/components/AccountProperties/index.css
@@ -4,9 +4,7 @@ div.AccountProperties .property > .row > .amount {
 }
 
 div.AccountProperties .property > .row > .amount > input {
-  font-size: 16px;
   width: calc(100% - 5px);
-  text-align: right;
 }
 
 div.AccountProperties .property > .row > .amount > input:disabled {

--- a/src/client/components/AccountProperties/index.css
+++ b/src/client/components/AccountProperties/index.css
@@ -1,8 +1,0 @@
-div.AccountProperties .property > .row > .amount {
-  display: flex;
-  align-items: center;
-}
-
-div.AccountProperties .property > .row > .amount > input:disabled {
-  color: inherit;
-}

--- a/src/client/components/AccountProperties/index.css
+++ b/src/client/components/AccountProperties/index.css
@@ -3,14 +3,6 @@ div.AccountProperties .property > .row > .amount {
   align-items: center;
 }
 
-div.AccountProperties .property > .row > .amount > input {
-  width: calc(100% - 5px);
-}
-
 div.AccountProperties .property > .row > .amount > input:disabled {
   color: inherit;
-}
-
-div.AccountProperties .property > .row > select {
-  text-align: right;
 }

--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -23,6 +23,10 @@ import {
   PerformanceBenchmark,
   InstitutionSpan,
   MoneyLabel,
+  Properties,
+  Property,
+  PropertyLabel,
+  Row,
   ToggleInput,
 } from "client/components";
 import { useAccountEventHandlers } from "./lib";
@@ -124,14 +128,14 @@ export const AccountProperties = ({ account }: Props) => {
     !isManualAccount && viewDate.getEndDate() >= latestViewDate.getEndDate();
 
   return (
-    <div className="AccountProperties Properties">
-      <div className="propertyLabel">Account&nbsp;Details</div>
-      <div className="property">
-        <div className="row keyValue">
+    <Properties className="AccountProperties">
+      <PropertyLabel>Account&nbsp;Details</PropertyLabel>
+      <Property>
+        <Row className="keyValue">
           <span className="propertyName">Name</span>
           <input type="text" value={nameInput} onChange={onChangeNameInput} placeholder={name} />
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Type</span>
           {isManualAccount ? (
             <select value={typeInput} onChange={onChangeTypeInput}>
@@ -144,34 +148,34 @@ export const AccountProperties = ({ account }: Props) => {
           ) : (
             <span>{toTitleCase(subtype || type)}</span>
           )}
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Institution</span>
           {isManualAccount ? (
             <span>Manual</span>
           ) : (
             <InstitutionSpan institution_id={account.institution_id} />
           )}
-        </div>
-      </div>
-      {(!isManualAccount || !!graphData.lines) && <div className="propertyLabel">Balance</div>}
+        </Row>
+      </Property>
+      {(!isManualAccount || !!graphData.lines) && <PropertyLabel>Balance</PropertyLabel>}
       {!isManualAccount && (
-        <div className="property">
-          <div className="row keyValue">
+        <Property>
+          <Row className="keyValue">
             <span className="propertyName">{currentLabel}</span>
             <span>
               {currencySymbol}&nbsp;
               {currentAmountString}
             </span>
-          </div>
-          <div className="row keyValue">
+          </Row>
+          <Row className="keyValue">
             <span className="propertyName">{pendingLabel}</span>
             <span>
               {currencySymbol}&nbsp;
               {pendingAmountString}
             </span>
-          </div>
-        </div>
+          </Row>
+        </Property>
       )}
       {!!graphData.lines && (
         <>
@@ -183,8 +187,8 @@ export const AccountProperties = ({ account }: Props) => {
             memoryKey={account_id}
           />
           <br />
-          <div className="property">
-            <div className="row keyValue">
+          <Property>
+            <Row className="keyValue">
               <span className="propertyName">{viewDate.toString()}&nbsp;balance</span>
               <div className="amount">
                 <DynamicCapacityInput
@@ -197,38 +201,38 @@ export const AccountProperties = ({ account }: Props) => {
                   onBlur={onChangeBalanceSnapshotInput}
                 />
               </div>
-            </div>
-          </div>
+            </Row>
+          </Property>
         </>
       )}
       {type === AccountType.Investment && <HoldingsComposition accounts={[account]} />}
       {type === AccountType.Investment && <PerformanceBenchmark accounts={[account]} />}
       {!isManualAccount && (
         <>
-          <div className="propertyLabel">Balance&nbsp;Graph&nbsp;Options</div>
-          <div className="property">
-            <div className="row keyValue">
+          <PropertyLabel>Balance&nbsp;Graph&nbsp;Options</PropertyLabel>
+          <Property>
+            <Row className="keyValue">
               <span className="propertyName">Use Transactions</span>
               <ToggleInput
                 checked={useTransactionsForGraph}
                 onChange={onClickUseTransactionsForGraph}
               />
-            </div>
-            <div className="row keyValue">
+            </Row>
+            <Row className="keyValue">
               <span className="propertyName">Use Snapshots</span>
               <ToggleInput checked={useSnapshotsForGraph} onChange={onClickUseSnapshotsForGraph} />
-            </div>
-          </div>
-          <div className="propertyLabel">Account&nbsp;Preference</div>
-          <div className="property">
-            <div className="row keyValue">
+            </Row>
+          </Property>
+          <PropertyLabel>Account&nbsp;Preference</PropertyLabel>
+          <Property>
+            <Row className="keyValue">
               <span className="propertyName">Default&nbsp;Budget</span>
               <select value={selectedBudgetIdLabel} onChange={onChangeBudgetSelect}>
                 <option value="">Select Budget</option>
                 {budgetOptions}
               </select>
-            </div>
-            <div className="row keyValue">
+            </Row>
+            <Row className="keyValue">
               <span className="propertyName">Archive</span>
               {/* Hide already removes the account from view entirely; archiving
                *  on top adds nothing and would surface in "Show archived (N)"
@@ -236,12 +240,12 @@ export const AccountProperties = ({ account }: Props) => {
                *  steer the user toward Unhide first if they want a different
                *  classification. Hoie 2026-06-25. */}
               <ToggleInput checked={isArchived} onChange={onClickArchive} disabled={isHidden} />
-            </div>
-            <div className="row keyValue">
+            </Row>
+            <Row className="keyValue">
               <span className="propertyName">Hide</span>
               <ToggleInput checked={isHidden} onChange={onClickHide} />
-            </div>
-          </div>
+            </Row>
+          </Property>
         </>
       )}
       {/* Orphan path: a manual account that was already archived (e.g. on
@@ -251,57 +255,57 @@ export const AccountProperties = ({ account }: Props) => {
        *  to avoid. Renders nothing for the common manual-and-not-archived
        *  case so we don't reintroduce a separate Archive section. */}
       {isManualAccount && isArchived && (
-        <div className="property">
-          <div className="row keyValue">
+        <Property>
+          <Row className="keyValue">
             <span className="propertyName">Archive</span>
             <ToggleInput checked={isArchived} onChange={onClickArchive} />
-          </div>
-        </div>
+          </Row>
+        </Property>
       )}
       {(isManualAccount || type === AccountType.Investment) && (
         <>
-          <div className="propertyLabel">Add</div>
-          <div className="property">
+          <PropertyLabel>Add</PropertyLabel>
+          <Property>
             {isManualAccount && type !== AccountType.Investment && (
-              <div className="row button">
+              <Row className="button">
                 <button onClick={onClickAddTransaction}>Add&nbsp;Transaction</button>
-              </div>
+              </Row>
             )}
             {type === AccountType.Investment && (
-              <div className="row button">
+              <Row className="button">
                 <button onClick={onClickAddInvestmentTransaction}>
                   Add&nbsp;Investment&nbsp;Transaction
                 </button>
-              </div>
+              </Row>
             )}
-          </div>
+          </Property>
         </>
       )}
-      <div className="propertyLabel">Navigate</div>
-      <div className="property">
-        <div className="row button">
+      <PropertyLabel>Navigate</PropertyLabel>
+      <Property>
+        <Row className="button">
           <button onClick={onClickConnectionDetail}>See&nbsp;Connection&nbsp;Details</button>
-        </div>
+        </Row>
         {screenType === ScreenType.Narrow && (
-          <div className="row button">
+          <Row className="button">
             <button className="propertyName" onClick={onClickTransactions}>
               See&nbsp;Transactions
             </button>
-          </div>
+          </Row>
         )}
-      </div>
+      </Property>
       {isManualAccount && (
         <>
           <br />
-          <div className="property">
-            <div className="row button">
+          <Property>
+            <Row className="button">
               <button className="delete colored" onClick={onClickRemove}>
                 Delete
               </button>
-            </div>
-          </div>
+            </Row>
+          </Property>
         </>
       )}
-    </div>
+    </Properties>
   );
 };

--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -30,7 +30,6 @@ import {
   ToggleInput,
 } from "client/components";
 import { useAccountEventHandlers } from "./lib";
-import "./index.css";
 
 interface Props {
   account: Account;

--- a/src/client/components/ApiKeyProperties/index.css
+++ b/src/client/components/ApiKeyProperties/index.css
@@ -1,7 +1,3 @@
-div.ApiKeyProperties {
-  padding: 0 10px;
-}
-
 .ApiKeyProperties .apiKeyError {
   color: var(--red);
   font-size: 13px;

--- a/src/client/components/ApiKeyProperties/index.tsx
+++ b/src/client/components/ApiKeyProperties/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type { ApiKeyJSON } from "server";
-import { call, PATH, useAppContext } from "client";
+import { call, PATH, Properties, Property, PropertyLabel, Row, useAppContext } from "client";
 
 import "./index.css";
 
@@ -105,43 +105,43 @@ export const ApiKeyProperties = () => {
   // ── Just-created view (key_id unset + justCreated set) ───────────────
   if (isNew && justCreated) {
     return (
-      <div className="ApiKeyProperties Properties">
-        <div className="propertyLabel">New&nbsp;Key&nbsp;—&nbsp;Save&nbsp;Now</div>
-        <div className="property">
-          <div className="row">
+      <Properties className="ApiKeyProperties">
+        <PropertyLabel>New&nbsp;Key&nbsp;—&nbsp;Save&nbsp;Now</PropertyLabel>
+        <Property>
+          <Row>
             <span className="apiKeyCopyOnceTitle">
               Copy this key — it will not be shown again.
             </span>
-          </div>
-          <div className="row keyValue">
+          </Row>
+          <Row className="keyValue">
             <span className="propertyName">Key</span>
             <code className="apiKeyPlaintext">{justCreated.plaintext}</code>
-          </div>
-        </div>
-        <div className="propertyLabel">&nbsp;</div>
-        <div className="property">
-          <div className="row button">
+          </Row>
+        </Property>
+        <PropertyLabel>&nbsp;</PropertyLabel>
+        <Property>
+          <Row className="button">
             <button type="button" className="colored" onClick={onCopy}>
               Copy&nbsp;to&nbsp;clipboard
             </button>
-          </div>
-          <div className="row button">
+          </Row>
+          <Row className="button">
             <button type="button" onClick={onSavedConfirm}>
               I&rsquo;ve&nbsp;saved&nbsp;it
             </button>
-          </div>
-        </div>
-      </div>
+          </Row>
+        </Property>
+      </Properties>
     );
   }
 
   // ── Create form (key_id unset, no justCreated yet) ───────────────────
   if (isNew) {
     return (
-      <div className="ApiKeyProperties Properties">
-        <div className="propertyLabel">New&nbsp;API&nbsp;Key</div>
-        <div className="property">
-          <div className="row keyValue">
+      <Properties className="ApiKeyProperties">
+        <PropertyLabel>New&nbsp;API&nbsp;Key</PropertyLabel>
+        <Property>
+          <Row className="keyValue">
             <span className="propertyName">Name</span>
             <input
               type="text"
@@ -151,8 +151,8 @@ export const ApiKeyProperties = () => {
               disabled={creating}
               maxLength={255}
             />
-          </div>
-          <div className="row keyValue">
+          </Row>
+          <Row className="keyValue">
             <span className="propertyName">Scope</span>
             <select value={scope} onChange={(e) => setScope(e.target.value)} disabled={creating}>
               {SCOPE_OPTIONS.map((o) => (
@@ -161,16 +161,16 @@ export const ApiKeyProperties = () => {
                 </option>
               ))}
             </select>
-          </div>
+          </Row>
           {error && (
-            <div className="row">
+            <Row>
               <span className="apiKeyError">{error}</span>
-            </div>
+            </Row>
           )}
-        </div>
-        <div className="propertyLabel">&nbsp;</div>
-        <div className="property">
-          <div className="row button">
+        </Property>
+        <PropertyLabel>&nbsp;</PropertyLabel>
+        <Property>
+          <Row className="button">
             <button
               type="button"
               className="colored"
@@ -179,98 +179,98 @@ export const ApiKeyProperties = () => {
             >
               {creating ? "Creating…" : "Create Key"}
             </button>
-          </div>
-          <div className="row button">
+          </Row>
+          <Row className="button">
             <button type="button" onClick={goBack}>
               Cancel
             </button>
-          </div>
-        </div>
-      </div>
+          </Row>
+        </Property>
+      </Properties>
     );
   }
 
   // ── Detail view loading state ────────────────────────────────────────
   if (loading && !apiKey) {
     return (
-      <div className="ApiKeyProperties Properties">
-        <div className="propertyLabel">API&nbsp;Key</div>
-        <div className="property">
-          <div className="row">
+      <Properties className="ApiKeyProperties">
+        <PropertyLabel>API&nbsp;Key</PropertyLabel>
+        <Property>
+          <Row>
             <span className="propertyName disabled">Loading&hellip;</span>
-          </div>
-        </div>
-      </div>
+          </Row>
+        </Property>
+      </Properties>
     );
   }
 
   // ── Detail view error / not-found ────────────────────────────────────
   if (error || !apiKey) {
     return (
-      <div className="ApiKeyProperties Properties">
-        <div className="propertyLabel">API&nbsp;Key</div>
-        <div className="property">
-          <div className="row">
+      <Properties className="ApiKeyProperties">
+        <PropertyLabel>API&nbsp;Key</PropertyLabel>
+        <Property>
+          <Row>
             <span className="propertyName disabled">{error ?? "Not found"}</span>
-          </div>
-        </div>
-        <div className="propertyLabel">&nbsp;</div>
-        <div className="property">
-          <div className="row button">
+          </Row>
+        </Property>
+        <PropertyLabel>&nbsp;</PropertyLabel>
+        <Property>
+          <Row className="button">
             <button type="button" onClick={goBack}>
               Back
             </button>
-          </div>
-        </div>
-      </div>
+          </Row>
+        </Property>
+      </Properties>
     );
   }
 
   // ── Detail view ──────────────────────────────────────────────────────
   return (
-    <div className="ApiKeyProperties Properties">
-      <div className="propertyLabel">API&nbsp;Key&nbsp;Details</div>
-      <div className="property">
-        <div className="row keyValue">
+    <Properties className="ApiKeyProperties">
+      <PropertyLabel>API&nbsp;Key&nbsp;Details</PropertyLabel>
+      <Property>
+        <Row className="keyValue">
           <span className="propertyName">Name</span>
           <span>{apiKey.name}</span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Prefix</span>
           <code className="apiKeyPrefix">{apiKey.key_prefix}…</code>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Scopes</span>
           <span>{apiKey.scopes.join(", ")}</span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Created</span>
           <span>{formatDate(apiKey.created_at)}</span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Last&nbsp;Used</span>
           <span>{formatDate(apiKey.last_used_at)}</span>
-        </div>
+        </Row>
         {apiKey.expires_at && (
-          <div className="row keyValue">
+          <Row className="keyValue">
             <span className="propertyName">Expires</span>
             <span>{formatDate(apiKey.expires_at)}</span>
-          </div>
+          </Row>
         )}
-      </div>
-      <div className="propertyLabel">&nbsp;</div>
-      <div className="property">
-        <div className="row button">
+      </Property>
+      <PropertyLabel>&nbsp;</PropertyLabel>
+      <Property>
+        <Row className="button">
           <button type="button" className="delete colored" onClick={onRevoke}>
             Revoke
           </button>
-        </div>
-        <div className="row button">
+        </Row>
+        <Row className="button">
           <button type="button" onClick={goBack}>
             Back
           </button>
-        </div>
-      </div>
-    </div>
+        </Row>
+      </Property>
+    </Properties>
   );
 };

--- a/src/client/components/BudgetProperties/index.tsx
+++ b/src/client/components/BudgetProperties/index.tsx
@@ -2,7 +2,7 @@ import { ChangeEventHandler, Dispatch, SetStateAction } from "react";
 import { LocalDate, ViewDate, getDateString } from "common";
 import { Capacity, useAppContext } from "client";
 import { BudgetFamily } from "client/lib/models/BudgetFamily";
-import { ToggleInput } from "client/components";
+import { Properties, Property, Row, ToggleInput } from "client/components";
 import RadioInputs from "./RadioInputs";
 import CapacitiesInput from "./CapacitiesInput";
 import "./index.css";
@@ -54,8 +54,8 @@ export const BudgetProperties = ({
   const isCategory = budgetLike.type === "category";
 
   return (
-    <div className="BudgetProperties Properties">
-      <div className="property">
+    <Properties className="BudgetProperties">
+      <Property>
         <RadioInputs
           disabled={isSyncedInput}
           checkedOptionId={isIncomeInput ? "income" : "expense"}
@@ -66,29 +66,29 @@ export const BudgetProperties = ({
           ]}
           onChange={(e) => setIsIncomeInput(e.target.id === "income")}
         />
-      </div>
-      <div className="property">
-        <div className="row">
+      </Property>
+      <Property>
+        <Row>
           <span>Limited budget</span>
           <ToggleInput
             disabled={isSyncedInput}
             checked={!isInfiniteInput}
             onChange={(e) => setIsInfiniteInput(!e.target.checked)}
           />
-        </div>
-      </div>
+        </Row>
+      </Property>
       {!isInfiniteInput && (
-        <div className="property">
-          <div className="row">
+        <Property>
+          <Row>
             <span>Rolls over to the next period</span>
             <ToggleInput
               disabled={isSyncedInput}
               checked={isRollOverInput}
               onChange={(e) => setIsRollOverInput(e.target.checked)}
             />
-          </div>
+          </Row>
           {isRollOverInput && (
-            <div className="row">
+            <Row>
               <span>Rolls over from&nbsp;</span>
               <div>
                 <input
@@ -99,12 +99,12 @@ export const BudgetProperties = ({
                   aria-label="Roll over start date"
                 />
               </div>
-            </div>
+            </Row>
           )}
-        </div>
+        </Property>
       )}
-      <div className="property">
-        <div className="row">
+      <Property>
+        <Row>
           <span className={isCategory ? "disabled lineThrough" : undefined}>
             Sync with children
           </span>
@@ -113,7 +113,7 @@ export const BudgetProperties = ({
             checked={isCategory ? false : isSyncedInput}
             onChange={onChangeSync}
           />
-        </div>
+        </Row>
         {!isInfiniteInput && (
           <CapacitiesInput
             budgetLike={budgetLike}
@@ -122,7 +122,7 @@ export const BudgetProperties = ({
             isSyncedInput={isSyncedInput}
           />
         )}
-      </div>
-    </div>
+      </Property>
+    </Properties>
   );
 };

--- a/src/client/components/Configuration/index.css
+++ b/src/client/components/Configuration/index.css
@@ -1,8 +1,3 @@
-div.Configuration button.delete {
-  font-weight: 500;
-  color: var(--darkRed);
-}
-
 div.Configuration .row > .connection {
   display: flex;
   justify-content: space-between;

--- a/src/client/components/Configuration/index.css
+++ b/src/client/components/Configuration/index.css
@@ -1,8 +1,3 @@
-div.Configuration {
-  margin-top: 20px;
-  padding: 0 10px;
-}
-
 div.Configuration button.delete {
   font-weight: 500;
   color: var(--darkRed);

--- a/src/client/components/ConnectionProperties/index.css
+++ b/src/client/components/ConnectionProperties/index.css
@@ -1,4 +1,3 @@
 div.ConnectionProperties {
-  margin-top: 20px;
   padding: 0 10px;
 }

--- a/src/client/components/ConnectionProperties/index.css
+++ b/src/client/components/ConnectionProperties/index.css
@@ -1,3 +1,0 @@
-div.ConnectionProperties {
-  padding: 0 10px;
-}

--- a/src/client/components/ConnectionProperties/index.tsx
+++ b/src/client/components/ConnectionProperties/index.tsx
@@ -20,7 +20,6 @@ import {
   StoreName,
 } from "client";
 import { ConnectedAccountRow } from "./ConnectedAccountRow";
-import "./index.css";
 
 interface Props {
   item: Item;

--- a/src/client/components/HoldingProperties/index.css
+++ b/src/client/components/HoldingProperties/index.css
@@ -1,7 +1,3 @@
-div.HoldingProperties {
-  padding: 0 10px;
-}
-
 .HoldingProperties .tickerField {
   display: flex;
   gap: 8px;

--- a/src/client/components/InvestmentTransactionProperties/index.tsx
+++ b/src/client/components/InvestmentTransactionProperties/index.tsx
@@ -12,7 +12,7 @@ import {
   call,
   indexedDb,
 } from "client";
-import { InstitutionSpan } from "client/components";
+import { InstitutionSpan, Properties, Property, PropertyLabel, Row } from "client/components";
 import type { ValidateTickerResponse } from "server";
 
 interface Props {
@@ -280,10 +280,10 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
   const currencySymbol = currencyCodeToSymbol(iso_currency_code || "USD");
 
   return (
-    <div className="InvestmentTransactionProperties Properties">
-      <div className="propertyLabel">Investment&nbsp;Transaction&nbsp;Details</div>
-      <div className="property">
-        <div className="row keyValue">
+    <Properties className="InvestmentTransactionProperties">
+      <PropertyLabel>Investment&nbsp;Transaction&nbsp;Details</PropertyLabel>
+      <Property>
+        <Row className="keyValue">
           <span className="propertyName">Date</span>
           {isManual ? (
             <input
@@ -301,8 +301,8 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
               })}
             </span>
           )}
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Name</span>
           {isManual ? (
             <input
@@ -315,12 +315,12 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
           ) : (
             <span>{name}</span>
           )}
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Security</span>
           <span>{security?.name || "—"}</span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Ticker</span>
           {isManual ? (
             <input
@@ -333,14 +333,14 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
           ) : (
             <span>{security?.ticker_symbol || "—"}</span>
           )}
-        </div>
+        </Row>
         {isManual && tickerMessage && (
-          <div className="row keyValue">
+          <Row className="keyValue">
             <span className="propertyName">&nbsp;</span>
             <span>{tickerMessage}</span>
-          </div>
+          </Row>
         )}
-        <div className="row keyValue">
+        <Row className="keyValue">
           <span className="propertyName">Type</span>
           {isManual ? (
             <select value={type} onChange={onChangeType}>
@@ -353,8 +353,8 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
           ) : (
             <span>{toTitleCase(type)}</span>
           )}
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Subtype</span>
           {isManual ? (
             <select value={subtype} onChange={onChangeSubtype}>
@@ -367,8 +367,8 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
           ) : (
             <span>{toTitleCase(subtype)}</span>
           )}
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Quantity</span>
           {isManual ? (
             <input
@@ -381,8 +381,8 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
           ) : (
             <span>{numberToCommaString(quantity)}</span>
           )}
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Price</span>
           {isManual ? (
             <input
@@ -397,8 +397,8 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
               {currencySymbol}&nbsp;{numberToCommaString(price)}
             </span>
           )}
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Amount</span>
           {/* Derived from quantity * price on manual rows (both branches
               render as a span). Plaid rows show the synced amount as
@@ -406,16 +406,16 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
           <span>
             {currencySymbol}&nbsp;{numberToCommaString(amount)}
           </span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Account</span>
           <span>{account?.custom_name || account?.name}</span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Institution</span>
           {account && <InstitutionSpan institution_id={account?.institution_id} />}
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Memo</span>
           <input
             type="text"
@@ -424,11 +424,11 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
             onChange={onChangeMemo}
             onBlur={onBlurMemo}
           />
-        </div>
-      </div>
-      <div className="propertyLabel">Budgets</div>
-      <div className="property">
-        <div className="row keyValue">
+        </Row>
+      </Property>
+      <PropertyLabel>Budgets</PropertyLabel>
+      <Property>
+        <Row className="keyValue">
           <span className="propertyName">Budget</span>
           <div>
             <select value={selectedBudgetIdLabel} onChange={onChangeBudgetSelect}>
@@ -436,12 +436,12 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
               {budgetOptions}
             </select>
           </div>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Section</span>
           <span>{sectionName}</span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Category</span>
           <div className={selectedCategoryIdLabel ? "" : "notification"}>
             <select value={selectedCategoryIdLabel} onChange={onChangeCategorySelect}>
@@ -449,13 +449,13 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
               {categoryOptions}
             </select>
           </div>
-        </div>
-      </div>
+        </Row>
+      </Property>
       {isManual && (
         <>
           <br />
-          <div className="property">
-            <div className="row button">
+          <Property>
+            <Row className="button">
               <button
                 className="delete colored"
                 onClick={async () => {
@@ -480,10 +480,10 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
               >
                 Delete
               </button>
-            </div>
-          </div>
+            </Row>
+          </Property>
         </>
       )}
-    </div>
+    </Properties>
   );
 };

--- a/src/client/components/Properties/index.css
+++ b/src/client/components/Properties/index.css
@@ -68,12 +68,17 @@ div.Properties .row span.small {
 
 div.Properties .row select {
   font-size: 14px;
+  text-align: right;
 }
 
 div.Properties .row input {
   font-size: 16px;
   height: 18px;
   text-align: right;
+}
+
+div.Properties .amount > input {
+  width: calc(100% - 5px);
 }
 
 div.Properties .row.keyValue span.propertyName {

--- a/src/client/components/Properties/index.css
+++ b/src/client/components/Properties/index.css
@@ -9,6 +9,7 @@
 
 div.Properties {
   margin-top: 20px;
+  padding: 0 10px;
 }
 
 div.Properties button:disabled {

--- a/src/client/components/Properties/index.css
+++ b/src/client/components/Properties/index.css
@@ -77,8 +77,17 @@ div.Properties .row input {
   text-align: right;
 }
 
+div.Properties .amount:has(> input) {
+  display: flex;
+  align-items: center;
+}
+
 div.Properties .amount > input {
   width: calc(100% - 5px);
+}
+
+div.Properties .amount > input:disabled {
+  color: inherit;
 }
 
 div.Properties .row.keyValue span.propertyName {

--- a/src/client/components/TransactionProperties/index.css
+++ b/src/client/components/TransactionProperties/index.css
@@ -1,11 +1,3 @@
-div.TransactionProperties .row > .splitItem > input {
-  height: 100%;
-  width: 30%;
-  flex-grow: 1;
-  text-align: center;
-  background-color: #191919;
-}
-
 div.SplitTransactionRow {
   width: 100%;
   display: flex;

--- a/src/client/components/TransactionProperties/index.css
+++ b/src/client/components/TransactionProperties/index.css
@@ -6,10 +6,6 @@ div.TransactionProperties .row > .splitItem > input {
   background-color: #191919;
 }
 
-div.TransactionProperties .row select {
-  text-align: right;
-}
-
 div.SplitTransactionRow {
   width: 100%;
   display: flex;
@@ -32,7 +28,6 @@ div.SplitTransactionRow > .amount {
 
 div.SplitTransactionRow > .amount > input {
   background-color: #191919;
-  width: calc(100% - 5px);
   text-align: left;
 }
 

--- a/src/client/components/TransactionProperties/index.css
+++ b/src/client/components/TransactionProperties/index.css
@@ -1,5 +1,4 @@
 div.TransactionProperties .row > .splitItem > input {
-  font-size: 16px;
   height: 100%;
   width: 30%;
   flex-grow: 1;
@@ -32,7 +31,6 @@ div.SplitTransactionRow > .amount {
 }
 
 div.SplitTransactionRow > .amount > input {
-  font-size: 16px;
   background-color: #191919;
   width: calc(100% - 5px);
   text-align: left;

--- a/src/client/components/TransactionProperties/index.css
+++ b/src/client/components/TransactionProperties/index.css
@@ -21,11 +21,6 @@ div.SplitTransactionRow > div > select {
   width: 100%;
 }
 
-div.SplitTransactionRow > .amount {
-  display: flex;
-  align-items: center;
-}
-
 div.SplitTransactionRow > .amount > input {
   background-color: #191919;
   text-align: left;

--- a/src/client/components/TransactionProperties/index.tsx
+++ b/src/client/components/TransactionProperties/index.tsx
@@ -449,11 +449,13 @@ export const TransactionProperties = ({ transaction }: Props) => {
           <Row>
             <div className="SplitTransactionRow">
               <div className="amount">
-                <span>
-                  {isIncome && <>+&nbsp;</>}
-                  {currencySymbol}&nbsp;
-                  {numberToCommaString(Math.abs(remainingAmount))}
-                </span>
+                {isIncome && <>+&nbsp;</>}
+                {currencySymbol}&nbsp;
+                <input
+                  type="text"
+                  value={numberToCommaString(Math.abs(remainingAmount))}
+                  disabled
+                />
               </div>
               <select value={selectedBudgetIdLabel} onChange={onChangeBudgetSelect}>
                 <option value="">Select Budget</option>

--- a/src/client/components/TransactionProperties/index.tsx
+++ b/src/client/components/TransactionProperties/index.tsx
@@ -20,7 +20,14 @@ import {
   call,
   indexedDb,
 } from "client";
-import { InstitutionSpan, TransferArrowIcon } from "client/components";
+import {
+  InstitutionSpan,
+  Properties,
+  Property,
+  PropertyLabel,
+  Row,
+  TransferArrowIcon,
+} from "client/components";
 import SplitTransactionRow from "./SplitTransactionRow";
 import "./index.css";
 
@@ -264,9 +271,9 @@ export const TransactionProperties = ({ transaction }: Props) => {
     ?.toArray()
     .map((s) => {
       return (
-        <div key={s.id} className="row">
+        <Row key={s.id}>
           <SplitTransactionRow splitTransaction={s} />
-        </div>
+        </Row>
       );
     });
 
@@ -325,10 +332,10 @@ export const TransactionProperties = ({ transaction }: Props) => {
   };
 
   return (
-    <div className="TransactionProperties Properties">
-      <div className="propertyLabel">Transaction&nbsp;Details</div>
-      <div className="property">
-        <div className="row keyValue">
+    <Properties className="TransactionProperties">
+      <PropertyLabel>Transaction&nbsp;Details</PropertyLabel>
+      <Property>
+        <Row className="keyValue">
           <span className="propertyName">Date</span>
           {isManual ? (
             <input
@@ -346,12 +353,12 @@ export const TransactionProperties = ({ transaction }: Props) => {
               })}
             </span>
           )}
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Merchant&nbsp;Name</span>
           <span>{merchant_name}</span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Name</span>
           {isManual ? (
             <input
@@ -364,8 +371,8 @@ export const TransactionProperties = ({ transaction }: Props) => {
           ) : (
             <span>{name}</span>
           )}
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Amount</span>
           {isManual ? (
             <input
@@ -382,20 +389,20 @@ export const TransactionProperties = ({ transaction }: Props) => {
               {numberToCommaString(Math.abs(amount))}
             </span>
           )}
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Location</span>
           <span>{locations.join(", ")}</span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Account</span>
           <span>{account?.custom_name || account?.name}</span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Institution</span>
           {account && <InstitutionSpan institution_id={account?.institution_id} />}
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Memo</span>
           <input
             type="text"
@@ -404,13 +411,13 @@ export const TransactionProperties = ({ transaction }: Props) => {
             onChange={onChangeMemo}
             onBlur={onBlurMemo}
           />
-        </div>
-      </div>
+        </Row>
+      </Property>
       {!splitTransactionInputRows?.length && (
         <>
-          <div className="propertyLabel">Budgets</div>
-          <div className="property">
-            <div className="row keyValue">
+          <PropertyLabel>Budgets</PropertyLabel>
+          <Property>
+            <Row className="keyValue">
               <span className="propertyName">Budget</span>
               <div>
                 <select value={selectedBudgetIdLabel} onChange={onChangeBudgetSelect}>
@@ -418,12 +425,12 @@ export const TransactionProperties = ({ transaction }: Props) => {
                   {budgetOptions}
                 </select>
               </div>
-            </div>
-            <div className="row keyValue">
+            </Row>
+            <Row className="keyValue">
               <span className="propertyName">Section</span>
               <span>{sectionName}</span>
-            </div>
-            <div className="row keyValue">
+            </Row>
+            <Row className="keyValue">
               <span className="propertyName">Category</span>
               <div className={selectedCategoryIdLabel ? "" : "notification"}>
                 <select value={selectedCategoryIdLabel} onChange={onChangeCategorySelect}>
@@ -431,15 +438,15 @@ export const TransactionProperties = ({ transaction }: Props) => {
                   {categoryOptions}
                 </select>
               </div>
-            </div>
-          </div>
+            </Row>
+          </Property>
         </>
       )}
-      <div className="propertyLabel">Split&nbsp;Transactions</div>
-      <div className="property">
+      <PropertyLabel>Split&nbsp;Transactions</PropertyLabel>
+      <Property>
         {splitTransactionInputRows}
         {!!splitTransactionInputRows?.length && (
-          <div className="row">
+          <Row>
             <div className="SplitTransactionRow">
               <div className="amount">
                 <span>
@@ -459,16 +466,16 @@ export const TransactionProperties = ({ transaction }: Props) => {
                 </select>
               </div>
             </div>
-          </div>
+          </Row>
         )}
-        <div className="row button">
+        <Row className="button">
           <button onClick={onClickAdd}>Add&nbsp;New&nbsp;Split</button>
-        </div>
-      </div>
-      <div className="propertyLabel">Transfer</div>
-      <div className="property">
+        </Row>
+      </Property>
+      <PropertyLabel>Transfer</PropertyLabel>
+      <Property>
         {!showPartnerPicker && (
-          <div className="row button">
+          <Row className="button">
             <button
               className="markAsTransferButton"
               onClick={() => setShowPartnerPicker(true)}
@@ -476,20 +483,20 @@ export const TransactionProperties = ({ transaction }: Props) => {
               <TransferArrowIcon size={12} />
               &nbsp;Mark&nbsp;as&nbsp;Transfer
             </button>
-          </div>
+          </Row>
         )}
         {showPartnerPicker && (
           <>
-            <div className="row keyValue">
+            <Row className="keyValue">
               <span className="propertyName">Pair&nbsp;with</span>
-            </div>
+            </Row>
             {partnerCandidates.length === 0 && (
-              <div className="row partnerPickerEmpty">
+              <Row className="partnerPickerEmpty">
                 <span className="partnerPickerEmptyText">
                   No matching transactions within ±{PARTNER_DATE_WINDOW_DAYS} days
                   (opposite sign, same absolute amount, not already paired).
                 </span>
-              </div>
+              </Row>
             )}
             {partnerCandidates.map((candidate) => {
               const candidateAccount = accounts.get(candidate.account_id);
@@ -500,9 +507,9 @@ export const TransactionProperties = ({ transaction }: Props) => {
                 ? undefined
                 : () => onClickPartnerCandidate(candidate.transaction_id);
               return (
-                <div
+                <Row
                   key={candidate.transaction_id}
-                  className={`row partnerCandidate${disabled ? " disabled" : ""}`}
+                  className={`partnerCandidate${disabled ? " disabled" : ""}`}
                   role="button"
                   tabIndex={disabled ? -1 : 0}
                   aria-disabled={disabled}
@@ -545,10 +552,10 @@ export const TransactionProperties = ({ transaction }: Props) => {
                       {isPending && <>&nbsp;…</>}
                     </div>
                   </div>
-                </div>
+                </Row>
               );
             })}
-            <div className="row button">
+            <Row className="button">
               <button
                 className="markAsTransferCancel"
                 disabled={!!pendingPartnerId}
@@ -556,15 +563,15 @@ export const TransactionProperties = ({ transaction }: Props) => {
               >
                 Cancel
               </button>
-            </div>
+            </Row>
           </>
         )}
-      </div>
+      </Property>
       {isManual && (
         <>
           <br />
-          <div className="property">
-            <div className="row button">
+          <Property>
+            <Row className="button">
               <button
                 className="delete colored"
                 onClick={async () => {
@@ -584,10 +591,10 @@ export const TransactionProperties = ({ transaction }: Props) => {
               >
                 Delete
               </button>
-            </div>
-          </div>
+            </Row>
+          </Property>
         </>
       )}
-    </div>
+    </Properties>
   );
 };

--- a/src/client/components/TransactionsTable/TransferRow.tsx
+++ b/src/client/components/TransactionsTable/TransferRow.tsx
@@ -1,7 +1,7 @@
 import { MouseEventHandler } from "react";
 import { numberToCommaString, currencyCodeToSymbol, LocalDate } from "common";
 import { useAppContext, PATH } from "client";
-import { InstitutionSpan, KebabIcon, RightArrowIcon, TransferArrowIcon } from "client/components";
+import { InstitutionSpan, RightArrowIcon, TransferArrowIcon } from "client/components";
 import type { JSONTransaction } from "common";
 
 interface Props {

--- a/src/client/components/TransferProperties/index.tsx
+++ b/src/client/components/TransferProperties/index.tsx
@@ -2,7 +2,14 @@ import { currencyCodeToSymbol, LocalDate, numberToCommaString } from "common";
 import type { JSONTransaction } from "common";
 import type { TransferPair } from "server";
 import { useAppContext, useTransfers } from "client";
-import { InstitutionSpan, TransferArrowIcon } from "client/components";
+import {
+  InstitutionSpan,
+  Properties,
+  Property,
+  PropertyLabel,
+  Row,
+  TransferArrowIcon,
+} from "client/components";
 import "./index.css";
 
 interface Props {
@@ -60,17 +67,17 @@ export const TransferProperties = ({ transfer }: Props) => {
     );
     return (
       <>
-        <div className="propertyLabel">{label}</div>
-        <div className="property">
-          <div className="row keyValue">
+        <PropertyLabel>{label}</PropertyLabel>
+        <Property>
+          <Row className="keyValue">
             <span className="propertyName">Account</span>
             <span>{account?.custom_name || account?.name || tx.account_id}</span>
-          </div>
-          <div className="row keyValue">
+          </Row>
+          <Row className="keyValue">
             <span className="propertyName">Institution</span>
             {account ? <InstitutionSpan institution_id={account.institution_id} /> : <span />}
-          </div>
-          <div className="row keyValue">
+          </Row>
+          <Row className="keyValue">
             <span className="propertyName">Date</span>
             <span>
               {new LocalDate(txDate).toLocaleString("en-US", {
@@ -79,44 +86,44 @@ export const TransferProperties = ({ transfer }: Props) => {
                 year: "numeric",
               })}
             </span>
-          </div>
-          <div className="row keyValue">
+          </Row>
+          <Row className="keyValue">
             <span className="propertyName">Merchant&nbsp;Name</span>
             <span>{tx.merchant_name}</span>
-          </div>
-          <div className="row keyValue">
+          </Row>
+          <Row className="keyValue">
             <span className="propertyName">Name</span>
             <span>{tx.name}</span>
-          </div>
+          </Row>
           {txLocations.length > 0 && (
-            <div className="row keyValue">
+            <Row className="keyValue">
               <span className="propertyName">Location</span>
               <span>{txLocations.join(", ")}</span>
-            </div>
+            </Row>
           )}
           {tx.label?.memo && (
-            <div className="row keyValue">
+            <Row className="keyValue">
               <span className="propertyName">Memo</span>
               <span>{tx.label.memo}</span>
-            </div>
+            </Row>
           )}
-        </div>
+        </Property>
       </>
     );
   };
 
   return (
-    <div className="TransferProperties Properties">
-      <div className="propertyLabel">Transfer&nbsp;Details</div>
-      <div className="property">
-        <div className="row keyValue">
+    <Properties className="TransferProperties">
+      <PropertyLabel>Transfer&nbsp;Details</PropertyLabel>
+      <Property>
+        <Row className="keyValue">
           <span className="propertyName">Type</span>
           <span className="transferChip transferChipConfirmed">
             <TransferArrowIcon size={12} />
             &nbsp;Transfer
           </span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Date</span>
           <span>
             {new LocalDate(date).toLocaleString("en-US", {
@@ -125,26 +132,26 @@ export const TransferProperties = ({ transfer }: Props) => {
               year: "numeric",
             })}
           </span>
-        </div>
-        <div className="row keyValue">
+        </Row>
+        <Row className="keyValue">
           <span className="propertyName">Amount</span>
           <span className="transferAmountInline">
             <TransferArrowIcon size={12} />
             &nbsp;{currencySymbol}&nbsp;
             {numberToCommaString(displayAmount)}
           </span>
-        </div>
-      </div>
+        </Row>
+      </Property>
       {renderSide("From", outgoing, fromAccount)}
       {renderSide("To", incoming, toAccount)}
-      <div className="propertyLabel">Actions</div>
-      <div className="property">
-        <div className="row button">
+      <PropertyLabel>Actions</PropertyLabel>
+      <Property>
+        <Row className="button">
           <button className="unpairButton" onClick={onClickUnpair}>
             Mark&nbsp;as&nbsp;Non-Transfer
           </button>
-        </div>
-      </div>
-    </div>
+        </Row>
+      </Property>
+    </Properties>
   );
 };

--- a/src/client/pages/AccountDetailPage/index.css
+++ b/src/client/pages/AccountDetailPage/index.css
@@ -1,3 +1,0 @@
-div.AccountDetailPage > div {
-  padding: 0 10px;
-}

--- a/src/client/pages/AccountDetailPage/index.tsx
+++ b/src/client/pages/AccountDetailPage/index.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { useAppContext, PATH, Account } from "client";
 import { AccountProperties } from "client/components";
 
-
 export type AccountDetailPageParams = {
   id?: string;
 };

--- a/src/client/pages/AccountDetailPage/index.tsx
+++ b/src/client/pages/AccountDetailPage/index.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { useAppContext, PATH, Account } from "client";
 import { AccountProperties } from "client/components";
 
-import "./index.css";
 
 export type AccountDetailPageParams = {
   id?: string;

--- a/src/client/pages/ChartDetailPage/index.css
+++ b/src/client/pages/ChartDetailPage/index.css
@@ -1,7 +1,3 @@
-div.ChartDetailPage > div {
-  padding: 0 10px;
-}
-
 div.ChartDetailPage > div.Properties > div.ProjectionChartRow,
 div.ChartDetailPage > div.Properties > div.BalanceChartRow {
   margin-bottom: 20px;

--- a/src/client/pages/TransactionDetailPage/index.css
+++ b/src/client/pages/TransactionDetailPage/index.css
@@ -1,3 +1,0 @@
-div.TransactionDetailPage > div {
-  padding: 0 10px;
-}

--- a/src/client/pages/TransactionDetailPage/index.tsx
+++ b/src/client/pages/TransactionDetailPage/index.tsx
@@ -5,7 +5,6 @@ import {
   TransferProperties,
 } from "client/components";
 
-import "./index.css";
 
 export type TransactionDetailPageParams = {
   transaction_id?: string;

--- a/src/client/pages/TransactionDetailPage/index.tsx
+++ b/src/client/pages/TransactionDetailPage/index.tsx
@@ -5,7 +5,6 @@ import {
   TransferProperties,
 } from "client/components";
 
-
 export type TransactionDetailPageParams = {
   transaction_id?: string;
   investment_transaction_id?: string;


### PR DESCRIPTION
## Summary

Continues #326 (design-component refactoring). PR #479 landed the
`<Properties>` / `<PropertyLabel>` / `<Property>` / `<Row>` shell and migrated
ConnectionProperties + HoldingProperties. The remaining six `*Properties`
panels still hand-rolled `<div className="XxxProperties Properties">` plus raw
`propertyLabel` / `property` / `row` divs. This migrates all six so the shared
shell convention is inherited instead of re-declared per panel — the direct
parallel, on the Properties axis, to #603's Page-shell migration.

## Migrated (6 panels)

- **AccountProperties** — many conditional sections; non-shell direct children (`<Graph>`, `<br/>`, `<HoldingsComposition>`, `<PerformanceBenchmark>`) and the `.amount` wrapper left as-is.
- **ApiKeyProperties** — all 5 render branches (just-created / create-form / loading / not-found / detail).
- **BudgetProperties** — RadioInputs / CapacitiesInput sub-components left raw (out of scope).
- **InvestmentTransactionProperties**
- **TransactionProperties** — incl. the dynamic ``className={`row partnerCandidate…`}`` row (→ `<Row className={`partnerCandidate…`}>`, all `role`/`tabIndex`/`aria`/handlers passed through `...rest`), the split-input rows, and the `.SplitTransactionRow` / `.notification` inner divs left untouched.
- **TransferProperties** — the per-side `renderSide` fragment keeps its label/property as direct Properties children.

## Why it's safe (DOM-preserving)

Each swap emits the **identical class string** because the shell merges in the
same order the raw markup used: `Properties` is appended (`XxxProperties Properties`),
`row` / `property` / `propertyLabel` are prepended (`row keyValue`, etc.). The
shell components spread `...rest`, so `onClick` / `key` / `aria-*` / `role` all
pass through. Every non-shell div (`.amount`, `.notification`,
`.SplitTransactionRow`, `.partnerCandidateInfo`, plain input wrappers) is left
exactly as it was, so the `div.Properties > .property` / `> .propertyLabel`
direct-child selectors still match.

## Scope

`#326` intentionally stays **open** — remaining phases per its checklist:
sub-component internals (RadioInputs / CapacitiesInput / SplitTransactionRow)
and a sweep for NEW common patterns to extract (section headers, button
clusters). No closing keyword here.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun --bun eslint src/client/components/{Account,ApiKey,Budget,InvestmentTransaction,Transaction,Transfer}Properties` — clean
- [x] `bun test src/client` — 312 pass / 0 fail
- [x] Open/close tag balance verified per file (opens == closes, no self-closing shell tags)
- [ ] Sandbox UI: open each of the 6 detail panels at mobile viewport and eye-check layout unchanged vs. main
