### PR TITLE
fix(lint): remove 3 unused-var errors breaking main CI

### DIFF
--- a/src/client/components/TransactionsPageTitle/index.tsx
+++ b/src/client/components/TransactionsPageTitle/index.tsx
@@ -1,5 +1,5 @@
 import { AccountType } from "plaid";
-import { KeyboardEvent, MouseEventHandler, useCallback, useEffect, useRef, useState } from "react";
+import { KeyboardEvent, useCallback, useEffect, useRef, useState } from "react";
 import { JSONInvestmentTransaction, JSONTransaction, toTitleCase } from "common";
 import {
   Account,

--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -14,7 +14,7 @@ import {
   SplitTransactionDictionary,
   indexedDb,
 } from "client";
-import { InstitutionSpan, KebabIcon } from "client/components";
+import { InstitutionSpan } from "client/components";
 import { ApiResponse } from "server";
 import TransferControls from "./TransferControls";
 
@@ -234,7 +234,7 @@ const TransactionRow = ({ transaction }: Props) => {
     if (isSuggested) void onAcceptSuggestion();
   };
 
-  const onClickConfirm: MouseEventHandler<HTMLButtonElement> = (e) => {
+  const onClickConfirm: MouseEventHandler<HTMLButtonElement> = () => {
     if (isSuggested) void onAcceptSuggestion();
   };
 


### PR DESCRIPTION
## Problem

`main`'s CI `test` job is currently **red** — the eslint step (`bun --bun eslint src`) fails on three `@typescript-eslint/no-unused-vars` errors introduced by the last transaction-row UI commit (`dec5c170`):

- `TransactionsPageTitle/index.tsx:2` — `MouseEventHandler` imported, never used.
- `TransactionsTable/TransactionRow.tsx:17` — `KebabIcon` imported, never used.
- `TransactionsTable/TransactionRow.tsx:237` — `onClickConfirm` declares an `e` arg it never reads.

Because CI lints the whole tree, this fails **every open PR's CI**, not just changes to these files.

## Fix

Remove the two dead imports and drop the unused handler arg. All three symbols are genuinely unreferenced (grep-confirmed). `MouseEventHandler` stays imported in `TransactionRow` because `onClickConfirm`'s type still uses it — only the unused `e` parameter is dropped.

## Test plan

- [x] `bun --bun eslint src` — clean (was 3 errors)
- [x] `bun run typecheck` — clean
- [x] `bun run test` — 1068 pass / 0 fail
- [x] No behavior change — pure dead-symbol removal, so there is no rendered surface to drive; the removed symbols were never referenced by any code path.
