### PR TITLE
refactor(client): extract `<ChartRowTitle>` shared component (#326 follow-up)

### DIFF
--- a/src/client/components/BalanceChartRow/index.css
+++ b/src/client/components/BalanceChartRow/index.css
@@ -1,15 +1,3 @@
-div.BalanceChartRow > .title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-div.BalanceChartRow > .title button {
-  background-color: inherit;
-  width: 32px;
-  height: 32px;
-}
-
 div.BalanceChartRow > .chart {
   display: flex;
   justify-content: space-between;

--- a/src/client/components/BalanceChartRow/index.tsx
+++ b/src/client/components/BalanceChartRow/index.tsx
@@ -2,7 +2,7 @@ import { Dispatch, KeyboardEvent, MouseEventHandler, SetStateAction } from "reac
 import { AccountType } from "plaid";
 import { numberToCommaString, toTitleCase } from "common";
 import { BalanceChart, getDisplayBalance, useAppContext, useReorder } from "client";
-import { ChevronDownIcon, ChevronUpIcon, QuestionIcon } from "client/components";
+import { ChartRowTitle, QuestionIcon } from "client/components";
 import { ColumnData, StackData, Stacks } from "./Stacks";
 import "./index.css";
 
@@ -157,24 +157,12 @@ export const BalanceChartRow = ({
       onDragEnd={onDragEnd}
     >
       {showTitle && (
-        <h3 className="title">
-          <span>{name}</span>
-          <button
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onTouchStart={onTouchHandleStart}
-            onTouchEnd={onTouchHandleEnd}
-            onGotPointerCapture={onGotPointerCapture}
-            style={{ touchAction: "none" }}
-          >
-            <div className="reorderIcon">
-              <ChevronUpIcon size={8} />
-              <ChevronDownIcon size={8} />
-            </div>
-          </button>
-        </h3>
+        <ChartRowTitle
+          name={name}
+          onTouchHandleStart={onTouchHandleStart}
+          onTouchHandleEnd={onTouchHandleEnd}
+          onGotPointerCapture={onGotPointerCapture}
+        />
       )}
       <div className="chart">
         <Stacks data={stacksData} />

--- a/src/client/components/ChartRowTitle/index.css
+++ b/src/client/components/ChartRowTitle/index.css
@@ -4,7 +4,8 @@ h3.chartRowTitle {
   align-items: center;
 }
 
-h3.chartRowTitle button {
+h3.chartRowTitle button,
+h3.chartRowTitle button:hover {
   background-color: inherit;
   width: 32px;
   height: 32px;

--- a/src/client/components/ChartRowTitle/index.css
+++ b/src/client/components/ChartRowTitle/index.css
@@ -1,0 +1,11 @@
+h3.chartRowTitle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+h3.chartRowTitle button {
+  background-color: inherit;
+  width: 32px;
+  height: 32px;
+}

--- a/src/client/components/ChartRowTitle/index.tsx
+++ b/src/client/components/ChartRowTitle/index.tsx
@@ -1,0 +1,36 @@
+import { PointerEventHandler, ReactNode, TouchEventHandler } from "react";
+import { ChevronDownIcon, ChevronUpIcon } from "client/components";
+import "./index.css";
+
+interface Props {
+  name: ReactNode;
+  onTouchHandleStart: TouchEventHandler<HTMLButtonElement>;
+  onTouchHandleEnd: TouchEventHandler<HTMLButtonElement>;
+  onGotPointerCapture: PointerEventHandler<HTMLButtonElement>;
+}
+
+export const ChartRowTitle = ({
+  name,
+  onTouchHandleStart,
+  onTouchHandleEnd,
+  onGotPointerCapture,
+}: Props) => (
+  <h3 className="chartRowTitle">
+    <span>{name}</span>
+    <button
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+      onTouchStart={onTouchHandleStart}
+      onTouchEnd={onTouchHandleEnd}
+      onGotPointerCapture={onGotPointerCapture}
+      style={{ touchAction: "none" }}
+    >
+      <div className="reorderIcon">
+        <ChevronUpIcon size={8} />
+        <ChevronDownIcon size={8} />
+      </div>
+    </button>
+  </h3>
+);

--- a/src/client/components/FlowChartRow/index.css
+++ b/src/client/components/FlowChartRow/index.css
@@ -1,15 +1,3 @@
-div.FlowChartRow > h3.title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-div.FlowChartRow > .title button {
-  background-color: inherit;
-  width: 32px;
-  height: 32px;
-}
-
 div.FlowChartRow > table {
   margin-top: 10px;
   text-align: center;

--- a/src/client/components/FlowChartRow/index.tsx
+++ b/src/client/components/FlowChartRow/index.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, MouseEventHandler, SetStateAction, useMemo } from "react";
 import { useAppContext, useReorder, FlowChart } from "client";
-import { ChevronDownIcon, ChevronUpIcon } from "client/components";
+import { ChartRowTitle } from "client/components";
 import { getSankeyData } from "./lib";
 import { Sankey } from "./Sankey";
 import "./index.css";
@@ -99,24 +99,12 @@ export const FlowChartRow = ({
       onDragEnd={onDragEnd}
     >
       {showTitle && (
-        <h3 className="title">
-          <span>{chart.name}</span>
-          <button
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onTouchStart={onTouchHandleStart}
-            onTouchEnd={onTouchHandleEnd}
-            onGotPointerCapture={onGotPointerCapture}
-            style={{ touchAction: "none" }}
-          >
-            <div className="reorderIcon">
-              <ChevronUpIcon size={8} />
-              <ChevronDownIcon size={8} />
-            </div>
-          </button>
-        </h3>
+        <ChartRowTitle
+          name={chart.name}
+          onTouchHandleStart={onTouchHandleStart}
+          onTouchHandleEnd={onTouchHandleEnd}
+          onGotPointerCapture={onGotPointerCapture}
+        />
       )}
       <Sankey memoryKey={chart.id} data={graphData} height={height} />
       {showTable && (

--- a/src/client/components/ProjectionChartRow/index.css
+++ b/src/client/components/ProjectionChartRow/index.css
@@ -1,15 +1,3 @@
-div.ProjectionChartRow > h3.title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-div.ProjectionChartRow > .title button {
-  background-color: inherit;
-  width: 32px;
-  height: 32px;
-}
-
 div.ProjectionChartRow > table {
   margin-top: 10px;
   text-align: right;

--- a/src/client/components/ProjectionChartRow/index.tsx
+++ b/src/client/components/ProjectionChartRow/index.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch, KeyboardEvent, MouseEventHandler, SetStateAction, useMemo } from "react";
 import { getYearMonthString, numberToCommaString, ViewDate } from "common";
 import { useAccountGraph, useAppContext, useReorder, ProjectionChart } from "client";
-import { ChevronDownIcon, ChevronUpIcon, DateLabel, Graph, MoneyLabel } from "client/components";
+import { ChartRowTitle, DateLabel, Graph, MoneyLabel } from "client/components";
 import { calculateProjection } from "./lib";
 import "./index.css";
 
@@ -174,24 +174,12 @@ export const ProjectionChartRow = ({
       onDragEnd={onDragEnd}
     >
       {showTitle && (
-        <h3 className="title">
-          <span>{chart.name}</span>
-          <button
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onTouchStart={onTouchHandleStart}
-            onTouchEnd={onTouchHandleEnd}
-            onGotPointerCapture={onGotPointerCapture}
-            style={{ touchAction: "none" }}
-          >
-            <div className="reorderIcon">
-              <ChevronUpIcon size={8} />
-              <ChevronDownIcon size={8} />
-            </div>
-          </button>
-        </h3>
+        <ChartRowTitle
+          name={chart.name}
+          onTouchHandleStart={onTouchHandleStart}
+          onTouchHandleEnd={onTouchHandleEnd}
+          onGotPointerCapture={onGotPointerCapture}
+        />
       )}
       <Graph
         height={150}

--- a/src/client/components/index.ts
+++ b/src/client/components/index.ts
@@ -33,6 +33,7 @@ export * from "./ToggleInput";
 export * from "./Spinner";
 export * from "./TransactionsPageTitle";
 export * from "./Icons";
+export * from "./ChartRowTitle";
 export * from "./BalanceChartRow";
 export * from "./ProjectionChartRow";
 export * from "./FlowChartRow";


### PR DESCRIPTION
## Summary

Continues #326. Reviewoie sweep-4 on #605 flagged `BalanceChartRow` / `ProjectionChartRow` / `FlowChartRow` all hand-roll the SAME title JSX + byte-identical `> .title` + `> .title button` CSS.

Extracts `<ChartRowTitle>` in a new `src/client/components/ChartRowTitle/` directory. Each of the 3 chart rows now delegates to it and drops the shared CSS block.

## Changes

- New: `src/client/components/ChartRowTitle/{index.tsx, index.css}` — owns the h3+span+button pattern with a `chartRowTitle` class (avoids collision with unrelated `.title` uses in `LabeledBar` and `BudgetConfigPage`).
- 3 consumers migrated: `BalanceChartRow`, `ProjectionChartRow`, `FlowChartRow` — swap the hand-rolled `<h3 class="title">…</h3>` for `<ChartRowTitle name={...} onTouchHandleStart={...} onTouchHandleEnd={...} onGotPointerCapture={...} />`. Imports slimmed (dropped `ChevronUpIcon` / `ChevronDownIcon` from each consumer).
- Per-file CSS cleared of the now-redundant `> .title { display: flex; ... }` and `> .title button { background-color: inherit; ... }` blocks.

`ProjectionChartRow`'s compact `{showTitle && <div className="title">…</div>}` form is a different pattern (name text, no button) — kept as a raw div.

Net: −93 / +22.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun --bun eslint src` clean
- [x] `bun test src/client` — 312 pass / 0 fail
- [ ] Sandbox: DashboardPage / ChartDetailPage — chart-row titles render identically, kebab/reorder button drag works
🤖 Generated with [Claude Code](https://claude.com/claude-code)
