### PR TITLE
refactor(client): extract `<PageTitle>` shared component (#326 phase 4a)

### DIFF
--- a/src/client/components/PageTitle/index.css
+++ b/src/client/components/PageTitle/index.css
@@ -1,0 +1,12 @@
+h2.PageTitle {
+  margin: 0;
+  padding: 16px 10px 10px;
+  position: sticky;
+  top: 50px;
+  background-color: #191919ee;
+  z-index: 110;
+}
+
+div.wideScreen h2.PageTitle {
+  top: 0;
+}

--- a/src/client/components/PageTitle/index.tsx
+++ b/src/client/components/PageTitle/index.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from "react";
+import "./index.css";
+
+interface Props {
+  children: ReactNode;
+}
+
+/**
+ * Sticky page-level `<h2>` heading used at the top of list pages
+ * (AccountsPage, BudgetsPage, DashboardPage, etc.). Provides the shared
+ * sticky/padding/z-index styling that every list page's own CSS used to
+ * declare identically.
+ */
+export const PageTitle = ({ children }: Props) => <h2 className="PageTitle">{children}</h2>;

--- a/src/client/components/index.ts
+++ b/src/client/components/index.ts
@@ -1,5 +1,6 @@
 export * from "./App";
 export * from "./Properties";
+export * from "./PageTitle";
 export * from "./HoldingProperties";
 export * from "./InvestmentTransactionProperties";
 export * from "./ErrorBoundary";

--- a/src/client/pages/AccountsPage/index.css
+++ b/src/client/pages/AccountsPage/index.css
@@ -2,19 +2,6 @@ div.AccountsPage {
   position: relative;
 }
 
-div.AccountsPage > h2 {
-  margin: 0;
-  padding: 16px 10px 10px;
-  position: sticky;
-  top: 50px;
-  background-color: #191919ee;
-  z-index: 110;
-}
-
-div.wideScreen div.AccountsPage > h2 {
-  top: 0;
-}
-
 div.AccountsPage > div.AccountsDonut {
   background-color: #191919ee;
   z-index: 100;

--- a/src/client/pages/AccountsPage/index.tsx
+++ b/src/client/pages/AccountsPage/index.tsx
@@ -9,7 +9,7 @@ import {
   useAppContext,
   useDebounce,
 } from "client";
-import { AccountsDonut, AccountsTable, DonutData } from "client/components";
+import { AccountsDonut, AccountsTable, DonutData, PageTitle } from "client/components";
 import "./index.css";
 
 export const AccountsPage = () => {
@@ -93,7 +93,7 @@ export const AccountsPage = () => {
 
   return (
     <div className={classNames.join(" ")}>
-      <h2>All&nbsp;Accounts</h2>
+      <PageTitle>All&nbsp;Accounts</PageTitle>
       <AccountsDonut
         balanceTotal={balanceTotal}
         currencySymbol={currencySymbol}

--- a/src/client/pages/BudgetsPage/index.css
+++ b/src/client/pages/BudgetsPage/index.css
@@ -4,19 +4,6 @@ div.BudgetsPage .placeholder {
   align-items: center;
 }
 
-div.BudgetsPage > h2 {
-  margin: 0;
-  padding: 16px 10px 10px;
-  position: sticky;
-  top: 50px;
-  background-color: #191919ee;
-  z-index: 110;
-}
-
-div.wideScreen div.BudgetsPage > h2 {
-  top: 0;
-}
-
 div.BudgetsPage > div.budgetsTable > .addButton {
   margin: 10px 10px;
 }

--- a/src/client/pages/BudgetsPage/index.tsx
+++ b/src/client/pages/BudgetsPage/index.tsx
@@ -10,7 +10,7 @@ import {
   Data,
   indexedDb,
 } from "client";
-import { BudgetBar } from "client/components";
+import { BudgetBar, PageTitle } from "client/components";
 import "./index.css";
 
 export const BudgetsPage = () => {
@@ -65,7 +65,7 @@ export const BudgetsPage = () => {
 
   return (
     <div className="BudgetsPage">
-      <h2>All Budgets</h2>
+      <PageTitle>All Budgets</PageTitle>
       <div className="budgetsTable">
         {budgetBars}
         <div className="addButton">

--- a/src/client/pages/DashboardPage/index.css
+++ b/src/client/pages/DashboardPage/index.css
@@ -1,16 +1,3 @@
-div.DashboardPage > h2 {
-  margin: 0;
-  padding: 16px 10px 10px;
-  position: sticky;
-  top: 50px;
-  background-color: #191919ee;
-  z-index: 110;
-}
-
-div.wideScreen div.DashboardPage > h2 {
-  top: 0;
-}
-
 div.DashboardPage > button {
   width: calc(100% - 20px);
   margin: 0 10px;

--- a/src/client/pages/DashboardPage/index.tsx
+++ b/src/client/pages/DashboardPage/index.tsx
@@ -14,7 +14,7 @@ import {
   FlowChart,
   indexedDb,
 } from "client";
-import { BalanceChartRow, FlowChartRow, ProjectionChartRow } from "client/components";
+import { BalanceChartRow, FlowChartRow, PageTitle, ProjectionChartRow } from "client/components";
 import "./index.css";
 
 export const DashboardPage = () => {
@@ -97,7 +97,7 @@ export const DashboardPage = () => {
 
   return (
     <div className="DashboardPage">
-      <h2>Dashboard</h2>
+      <PageTitle>Dashboard</PageTitle>
       {chartRows}
       <button onClick={onClickAddChart}>Add&nbsp;Chart</button>
     </div>


### PR DESCRIPTION
## Summary

Continues #326 with the "common page components" ask. `AccountsPage` / `BudgetsPage` / `DashboardPage` each declared byte-identical `> h2` sticky CSS and hand-rolled `<h2>{title}</h2>`. Extracted `<PageTitle>` shell.

## Changes

- New: `src/client/components/PageTitle/{index.tsx, index.css}` — renders `<h2 className="PageTitle">{children}</h2>`; owns the shared sticky/padding/z-index + wide-screen `top: 0` override.
- 3 consumers swap `<h2>Title</h2>` → `<PageTitle>Title</PageTitle>` and drop the per-page `> h2` CSS blocks.
- Barrel export.

`TransactionsPage` / `TransactionsPageTitle` kept as-is — it uses a fixed-height, higher-z-index variant with siblings (`<h3 className="heading">` subtitle, `SearchBar`, `TransactionsHead`) and needs the "filterable title" primitive I'm planning as phase 4b (per your ask to make the transaction filter embedded title generic for account filtering).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun --bun eslint src` clean
- [x] `bun test src/client` 312 pass / 0 fail
- [ ] Sandbox: DashboardPage / AccountsPage / BudgetsPage — sticky heading behaves identically to main (position + scroll)
🤖 Generated with [Claude Code](https://claude.com/claude-code)
