### PR TITLE
refactor(client): extract `<PageFilterTitle>` primitive from TransactionsPageTitle (#326 phase 4b)

### DIFF
--- a/src/client/components/PageFilterTitle/index.css
+++ b/src/client/components/PageFilterTitle/index.css
@@ -1,0 +1,97 @@
+h2.PageFilterTitle > button {
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  font-size: 1em;
+  font-weight: bold;
+  background-color: transparent;
+  white-space: nowrap;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  overflow: hidden;
+  text-align: left;
+}
+
+h2.PageFilterTitle > button > span:not(.checkmark) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1;
+}
+
+h2.PageFilterTitle > div.select {
+  position: absolute;
+  top: 50px;
+  width: calc(100% - 20px);
+  background-color: #292929;
+  display: block;
+  border-radius: 10px;
+  border: 1px solid #666;
+  overflow: hidden;
+}
+
+h2.PageFilterTitle > div.select * {
+  font-size: 14px;
+  font-weight: normal;
+}
+
+h2.PageFilterTitle > div.select > div.selectLabel {
+  padding: 10px;
+  border-bottom: 1px solid #666;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+h2.PageFilterTitle > div.select > div.selectLabel > button.closeButton {
+  font-size: 18px;
+}
+
+h2.PageFilterTitle > div.select > div.options > button {
+  width: 100%;
+  padding: 4px 0 6px 30px;
+  height: 28px;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+h2.PageFilterTitle > div.select > div.options > button:first-child {
+  height: 32px;
+  padding-top: 10px;
+  padding-left: 10px;
+}
+
+h2.PageFilterTitle > div.select > div.options > button:last-child {
+  padding-bottom: 10px;
+}
+
+h2.PageFilterTitle > div.select > div.options > button > span.checkbox {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 1px solid #888;
+  border-radius: 2px;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  position: relative;
+}
+
+h2.PageFilterTitle > div.select > div.options > button > span.checkbox.checked {
+  background-color: #4a4a4a;
+  border-color: #aaa;
+}
+
+/* Inset ✓ glyph rendered via ::after so the checkbox span itself stays a
+   pure visual element — keeps the option button click target unified. */
+h2.PageFilterTitle > div.select > div.options > button > span.checkbox.checked::after {
+  content: "✓";
+  position: absolute;
+  top: -3px;
+  left: 0px;
+  font-size: 18px;
+  line-height: 12px;
+  color: #e8e8e8;
+}

--- a/src/client/components/PageFilterTitle/index.tsx
+++ b/src/client/components/PageFilterTitle/index.tsx
@@ -1,0 +1,81 @@
+import { KeyboardEvent, ReactNode, useEffect, useRef, useState } from "react";
+import { ChevronDownIcon } from "client/components";
+import "./index.css";
+
+interface Props {
+  /** Text or fragment shown inside the trigger button. */
+  label: ReactNode;
+  /** When set, the dropdown includes a sticky-close row with this label. */
+  dropdownLabel?: string;
+  /** Extra class on the outer `<h2>` for per-page overrides (z-index / height). */
+  className?: string;
+  /** The dropdown options (typically `<button>` elements). */
+  children: ReactNode;
+}
+
+/**
+ * Page-title heading with an embedded dropdown filter. Extracted from
+ * `TransactionsPageTitle` so other list pages (e.g. `AccountsPage`) can
+ * reuse the same trigger-button + dropdown chrome.
+ *
+ * Owns: isOpen state, buttonRef, selectBoxRef, touch-outside dismissal,
+ * mouse-leave dismissal, keyboard Escape/Enter/Space dismissal on the
+ * dropdown label. Consumer only supplies `label`, an optional
+ * `dropdownLabel`, and the option buttons as children.
+ */
+export const PageFilterTitle = ({ label, dropdownLabel, className, children }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const selectBoxRef = useRef<HTMLDivElement>(null);
+
+  const toggle = () => setIsOpen((v) => !v);
+  const close = () => setIsOpen(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleTouchOutside: EventListener = (event) => {
+      const node = event.target as Node;
+      const isOutsideSelectBox = !selectBoxRef.current || !selectBoxRef.current.contains(node);
+      const isOutsideButton = !buttonRef.current || !buttonRef.current.contains(node);
+      if (isOutsideSelectBox && isOutsideButton) close();
+    };
+    document.addEventListener("touchstart", handleTouchOutside);
+    return () => document.removeEventListener("touchstart", handleTouchOutside);
+  }, [isOpen]);
+
+  const onLabelKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " " || e.key === "Escape") {
+      e.preventDefault();
+      close();
+    }
+  };
+
+  return (
+    <h2 className={"PageTitle PageFilterTitle" + (className ? " " + className : "")}>
+      <button onClick={toggle} ref={buttonRef}>
+        <span>{label}</span>
+        <ChevronDownIcon size={15} />
+      </button>
+      {isOpen && (
+        <div ref={selectBoxRef} className="select" onMouseLeave={close}>
+          {dropdownLabel && (
+            <div
+              className="selectLabel"
+              onClick={close}
+              onKeyDown={onLabelKeyDown}
+              role="button"
+              tabIndex={0}
+              aria-label={`Close ${dropdownLabel}`}
+            >
+              <span>{dropdownLabel}</span>
+              <button className="closeButton" aria-hidden="true">
+                ✕
+              </button>
+            </div>
+          )}
+          <div className="options">{children}</div>
+        </div>
+      )}
+    </h2>
+  );
+};

--- a/src/client/components/PageFilterTitle/index.tsx
+++ b/src/client/components/PageFilterTitle/index.tsx
@@ -6,7 +6,10 @@ interface Props {
   /** Text or fragment shown inside the trigger button. */
   label: ReactNode;
   /** When set, the dropdown includes a sticky-close row with this label. */
-  dropdownLabel?: string;
+  dropdownLabel?: ReactNode;
+  /** aria-label on the sticky-close row (defaults to `"Close"`). Set this
+   * when `dropdownLabel` reads awkwardly as `"Close <dropdownLabel>"`. */
+  closeAriaLabel?: string;
   /** Extra class on the outer `<h2>` for per-page overrides (z-index / height). */
   className?: string;
   /** The dropdown options (typically `<button>` elements). */
@@ -23,7 +26,13 @@ interface Props {
  * dropdown label. Consumer only supplies `label`, an optional
  * `dropdownLabel`, and the option buttons as children.
  */
-export const PageFilterTitle = ({ label, dropdownLabel, className, children }: Props) => {
+export const PageFilterTitle = ({
+  label,
+  dropdownLabel,
+  closeAriaLabel = "Close",
+  className,
+  children,
+}: Props) => {
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const selectBoxRef = useRef<HTMLDivElement>(null);
@@ -65,7 +74,7 @@ export const PageFilterTitle = ({ label, dropdownLabel, className, children }: P
               onKeyDown={onLabelKeyDown}
               role="button"
               tabIndex={0}
-              aria-label={`Close ${dropdownLabel}`}
+              aria-label={closeAriaLabel}
             >
               <span>{dropdownLabel}</span>
               <button className="closeButton" aria-hidden="true">

--- a/src/client/components/TransactionsPageTitle/index.css
+++ b/src/client/components/TransactionsPageTitle/index.css
@@ -1,4 +1,9 @@
-div.TransactionsPage > h2,
+/* TransactionsPage-specific sticky rules. Base sticky/padding on `h2`
+ * comes from `<PageTitle>`; button + dropdown chrome comes from
+ * `<PageFilterTitle>`. Everything below layers TxPage-specific overrides
+ * (fixed h2 height, higher z-index because SearchBar/TransactionsHead
+ * sit visually below the h2) and the sticky siblings (h3 subtitle,
+ * TransactionsHead, active SearchBar). */
 div.TransactionsPage > h3,
 div.TransactionsPage > div.TransactionsHead,
 div.SearchBar.active {
@@ -12,15 +17,9 @@ div.TransactionsHead {
   z-index: 108;
 }
 
-div.TransactionsPage > h2 {
-  top: 50px;
+h2.TransactionsFilterTitle {
   height: 54px;
-  padding: 16px 10px 10px;
   z-index: 111;
-}
-
-div.wideScreen div.TransactionsPage > h2 {
-  top: 0;
 }
 
 div.TransactionsPage > h3 {
@@ -31,104 +30,6 @@ div.TransactionsPage > h3 {
 
 div.wideScreen div.TransactionsPage > h3 {
   top: 55px;
-}
-
-div.TransactionsPage > .heading > button {
-  padding: 0;
-  width: 100%;
-  height: 100%;
-  font-size: 1em;
-  font-weight: bold;
-  background-color: transparent;
-  white-space: nowrap;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  overflow: hidden;
-  text-align: left;
-}
-
-div.TransactionsPage > .heading > button > span:not(.checkmark) {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-  flex: 1;
-}
-
-div.TransactionsPage > .heading > div.select {
-  position: absolute;
-  top: 50px;
-  width: calc(100% - 20px);
-  background-color: #292929;
-  display: block;
-  border-radius: 10px;
-  border: 1px solid #666;
-  overflow: hidden;
-}
-
-div.TransactionsPage > .heading > div.select * {
-  font-size: 14px;
-  font-weight: normal;
-}
-
-div.TransactionsPage > .heading > div.select > div.selectLabel {
-  padding: 10px;
-  border-bottom: 1px solid #666;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-div.TransactionsPage > .heading > div.select > div.selectLabel > button.closeButton {
-  font-size: 18px;
-}
-
-div.TransactionsPage > .heading > div.select > div.options > button {
-  width: 100%;
-  padding: 4px 0 6px 30px;
-  height: 28px;
-  text-align: left;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-div.TransactionsPage > .heading > div.select > div.options > button:first-child {
-  height: 32px;
-  padding-top: 10px;
-  padding-left: 10px;
-}
-
-div.TransactionsPage > .heading > div.select > div.options > button:last-child {
-  padding-bottom: 10px;
-}
-
-div.TransactionsPage > .heading > div.select > div.options > button > span.checkbox {
-  display: inline-block;
-  width: 14px;
-  height: 14px;
-  border: 1px solid #888;
-  border-radius: 2px;
-  box-sizing: border-box;
-  flex-shrink: 0;
-  position: relative;
-}
-
-div.TransactionsPage > .heading > div.select > div.options > button > span.checkbox.checked {
-  background-color: #4a4a4a;
-  border-color: #aaa;
-}
-
-/* Inset ✓ glyph rendered via ::after so the checkbox span itself stays a
-   pure visual element — keeps the option button click target unified. */
-div.TransactionsPage > .heading > div.select > div.options > button > span.checkbox.checked::after {
-  content: "✓";
-  position: absolute;
-  top: -3px;
-  left: 0px;
-  font-size: 18px;
-  line-height: 12px;
-  color: #e8e8e8;
 }
 
 div.SearchBar {

--- a/src/client/components/TransactionsPageTitle/index.tsx
+++ b/src/client/components/TransactionsPageTitle/index.tsx
@@ -1,5 +1,5 @@
 import { AccountType } from "plaid";
-import { KeyboardEvent, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback } from "react";
 import { JSONInvestmentTransaction, JSONTransaction, toTitleCase } from "common";
 import {
   Account,
@@ -9,11 +9,11 @@ import {
   Section,
   SplitTransaction,
   Transaction,
-  ChevronDownIcon,
   ScreenType,
   Sorter,
   useAppContext,
 } from "client";
+import { PageFilterTitle } from "client/components";
 import { TransactionsHead } from "./TransactionsHead";
 import "./index.css";
 import { SearchBar } from "./SearchBar";
@@ -97,25 +97,6 @@ export const TransactionsPageTitle = ({
   const { types: selectedTypes, account, budget, section, category } = filters;
   const { router, screenType } = useAppContext();
   const { go, path, params } = router;
-
-  const [isSelecting, setIsSelecting] = useState(false);
-
-  const selectBoxRef = useRef<HTMLDivElement>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-
-  const onClickSelect = () => setIsSelecting(!isSelecting);
-  const closeSelect = () => setIsSelecting(false);
-
-  useEffect(() => {
-    const handleTouchOutside: EventListener = (event) => {
-      const node = event.target as Node;
-      const isOutsideSelectBox = !selectBoxRef.current || !selectBoxRef.current.contains(node);
-      const isOutsideButton = !buttonRef.current || !buttonRef.current.contains(node);
-      if (isOutsideSelectBox && isOutsideButton) closeSelect();
-    };
-    document.addEventListener("touchstart", handleTouchOutside);
-    return () => document.removeEventListener("touchstart", handleTouchOutside);
-  }, []);
 
   const writeTypes = (next: TransactionsPageType[]) => {
     const newParams = new URLSearchParams(params);
@@ -203,40 +184,16 @@ export const TransactionsPageTitle = ({
 
   return (
     <>
-      <h2 className="heading">
-        <button onClick={onClickSelect} ref={buttonRef}>
-          <span>{titleForSelection(selectedTypes)}</span>
-          <ChevronDownIcon size={15} />
-        </button>
-        {isSelecting && (
-          <div ref={selectBoxRef} className="select" onMouseLeave={closeSelect}>
-            <div
-              className="selectLabel"
-              onClick={closeSelect}
-              onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
-                if (e.key === "Enter" || e.key === " " || e.key === "Escape") {
-                  e.preventDefault();
-                  closeSelect();
-                }
-              }}
-              role="button"
-              tabIndex={0}
-              aria-label="Close transaction type selector"
-            >
-              <span>Select&nbsp;transaction&nbsp;types</span>
-              <button className="closeButton" aria-hidden="true">
-                ✕
-              </button>
-            </div>
-            <div className="options">
-              {allButton}
-              {typeButtons}
-            </div>
-          </div>
-        )}
-      </h2>
+      <PageFilterTitle
+        className="TransactionsFilterTitle"
+        label={titleForSelection(selectedTypes)}
+        dropdownLabel="Select transaction types"
+      >
+        {allButton}
+        {typeButtons}
+      </PageFilterTitle>
       {!!subtitle && (
-        <h3 className="heading">
+        <h3>
           <span>{toTitleCase(subtitle)}</span>
         </h3>
       )}

--- a/src/client/components/TransactionsPageTitle/index.tsx
+++ b/src/client/components/TransactionsPageTitle/index.tsx
@@ -187,7 +187,8 @@ export const TransactionsPageTitle = ({
       <PageFilterTitle
         className="TransactionsFilterTitle"
         label={titleForSelection(selectedTypes)}
-        dropdownLabel="Select transaction types"
+        dropdownLabel={<>Select&nbsp;transaction&nbsp;types</>}
+        closeAriaLabel="Close transaction type selector"
       >
         {allButton}
         {typeButtons}

--- a/src/client/components/index.ts
+++ b/src/client/components/index.ts
@@ -1,6 +1,7 @@
 export * from "./App";
 export * from "./Properties";
 export * from "./PageTitle";
+export * from "./PageFilterTitle";
 export * from "./HoldingProperties";
 export * from "./InvestmentTransactionProperties";
 export * from "./ErrorBoundary";


### PR DESCRIPTION
## Summary

Continues #326 phase 4. #610 shipped `<PageTitle>`; this PR extracts the button + dropdown chrome that `TransactionsPageTitle` hand-rolled into a reusable `<PageFilterTitle>` primitive, so `AccountsPage` (and any other list page) can adopt filter-in-title with zero duplication.

## Changes

- New: `src/client/components/PageFilterTitle/{index.tsx, index.css}`.
  - Renders `<h2 className="PageTitle PageFilterTitle {optional className}">` — inherits `<PageTitle>`'s sticky/z-index/padding + adds the trigger button + dropdown mechanics.
  - Owns `isOpen`, `buttonRef`, `selectBoxRef`, touch-outside (registered only while open — cleaner than the always-on listener original), mouse-leave, and keyboard Escape/Enter/Space dismissal.
  - Props: `label` (button text), `dropdownLabel?` (sticky close row inside the dropdown), `className?` (per-page overrides), `children` (option buttons).
- `TransactionsPageTitle`: `<h2 className="heading">…hand-rolled button + dropdown…</h2>` → `<PageFilterTitle className="TransactionsFilterTitle" label={titleForSelection(...)} dropdownLabel="Select transaction types">{allButton}{typeButtons}</PageFilterTitle>`. Drops isSelecting state, buttonRef/selectBoxRef, the touch-outside effect, closeSelect handler, and the h3 subtitle's now-redundant `className="heading"`.
- CSS: dropdown chrome moved wholesale into the shell. `TxPage` keeps only its layout-specific overrides (`h2.TransactionsFilterTitle { height: 54px; z-index: 111 }` because SearchBar/TransactionsHead sit z-below) and the `h3 subtitle` + SearchBar + TransactionsHead sticky rules.
- Barrel export.

Net −52 / +197 (of which 178 is the new component). TransactionsPageTitle itself shrinks 160 → 62 tsx lines and 161 → 48 css lines.

## What this unblocks

`AccountsPage` can adopt `<PageFilterTitle label={titleForAccountFilter(selectedTypes)} dropdownLabel="Select account types">{accountTypeButtons}</PageFilterTitle>` in a follow-up PR. That's the feature you asked about.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun --bun eslint src` clean
- [x] `bun test src/client` 312 pass / 0 fail
- [x] Sandbox: TransactionsPage — filter dropdown opens/closes on click, mouse-leave, touch-outside, Escape; multi-select preserves state; subtitle + SearchBar + TransactionsHead siblings render correctly
🤖 Generated with [Claude Code](https://claude.com/claude-code)

