### PR TITLE
refactor(client): route ChartAccountsPage + CapacitiesInput through the Properties/Row shell (#326 phase 4c)

### DIFF
--- a/src/client/components/BudgetProperties/CapacitiesInput/index.tsx
+++ b/src/client/components/BudgetProperties/CapacitiesInput/index.tsx
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction, ChangeEventHandler, useRef, useEffect } from 
 import { LocalDate, ViewDate, currencyCodeToSymbol, getDateString } from "common";
 import { Budget, Capacity, CapacityData, sortCapacities, useAppContext } from "client";
 import { BudgetFamily } from "client/lib/models/BudgetFamily";
-import { CapacityInput } from "client/components";
+import { CapacityInput, Row } from "client/components";
 import BudgetDonut from "./BudgetDonut";
 import "./index.css";
 
@@ -76,7 +76,7 @@ const CapacitiesInput = ({
     // time period backward so `new Date(0)` can be used to refer to the default capacity.
     const date = active_from || new Date(0);
     return (
-      <div key={key} className="row">
+      <Row key={key}>
         <div className="capacityAnalysis">
           <div className="dateLabel">
             <div>
@@ -117,7 +117,7 @@ const CapacitiesInput = ({
             />
           )}
         </div>
-      </div>
+      </Row>
     );
   });
 
@@ -156,9 +156,9 @@ const CapacitiesInput = ({
 
   return (
     <div className="CapacitiesInput">
-      <div className="row button">
+      <Row className="button">
         <button onClick={onClickAdd}>Add&nbsp;New&nbsp;Period</button>
-      </div>
+      </Row>
       {rows}
     </div>
   );

--- a/src/client/pages/ChartAccountsPage.tsx
+++ b/src/client/pages/ChartAccountsPage.tsx
@@ -12,7 +12,7 @@ import {
   FlowChartConfiguration,
   indexedDb,
 } from "client";
-import { ToggleInput } from "client/components";
+import { ToggleInput, Properties, PropertyLabel, Property, Row } from "client/components";
 
 export const ChartAccountsPage = () => {
   const { data, setData, router, viewDate } = useAppContext();
@@ -72,7 +72,7 @@ export const ChartAccountsPage = () => {
       };
 
       return (
-        <div key={a.id} className="row keyValue">
+        <Row key={a.id} className="keyValue">
           <div>
             <span>{a.custom_name || a.name}</span>
             <span className="small">&nbsp;&nbsp;{a.type}</span>
@@ -81,7 +81,7 @@ export const ChartAccountsPage = () => {
             defaultChecked={account_ids.includes(a.account_id)}
             onChange={onChangeToggle}
           />
-        </div>
+        </Row>
       );
     });
 
@@ -122,7 +122,7 @@ export const ChartAccountsPage = () => {
   // hatch other than deselecting every budget (= include all).
   const othersRow =
     type === ChartType.FLOW ? (
-      <div key={UNSORTED_BUDGET_ID} className="row keyValue">
+      <Row key={UNSORTED_BUDGET_ID} className="keyValue">
         <div>
           <em>Others</em>
           <span className="small">&nbsp;&nbsp;transactions without a budget label</span>
@@ -131,7 +131,7 @@ export const ChartAccountsPage = () => {
           defaultChecked={budget_ids.includes(UNSORTED_BUDGET_ID)}
           onChange={makeBudgetToggleHandler(UNSORTED_BUDGET_ID)}
         />
-      </div>
+      </Row>
     ) : null;
 
   const budgetRows = showBudgetSelector
@@ -150,7 +150,7 @@ export const ChartAccountsPage = () => {
         const capacityString = [sign, "$", numberToCommaString(capacityAmount, 0)].join(" ");
 
         return (
-          <div key={b.id} className="row keyValue">
+          <Row key={b.id} className="keyValue">
             <div>
               <span>{b.name}</span>
               <span className="small">
@@ -161,26 +161,26 @@ export const ChartAccountsPage = () => {
               defaultChecked={budget_ids.includes(b.id)}
               onChange={makeBudgetToggleHandler(b.id)}
             />
-          </div>
+          </Row>
         );
       })
     : [];
 
   return (
     <div className="ChartAccountsPage">
-      <div className="Properties sidePadding">
-        <div className="propertyLabel">Select accounts</div>
-        <div className="property">{accountRows}</div>
+      <Properties className="sidePadding">
+        <PropertyLabel>Select accounts</PropertyLabel>
+        <Property>{accountRows}</Property>
         {showBudgetSelector && (
           <>
-            <div className="propertyLabel">Select budgets</div>
-            <div className="property">
+            <PropertyLabel>Select budgets</PropertyLabel>
+            <Property>
               {othersRow}
               {budgetRows}
-            </div>
+            </Property>
           </>
         )}
-      </div>
+      </Properties>
     </div>
   );
 };


### PR DESCRIPTION
## What

`#326` phase 4c — route the two remaining hand-rolled shell-markup sites through the `<Properties>`/`<Row>` primitives, so every property panel and property-shaped list uses one canonical shell (Principle 2 — one canonical way per thing).

- **ChartAccountsPage** — opened a raw `<div className="Properties sidePadding">` with hand-rolled `.propertyLabel` / `.property` children and `.row keyValue` account/budget rows. Swapped for `<Properties className="sidePadding">` / `<PropertyLabel>` / `<Property>` / `<Row className="keyValue">`. This is the "ChartAccountsPage inline property markup" item from the `#326` tracking checklist.
- **CapacitiesInput** (`BudgetProperties/CapacitiesInput`) — its two `.row` divs (the per-period capacity rows and the "Add New Period" `.row button`) now route through `<Row>` / `<Row className="button">`.

Both are the same finding-kind (hand-rolled shell markup → shell primitive), bundled per the sweep-bundling rule.

## Why it's behavior-preserving

Pure div→component swap. The shell primitives emit the identical class strings:

- `<Row className="keyValue">` → `<div class="row keyValue">` (Row merges `row ${className}`) — byte-identical.
- `<Row>` → `<div class="row">` — byte-identical.
- `<Row className="button">` → `<div class="row button">` — byte-identical.
- `<PropertyLabel>` → `<div class="propertyLabel">`, `<Property>` → `<div class="property">` — byte-identical.
- `<Properties className="sidePadding">` → `<div class="sidePadding Properties">`. **Only token order differs** from the original `class="Properties sidePadding"`; `.sidePadding` is a standalone class (`App/index.css`) and CSS class matching is order-independent, so the cascade is unchanged. The direct-child structure (`.Properties > .propertyLabel`, `.Properties > .property`, `.property > .row`) is preserved exactly.

No `.tsx` logic, no handlers, no CSS changed.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun --bun eslint src` — clean
- [x] `bun run build:client` — built
- [x] `bun test src` — 1068 pass / 0 fail / 2 skip
- [x] **UI E2E** — sandbox, 390×844 mobile viewport, real click-chains (no direct-URL deep-links), screenshots eye-checked:
  - **ChartAccountsPage** — `/dashboard` → clicked a chart's `.chartRowTitle` (→ `/chart-detail`) → clicked the "N selected" accounts button (→ `/chart-accounts`). Rendered `class="sidePadding Properties"` (both tokens present; reordered from `Properties sidePadding`, CSS-irrelevant), `Select accounts` label as a **direct child** of `.Properties`, 1 `.property` box direct child, 19 account rows each `class="row keyValue"` under `.property` (direct-child selectors intact — no #472 wrapper regression). Screenshot: boxed account list, name + type + toggle per row, section frame + side padding correct.
  - **CapacitiesInput** — `/budgets` → expanded a budget bar → clicked its ✎ edit (→ `/budget-config`). `.CapacitiesInput` renders 2 direct `.row` children: the `class="row button"` "Add New Period" row and a capacity `class="row"` row (Remove + BudgetDonut). Screenshot: rows framed with dividers, donut renders — no layout breakage.
  - Screenshots: `/tmp/pr-612-chart-accounts.png`, `/tmp/pr-612-capacities.png`.
- [x] **reviewoie** — clean, 0 findings ([review](https://github.com/hoiekim/budget/pull/612#pullrequestreview-4653316996)). Verified shell primitives add no wrapper div, class strings byte-identical except the one CSS-irrelevant `sidePadding`/`Properties` reorder (confirmed zero order-sensitive selectors in `src/client`), direct-child + `.CapacitiesInput > div` selectors survive, no handler/logic change.
