### PR TITLE
refactor(client): getActiveParams follow-up (useCallback + JSDoc + tests)

### DIFF
--- a/src/client/lib/hooks/router.test.ts
+++ b/src/client/lib/hooks/router.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect } from "bun:test";
+import { deriveActiveParams, PATH } from "./router";
+import { ScreenType } from "./context";
+
+const p = (init: string) => new URLSearchParams(init);
+
+describe("deriveActiveParams", () => {
+  test("returns live params when currentPath matches targetPath (narrow, transitioning)", () => {
+    const live = p("account_type=depository");
+    const outgoing = p("account_type=investment");
+    const out = deriveActiveParams(
+      PATH.ACCOUNTS,
+      PATH.ACCOUNTS,
+      ScreenType.Narrow,
+      live,
+      outgoing,
+    );
+    expect(out).toBe(live);
+  });
+
+  test("returns live params on wide-screen even when currentPath differs", () => {
+    const live = p("account_type=depository");
+    const outgoing = p("account_type=investment");
+    const out = deriveActiveParams(
+      PATH.ACCOUNTS,
+      PATH.ACCOUNT_DETAIL,
+      ScreenType.Wide,
+      live,
+      outgoing,
+    );
+    expect(out).toBe(live);
+  });
+
+  test("returns incoming params when narrow AND currentPath differs from targetPath", () => {
+    const live = p("account_id=abc");
+    const outgoing = p("account_type=investment");
+    const out = deriveActiveParams(
+      PATH.ACCOUNTS,
+      PATH.ACCOUNT_DETAIL,
+      ScreenType.Narrow,
+      live,
+      outgoing,
+    );
+    expect(out).toBe(outgoing);
+  });
+
+  test("foot-gun: passing sibling PATH on steady-state narrow returns incomingParams, not live", () => {
+    // The AccountsPage caller mistakenly passing PATH.BUDGETS while
+    // the current page IS AccountsPage. currentPath === ACCOUNTS !==
+    // BUDGETS, so under narrow it reads incomingParams. This is the
+    // documented failure mode of the wrong-PATH arg — the test pins it
+    // so the behavior can't silently change.
+    const live = p("account_type=depository");
+    const outgoing = p("");
+    const out = deriveActiveParams(
+      PATH.BUDGETS,
+      PATH.ACCOUNTS,
+      ScreenType.Narrow,
+      live,
+      outgoing,
+    );
+    expect(out).toBe(outgoing);
+  });
+
+  test("wide-screen keeps live params even with wrong PATH", () => {
+    // Wrong PATH under wide-screen still returns live — the target
+    // check is short-circuited by `screenType !== Narrow`.
+    const live = p("account_type=depository");
+    const outgoing = p("");
+    const out = deriveActiveParams(
+      PATH.BUDGETS,
+      PATH.ACCOUNTS,
+      ScreenType.Wide,
+      live,
+      outgoing,
+    );
+    expect(out).toBe(live);
+  });
+
+  test("empty params on both sides — live still returned on match", () => {
+    const live = p("");
+    const outgoing = p("");
+    const out = deriveActiveParams(
+      PATH.DASHBOARD,
+      PATH.DASHBOARD,
+      ScreenType.Narrow,
+      live,
+      outgoing,
+    );
+    expect(out).toBe(live);
+  });
+});

--- a/src/client/lib/hooks/router.ts
+++ b/src/client/lib/hooks/router.ts
@@ -22,6 +22,23 @@ export enum PATH {
   CHART_ACCOUNTS = "chart-accounts",
 }
 
+/**
+ * Pure helper backing `router.getActiveParams`. Extracted so it can be
+ * unit-tested without mounting the router hook. See the docstring on
+ * `getActiveParams` inside `useRouter` for the semantics + the foot-gun
+ * on passing a sibling page's PATH.
+ */
+export const deriveActiveParams = (
+  targetPath: PATH,
+  currentPath: PATH,
+  screenType: ScreenType,
+  params: URLSearchParams,
+  incomingParams: URLSearchParams,
+): URLSearchParams => {
+  if (currentPath === targetPath || screenType !== ScreenType.Narrow) return params;
+  return incomingParams;
+};
+
 const getHighLevelPage = (path: string): PATH | undefined => {
   switch (path) {
     case PATH.BUDGETS:
@@ -286,10 +303,28 @@ export const useRouter = (screenType: ScreenType): ClientRouter => {
     window.history.back();
   }, []);
 
-  const getActiveParams = (targetPath: PATH) => {
-    if (path === targetPath || screenType !== ScreenType.Narrow) return params;
-    return incomingParams;
-  };
+  /**
+   * URL params source for a page or component whose UI should keep
+   * rendering the OUTGOING state during a narrow-screen slide-out.
+   *
+   * `targetPath` must be the {@link PATH} the caller BELONGS to (the
+   * page that owns this JSX). When we're steady-state on that page, or
+   * on any wide-screen viewport, we return the live `params` — reads +
+   * writes stay in sync. During a narrow-screen transition OFF that
+   * page, `path` has already flipped to the destination but the caller's
+   * JSX is still animating; returning `transition.incomingParams`
+   * (a snapshot of the outgoing URL) prevents its title label / filter
+   * chrome / detail lookup from flashing empty mid-animation.
+   *
+   * Passing the wrong `PATH` (a sibling page's identity) silently keeps
+   * the caller reading `incomingParams` at steady-state, which reads as
+   * "the filter dropdown never updates from the URL" — verify the arg
+   * matches the enclosing route.
+   */
+  const getActiveParams = useCallback(
+    (targetPath: PATH) => deriveActiveParams(targetPath, path, screenType, params, incomingParams),
+    [path, screenType, params, incomingParams],
+  );
 
   return {
     path,

--- a/src/client/lib/hooks/useMultiSelectQueryFilter.ts
+++ b/src/client/lib/hooks/useMultiSelectQueryFilter.ts
@@ -20,15 +20,25 @@ interface UseMultiSelectQueryFilterResult<T extends string> {
 
 /**
  * URL-first multi-select filter hook. Reads the current selection from
- * `activeParams` (defaults to `router.params`), validates against the
- * keys of `labels`, and provides `toggle` / `clearAll` writers that
- * preserve canonical (label-declaration) order in the serialized URL.
+ * `router.getActiveParams(targetPath)` (comma-separated), validates
+ * against the keys of `labels`, and provides `toggle` / `clearAll`
+ * writers that preserve canonical (label-declaration) order in the
+ * serialized URL.
  *
  * The `labels` record is the single source of truth: the allowed values
  * are `Object.keys(labels)`, and the returned `options` array zips each
  * value with its display label. That makes value/label consistency a
  * compile-time property — adding a new `T` to the union forces adding
  * a `labels` entry, and the hook picks it up automatically.
+ *
+ * `targetPath` must be the {@link PATH} of the page/component that owns
+ * this hook call — it feeds `router.getActiveParams` so the reader
+ * uses `incomingParams` during a narrow-screen slide-out and `params`
+ * otherwise. Passing a sibling page's PATH silently makes the dropdown
+ * read from the outgoing snapshot forever. The WRITER (`toggle` /
+ * `clearAll`) always writes through the live `router.params`; a click
+ * mid-transition should update the destination URL, not the frozen
+ * outgoing snapshot.
  *
  * Consumer contract: `labels` should be a stable (module-level) object
  * — passing a fresh reference every render breaks memoized comparisons


### PR DESCRIPTION
## Summary

Follow-up to `1a07bc0e implemented getActiveParams to reduce redundant code`, addressing the review notes on that commit. No behavior change — refactor + docs + tests.

## Changes

### `router.ts`

- **Wrap `getActiveParams` in `useCallback`** so the reference is stable across renders while `path` / `screenType` / `params` / `incomingParams` don't change. `go` / `back` / `forward` next to it are already useCallback'd; this makes the pattern consistent and lets future consumers put `getActiveParams` in useEffect / useMemo deps without re-firing on every parent render.
- **Extract `deriveActiveParams(targetPath, currentPath, screenType, params, incomingParams)`** as a pure module-level helper. The useCallback in the router forwards to it. Pure form unblocks unit testing without React harness or DOM mocks (the rest of `useRouter` touches `window` / `history` / `location`).
- **Add JSDoc** to `getActiveParams` explaining the transition-aware intent AND the foot-gun of passing a sibling page's PATH (silent read-from-`incomingParams`-forever at steady-state under narrow).

### `useMultiSelectQueryFilter.ts`

- **Add JSDoc for `targetPath`** in the main hook comment: it must match the enclosing page's route, and the writer always writes through live `params` (not the outgoing snapshot). Restores the reader/writer asymmetry explanation the old `Options` interface carried before `1a07bc0e` stripped it.

### `router.test.ts` (new)

6 tests pinning `deriveActiveParams` behavior:

- same-path narrow → live params.
- wide-screen bypass (currentPath differs) → live params.
- cross-path narrow → incoming params.
- **wrong-PATH foot-gun (steady-state under narrow) → incoming params** — pins the documented failure mode so it can't silently change.
- wrong-PATH bypassed by wide-screen → live params.
- empty-params base case.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun --bun eslint src` clean
- [x] `bun test src/client` → 318/0, 6 new tests
- [ ] Sandbox smoke — no behavior change expected, but worth clicking through AccountsPage / DashboardPage / BudgetsPage / TransactionsPage narrow-viewport transitions once to confirm no regression from the useCallback wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
