### PR TITLE
refactor(client): extract `<Placeholder>` common component (#326 phase 5a)

### DIFF
--- a/src/client/components/AccountsTable/index.css
+++ b/src/client/components/AccountsTable/index.css
@@ -104,12 +104,6 @@ div.AccountsTable > div > button {
   margin-left: 10px;
 }
 
-div.AccountsTable .placeholder {
-  padding: 10px;
-  display: flex;
-  align-items: center;
-}
-
 div.AccountsTable > .sectionTitle {
   margin-left: 10px;
   margin-top: 20px;

--- a/src/client/components/AccountsTable/index.tsx
+++ b/src/client/components/AccountsTable/index.tsx
@@ -1,6 +1,7 @@
 import { CSSProperties, ReactNode, useState } from "react";
 import { AccountType } from "plaid";
 import { Account, DonutData, useAppContext } from "client";
+import { Placeholder } from "client/components";
 import AccountRow from "./AccountRow";
 
 export type AccountHeaders = { [k in keyof Account]?: boolean } & {
@@ -98,9 +99,9 @@ export const AccountsTable = ({ donutData, selectedTypes, style }: Props) => {
         </div>
       )}
       {!accounts.size && (
-        <div className="placeholder">
+        <Placeholder>
           You don't have any connected accounts! Click this button to connect your accounts.
-        </div>
+        </Placeholder>
       )}
     </div>
   );

--- a/src/client/components/Placeholder/index.css
+++ b/src/client/components/Placeholder/index.css
@@ -1,0 +1,5 @@
+div.Placeholder {
+  padding: 10px;
+  display: flex;
+  align-items: center;
+}

--- a/src/client/components/Placeholder/index.tsx
+++ b/src/client/components/Placeholder/index.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from "react";
+import "./index.css";
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+}
+
+export const Placeholder = ({ children, className }: Props) => {
+  const classes = ["Placeholder", className].filter(Boolean).join(" ");
+  return <div className={classes}>{children}</div>;
+};

--- a/src/client/components/index.ts
+++ b/src/client/components/index.ts
@@ -2,6 +2,7 @@ export * from "./App";
 export * from "./Properties";
 export * from "./PageTitle";
 export * from "./PageFilterTitle";
+export * from "./Placeholder";
 export * from "./HoldingProperties";
 export * from "./InvestmentTransactionProperties";
 export * from "./ErrorBoundary";

--- a/src/client/pages/BudgetsPage/index.css
+++ b/src/client/pages/BudgetsPage/index.css
@@ -1,9 +1,3 @@
-div.BudgetsPage .placeholder {
-  padding: 10px;
-  display: flex;
-  align-items: center;
-}
-
 div.BudgetsPage > div.budgetsTable > .addButton {
   margin: 10px 10px;
 }

--- a/src/client/pages/BudgetsPage/index.tsx
+++ b/src/client/pages/BudgetsPage/index.tsx
@@ -11,7 +11,7 @@ import {
   Data,
   indexedDb,
 } from "client";
-import { BudgetBar, FilterOption, PageFilterTitle } from "client/components";
+import { BudgetBar, FilterOption, PageFilterTitle, Placeholder } from "client/components";
 import "./index.css";
 
 /**
@@ -169,9 +169,7 @@ export const BudgetsPage = () => {
           <button onClick={onClickAddBudget}>+</button>
         </div>
         {!budgetBars.length && (
-          <div className="placeholder">
-            You don't have any budgets! Click this button to create one.
-          </div>
+          <Placeholder>You don't have any budgets! Click this button to create one.</Placeholder>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Extracts the empty-state placeholder pattern into a shared `<Placeholder>` component. First of the "clear win" batch from the #326 componentization survey.

## What

Two sites in the codebase render the same empty-state pattern with byte-identical CSS:

- `AccountsTable/index.tsx` — "You don't have any connected accounts…"
- `BudgetsPage/index.tsx` — "You don't have any budgets…"

Both wrapped `<div className="placeholder">…</div>` and both defined the SAME CSS block scoped to their parent:

```css
.placeholder {
  padding: 10px;
  display: flex;
  align-items: center;
}
```

Consolidated as `<Placeholder>{message}</Placeholder>` — component owns the class + CSS, consumers just render children. Same shape as `<PageTitle>` / `<PageFilterTitle>` / `<FilterOption>`.

## Changes

- **`src/client/components/Placeholder/`** (new) — `index.tsx` (12 LOC) + `index.css` (byte-identical block promoted to `div.Placeholder`) + barrel export in `src/client/components/index.ts`.
- **`AccountsTable/index.tsx`** — `<div className="placeholder">…</div>` → `<Placeholder>…</Placeholder>`. Local `.placeholder` CSS block removed from `AccountsTable/index.css`.
- **`BudgetsPage/index.tsx`** — same swap. Local `.placeholder` CSS block removed from `BudgetsPage/index.css`.

Net: +23 / -18 across 7 files. Rendered DOM class-string differs (`.placeholder` → `.Placeholder`) but the applied CSS is unchanged.

## Consolidation-sweep note (excluded)

Two other empty-state renders were considered and **intentionally excluded** — their structural requirements can't fit `<Placeholder>`:

- `HoldingsComposition/index.tsx:307` — `<div className="holdingsRow holdingsEmpty">` sits INSIDE a CSS-grid `holdingsTable` and needs the `holdingsRow` grid-child layout to line up with the header. Wrapping it in `<Placeholder>` would break the grid contract.
- `HoldingProperties/index.tsx:204` — `loadError` is a plain `string` passed to a downstream error slot, not rendered directly. No JSX to swap; not an empty-state UI at all.

No other `.placeholder`-classed elements remain in the codebase (grep confirmed 0 sites post-refactor).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun --bun eslint src` clean
- [x] `bun test src/client` → 318/0
- [x] Sandbox — forced empty-state via `/budgets?budget_filter=income,unlimited,rolling-over`; `div.Placeholder` rendered with text "You don't have any budgets! Click this button to create one.", class `Placeholder`, computed CSS `padding: 10px; display: flex; align-items: center` — byte-identical to pre-refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)