### PR TITLE
fix(client): useViewDate — parse YYYY-MM correctly + URL-first re-derivation + tests

### DIFF
--- a/src/client/components/App/AppContext.tsx
+++ b/src/client/components/App/AppContext.tsx
@@ -1,14 +1,6 @@
 import { useState, useMemo, ReactNode } from "react";
-import {
-  useLocalStorageState,
-  ContextType,
-  Context,
-  useRouter,
-  reduceStatuses,
-  useViewDate,
-} from "client";
+import { ContextType, Context, useRouter, reduceStatuses, useViewDate } from "client";
 import { MaskedUser } from "server";
-import { Interval, ViewDate } from "common";
 import { useData, useScreenType } from "./lib";
 
 interface Props {

--- a/src/client/components/Header/index.tsx
+++ b/src/client/components/Header/index.tsx
@@ -4,38 +4,17 @@ import {
   ArrowLeftIcon,
   BankIcon,
   ChartIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
   HamburgerIcon,
   ListIcon,
   RecieptIcon,
 } from "client/components";
-import { getYearMonthString, Interval, parseYearMonthString, ViewDate } from "common";
+import { getYearMonthString, parseYearMonthString, ViewDate } from "common";
 import "./index.css";
 
 export const Header = () => {
   const { user, router, viewDate, setViewDate, screenType } = useAppContext();
 
   const { path, params, go, back } = router;
-
-  const onClickPreviousView = () => {
-    setViewDate((oldViewDate) => {
-      const newViewDate = oldViewDate.clone().previous();
-      return newViewDate;
-    });
-  };
-
-  const onClickNextView = () => {
-    setViewDate((oldViewDate) => {
-      const newViewDate = oldViewDate.clone().next();
-      return newViewDate;
-    });
-  };
-
-  const getIntervalOptionText = (interval: Interval, fallback: string) => {
-    if (viewDate.getInterval() !== interval) return fallback;
-    return viewDate.toString();
-  };
 
   const onClickBack: MouseEventHandler<HTMLButtonElement> = (e) => {
     e.preventDefault();

--- a/src/client/lib/hooks/context.ts
+++ b/src/client/lib/hooks/context.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext, Dispatch, SetStateAction } from "react";
 import { MaskedUser } from "server";
-import { Interval, ViewDate } from "common";
+import { ViewDate } from "common";
 import { ClientRouter, Status, Data, Calculations, CapacityData } from "client";
 
 export enum ScreenType {

--- a/src/client/lib/hooks/viewDate.test.ts
+++ b/src/client/lib/hooks/viewDate.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from "bun:test";
+import { parseViewDateString } from "./viewDate";
+
+describe("parseViewDateString", () => {
+  test("YYYY-MM parses to the correct month", () => {
+    // Reads position 5-6 for month via `parseYearMonthString`. Pre-fix,
+    // the hook used `substring(4, 6)` which grabbed the dash + first
+    // month digit ("-0"), parseInt("-0") = 0, || 1 → month index 0,
+    // resetting every session to January of the year in URL. This
+    // pins the corrected behavior.
+    const { interval, date } = parseViewDateString("2026-07");
+    expect(interval).toBe("month");
+    expect(date.getFullYear()).toBe(2026);
+    expect(date.getMonth()).toBe(6); // July (0-indexed)
+  });
+
+  test("YYYY-01 parses January without off-by-one", () => {
+    const { interval, date } = parseViewDateString("2026-01");
+    expect(interval).toBe("month");
+    expect(date.getMonth()).toBe(0);
+  });
+
+  test("YYYY-12 parses December without off-by-one", () => {
+    const { interval, date } = parseViewDateString("2026-12");
+    expect(interval).toBe("month");
+    expect(date.getMonth()).toBe(11);
+  });
+
+  test("YYYY parses to year interval + January 1st of that year", () => {
+    // Year interval is still readable so a bookmarked year URL still
+    // works even though there's no UI toggle post-Header simplification.
+    const { interval, date } = parseViewDateString("2026");
+    expect(interval).toBe("year");
+    expect(date.getFullYear()).toBe(2026);
+    expect(date.getMonth()).toBe(0);
+  });
+
+  test("garbage input falls back to month interval + today", () => {
+    // Invalid input shouldn't throw. Falls back to `new Date()` for
+    // the date; interval defaults to month. Pin so a hand-edited URL
+    // can't crash the app.
+    const before = Date.now();
+    const { interval, date } = parseViewDateString("garbage");
+    const after = Date.now();
+    expect(interval).toBe("month");
+    expect(date.getTime()).toBeGreaterThanOrEqual(before);
+    expect(date.getTime()).toBeLessThanOrEqual(after);
+  });
+
+  test("empty string falls back to month interval + today", () => {
+    const before = Date.now();
+    const { interval, date } = parseViewDateString("");
+    const after = Date.now();
+    expect(interval).toBe("month");
+    expect(date.getTime()).toBeGreaterThanOrEqual(before);
+    expect(date.getTime()).toBeLessThanOrEqual(after);
+  });
+});

--- a/src/client/lib/hooks/viewDate.ts
+++ b/src/client/lib/hooks/viewDate.ts
@@ -1,41 +1,59 @@
-import { Dispatch, SetStateAction, useCallback, useState } from "react";
-import { getYearMonthString, ViewDate } from "common";
+import { Dispatch, SetStateAction, useCallback, useMemo } from "react";
+import { getYearMonthString, Interval, parseYearMonthString, ViewDate } from "common";
 import { ClientRouter } from "./router";
+
+/**
+ * Pure parser for the `view_date` URL param. Extracted so it can be
+ * unit-tested without mounting the hook.
+ *
+ * URL format contract (matches what `setViewDate` writes):
+ *
+ * - month interval → `YYYY-MM` (7 chars, dashed — `getYearMonthString`
+ *   output).
+ * - year interval  → `YYYY`     (4 chars — bare year).
+ *
+ * Missing / invalid input falls back to today's month; keeps the hook
+ * from ever throwing on a hand-edited URL.
+ */
+export const parseViewDateString = (
+  viewDateString: string,
+): { interval: Interval; date: Date } => {
+  if (viewDateString.length === 4) {
+    const year = parseInt(viewDateString);
+    if (year) return { interval: "year", date: new Date(year, 0) };
+  }
+  const parsed = parseYearMonthString(viewDateString);
+  return { interval: "month", date: parsed ?? new Date() };
+};
 
 export const useViewDate = (router: ClientRouter) => {
   const { path, params, go } = router;
 
+  // URL is the source of truth. Read `params.get("view_date")` every
+  // render so a back-button / cross-consumer navigation re-derives
+  // viewDate without needing a separate state-sync effect. Memoize on
+  // the raw string so the returned `ViewDate` reference stays stable
+  // while the URL param doesn't change — consumers using viewDate in
+  // their own `useMemo` deps don't thrash.
   const viewDateString = params.get("view_date") || getYearMonthString();
-  const interval = viewDateString.length === 4 ? "year" : "month";
-  const year = parseInt(viewDateString.substring(0, 4));
-  const month = parseInt(viewDateString.substring(4, 6)) || 1;
-  const viewDateInit = new Date(year, month - 1);
-  const defaultViewDate = new ViewDate(interval, viewDateInit);
 
-  const [viewDate, _setViewDate] = useState(defaultViewDate);
+  const viewDate = useMemo(() => {
+    const { interval, date } = parseViewDateString(viewDateString);
+    return new ViewDate(interval, date);
+  }, [viewDateString]);
 
   const setViewDate: Dispatch<SetStateAction<ViewDate>> = useCallback(
     (value) => {
-      _setViewDate((prev) => {
-        let resolvedValue: ViewDate;
-        if (typeof value === "function") resolvedValue = value(prev);
-        else resolvedValue = value;
-
-        const newParams = new URLSearchParams(params);
-        if (resolvedValue.getInterval() === "year") {
-          const year = resolvedValue.getEndDate().getFullYear().toString();
-          newParams.set("view_date", year);
-        } else {
-          const yearMonth = getYearMonthString(resolvedValue.getEndDate());
-          newParams.set("view_date", yearMonth);
-        }
-
-        go(path, { params: newParams, animate: false });
-
-        return resolvedValue;
-      });
+      const resolvedValue = typeof value === "function" ? value(viewDate) : value;
+      const newParams = new URLSearchParams(params);
+      if (resolvedValue.getInterval() === "year") {
+        newParams.set("view_date", resolvedValue.getEndDate().getFullYear().toString());
+      } else {
+        newParams.set("view_date", getYearMonthString(resolvedValue.getEndDate()));
+      }
+      go(path, { params: newParams, animate: false });
     },
-    [_setViewDate, path, params, go],
+    [viewDate, path, params, go],
   );
 
   return [viewDate, setViewDate] as const;


### PR DESCRIPTION
## Summary

Fixes both bugs + the nits I flagged in the review of `b675929e` (implemented useViewDate). Leaves the "year view — retire or add UI toggle?" question to a separate call from Hoie.

## Fixes

### 🔴 HIGH — month parse bug (viewDate reset to January every session)

`setViewDate` writes `getYearMonthString(...)` which returns `YYYY-MM` (dashed). URL becomes `?view_date=2026-07`. But the hook read the URL back with `substring(4, 6)`:

```ts
const year  = parseInt(viewDateString.substring(0, 4));  // 2026 ✓
const month = parseInt(viewDateString.substring(4, 6)) || 1;
```

For `"2026-07"`, position 4 is the dash → `substring(4,6) === "-0"` → `parseInt("-0") === 0` → `|| 1` → month = 1 (January). Every session re-initialized to Jan 1 of the year in URL. Verified via `bun -e` — see commit body.

**Fix**: extract `parseViewDateString(viewDateString)` as a pure helper that dispatches to the existing `parseYearMonthString` for the dashed month form. Year form (`YYYY`, 4 chars) still supported so bookmarked year URLs keep working.

### 🟡 MED — URL back-button didn't sync viewDate

`useState(defaultViewDate)`'s initializer only ran on mount. If URL flipped (browser back, cross-consumer navigation, tab restore), `defaultViewDate` recomputed on re-render but `viewDate` stayed at the mount-time value.

**Fix**: drop the useState + derive `viewDate` from `params` each render via `useMemo(..., [viewDateString])`. Reference is stable while the URL param doesn't change (consumers' useMemo deps don't thrash), and back-button updates propagate immediately. Same URL-first shape as `useMultiSelectQueryFilter`. `setViewDate` closes over the derived `viewDate` to resolve functional-set callbacks — URL is still the only durable state.

### 🟢 Nits — unused imports left by b675929e

Main's CD workflow doesn't lint; the PR `test` workflow does, so any downstream PR touching these files would be red. Cleaned up:

- `AppContext.tsx` — `useLocalStorageState`, `Interval`, `ViewDate` (previously destructured for the `useState(new ViewDate(selectedInterval))` shape that's gone).
- `Header/index.tsx` — `ChevronLeftIcon`, `ChevronRightIcon`, `onClickPreviousView`, `onClickNextView`, `getIntervalOptionText`, `Interval` — dead code from the old prev/next chevron + interval `<select>` that the native `<input type="month">` replaced.
- `context.ts` — `Interval` (no longer on `ContextType`).

Also dropped from `useCallback` deps: `_setViewDate` (stable from `useState` — not needed even before this rewrite; the new hook shape doesn't use it at all).

## Tests

New `src/client/lib/hooks/viewDate.test.ts` — 6 tests pinning `parseViewDateString`:

- YYYY-MM correct-month (regression pin for the HIGH).
- YYYY-01 no off-by-one.
- YYYY-12 no off-by-one.
- YYYY year interval.
- garbage input → fallback to now.
- empty string → fallback to now.

Full suite 324 / 0, +6.

## Left out

**Year interval**: still readable in the hook so bookmarked year URLs work, but there's no UI toggle post-Header refactor. If the intent was to fully retire year mode, the `interval === "year"` branches in the hook can go too — deferred pending explicit call.

**Back-button-no-animation on view_date-only changes**: separate request Hoie made after the review — will address in a follow-up so this PR stays scoped to the 3 review-note fixes.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun --bun eslint src` clean
- [x] `bun test src/client` → 324 / 0 (+6 new)
- [ ] Sandbox — reload with `?view_date=2026-07` and confirm view stays on July (not January); click Add Budget then browser-back and confirm viewDate updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
