### PR TITLE
fix(client): skip transition animation on same-path query-only changes

### DIFF
--- a/src/client/lib/hooks/router.ts
+++ b/src/client/lib/hooks/router.ts
@@ -254,6 +254,22 @@ export const useRouter = (screenType: ScreenType): ClientRouter => {
         isAnimationEnabled.current = false;
       };
 
+      // Same-path (query-param-only) transitions never slide. Animation
+      // is meaningful for a NEW view — a URL that swapped one filter for
+      // another, or a browser-back stepping through the view_date
+      // history on the current page, should not flash a 300ms slide
+      // over otherwise-identical layout. Callers that navigate
+      // explicitly (e.g. `useMultiSelectQueryFilter`'s writer) already
+      // pass `animate: false` to `go()`, but browser-driven popstate
+      // flips this on: `back()` defaults `isAnimationEnabled.current =
+      // true`, and popstate can't know whether the target is same-path.
+      // Detect it here instead — the refs advanced above hold the
+      // outgoing route.
+      const isSamePath = newPath === outgoingPath;
+      if (isSamePath) {
+        isAnimationEnabled.current = false;
+      }
+
       if (window.innerWidth < 950 && isAnimationEnabled.current) {
         timeout.current = setTimeout(endTransition, DEFAULT_TRANSITION_DURATION);
       } else {


### PR DESCRIPTION
## Summary

Skips the router's slide animation on same-path query-param-only transitions. Answers Hoie's follow-up ask to the `useViewDate` review (opting for the broader "all same-path query changes" scope over view_date-specifically).

## Problem

The router's `back()` defaults `isAnimationEnabled.current = true`, and the popstate listener has no way to know whether the target URL is same-path. Result:

- Browser back/forward stepping through `?view_date=2026-08` → `?view_date=2026-05` on the same page flashes a 300ms slide over otherwise-identical layout.
- Same for filter param walks via history.
- Any future caller that forgets to pass `animate: false` on a same-path navigation gets the same jitter.

## Fix

`transition()` in `router.ts` detects `newPath === outgoingPath` right before the animation branch and forces `isAnimationEnabled.current = false`:

```ts
const isSamePath = newPath === outgoingPath;
if (isSamePath) {
  isAnimationEnabled.current = false;
}
```

Callers that navigate explicitly (`useMultiSelectQueryFilter`'s writer, `useViewDate`'s writer, most in-app `go()` calls) already pass `animate: false`, so this is a no-op for them. The change fires on:

- Browser back/forward that lands on the same path with different query params.
- Any caller that forgot `animate: false` on a same-path navigation — belt-and-braces.

## Depends on #620

`fix/useviewdate-parse-and-sync` — this branch is based on #620 (couldn't stack across forks in GitHub UI, so the diff here is against `main` and includes both sets until #620 merges). When #620 lands, this rebases to a single-file diff.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun --bun eslint src` clean (via #620's cleanup, folded in)
- [x] `bun test src/client` → 324 / 0
- [ ] Sandbox — narrow-viewport: navigate `?view_date=2026-08` → back → confirm no slide, only picker value flips. Also: `?account_type=depository` → `?account_type=credit` → back → confirm no slide. Cross-path back (detail → list) should still slide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)