### PR TITLE
fix(budgets): point-in-time capacity aggregation so the donut center matches its ring

### DIFF
--- a/src/client/lib/hooks/calculation/budgets.test.ts
+++ b/src/client/lib/hooks/calculation/budgets.test.ts
@@ -325,6 +325,54 @@ describe("getCapacityData — hierarchy aggregation", () => {
     const budgetCapId = budget.getActiveCapacity(new Date(0)).id;
     expect(cap.get(budgetCapId).children_total).toBe(-MAX_FLOAT);
   });
+
+  // Regression: #590 — a child versioned more granularly than its parent must
+  // not sum its stale (superseded) versions into the parent bucket. The budget
+  // has ONE "All past" capacity; its donut renders at date = that version's
+  // active_from (epoch), so children_total must equal the section's amount
+  // ACTIVE at epoch (its base 300 version), not 300 + 500 = 800.
+  test("section with two versions under a one-version budget does not double-count the stale version", () => {
+    const budget = new Budget({ name: "B" });
+    const section = new Section({
+      budget_id: budget.id,
+      capacities: [{ month: 300 }, { month: 500, active_from: new Date("2025-01-01") }],
+    });
+    const budgets = new BudgetDictionary();
+    budgets.set(budget.id, budget);
+    const sections = new SectionDictionary();
+    sections.set(section.id, section);
+
+    const cap = getCapacityData(budgets, sections, new CategoryDictionary());
+    const budgetCapId = budget.getActiveCapacity(new Date(0)).id;
+    // Point-in-time at the budget version's active_from (epoch) = base 300,
+    // matching the donut's child slices; NOT 800 (both versions summed).
+    expect(cap.get(budgetCapId).children_total).toBe(300);
+  });
+
+  // Regression: #590 (category granularity) — a category with two versions
+  // under a single-version section + single-version budget must contribute only
+  // its epoch-active version to both the section children_total and the budget
+  // grand_children_total, not the sum of both versions.
+  test("category with two versions does not double-count into section/budget buckets", () => {
+    const budget = new Budget({ name: "B" });
+    const section = new Section({ budget_id: budget.id, capacities: [{ month: 400 }] });
+    const category = new Category({
+      section_id: section.id,
+      capacities: [{ month: 100 }, { month: 250, active_from: new Date("2025-01-01") }],
+    });
+    const budgets = new BudgetDictionary();
+    budgets.set(budget.id, budget);
+    const sections = new SectionDictionary();
+    sections.set(section.id, section);
+    const categories = new CategoryDictionary();
+    categories.set(category.id, category);
+
+    const cap = getCapacityData(budgets, sections, categories);
+    const sectionCapId = section.getActiveCapacity(new Date(0)).id;
+    const budgetCapId = budget.getActiveCapacity(new Date(0)).id;
+    expect(cap.get(sectionCapId).children_total).toBe(100);
+    expect(cap.get(budgetCapId).grand_children_total).toBe(100);
+  });
 });
 
 describe("getBudgetData — confirmed-transfer exclusion", () => {

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -236,22 +236,14 @@ const oldestDate = new Date(0);
 /**
  * Point-in-time capacity aggregation, keyed by parent capacity version.
  *
- * Each parent capacity version renders its own `BudgetDonut` with
+ * Each parent capacity version renders its own `BudgetDonut` at
  * `date = capacity.active_from` (see `CapacitiesInput`), and that donut's
  * child slices read `child.getActiveAmount(date)`. So each bucket must hold
- * the sum of its children's amount **active at that same date** — not the
- * running sum of every historical child version.
- *
- * The previous shape iterated each child's capacity *versions* and bucketed
- * every version by whichever parent version was active at that child version's
- * own `active_from`. When a child is versioned more granularly than its parent
- * (e.g. a section bumped for a new period while the budget keeps one "All past"
- * capacity), two or more child versions collapse into the *same* parent bucket
- * and get summed — inflating the donut's center number by the stale, superseded
- * child versions while its ring (point-in-time child slices) stayed correct, so
- * the two disagreed on the same screen (#590). Summing each child's *active*
- * amount at the parent version's own `active_from` keeps the bucket point-in-
- * time and self-consistent with the ring.
+ * the sum of its children's amount **active at that same date**: a child
+ * versioned more granularly than its parent (e.g. a section bumped for a new
+ * period while the budget keeps one "All past" capacity) contributes only its
+ * version active at the parent's `active_from`, never the sum of its historical
+ * versions — otherwise the donut's center number drifts off its own ring.
  */
 export const getCapacityData = (
   budgets: BudgetDictionary,

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -233,6 +233,26 @@ export const getBudgetData = (
 
 const oldestDate = new Date(0);
 
+/**
+ * Point-in-time capacity aggregation, keyed by parent capacity version.
+ *
+ * Each parent capacity version renders its own `BudgetDonut` with
+ * `date = capacity.active_from` (see `CapacitiesInput`), and that donut's
+ * child slices read `child.getActiveAmount(date)`. So each bucket must hold
+ * the sum of its children's amount **active at that same date** — not the
+ * running sum of every historical child version.
+ *
+ * The previous shape iterated each child's capacity *versions* and bucketed
+ * every version by whichever parent version was active at that child version's
+ * own `active_from`. When a child is versioned more granularly than its parent
+ * (e.g. a section bumped for a new period while the budget keeps one "All past"
+ * capacity), two or more child versions collapse into the *same* parent bucket
+ * and get summed — inflating the donut's center number by the stale, superseded
+ * child versions while its ring (point-in-time child slices) stayed correct, so
+ * the two disagreed on the same screen (#590). Summing each child's *active*
+ * amount at the parent version's own `active_from` keeps the bucket point-in-
+ * time and self-consistent with the ring.
+ */
 export const getCapacityData = (
   budgets: BudgetDictionary,
   sections: SectionDictionary,
@@ -240,49 +260,39 @@ export const getCapacityData = (
 ) => {
   const capacityData = new CapacityData();
 
-  sections.forEach((section) => {
-    const budget = budgets.get(section.budget_id);
-    if (!budget) return;
-    section.capacities.forEach((capacity) => {
-      const { active_from } = capacity;
-      // For is_synced sections the stored `capacity.month` is just the
-      // advisory cache — sum the section's derived amount at this period
-      // so downstream consumers (BudgetDonut, isChildrenSynced legacy
-      // fallthrough) see the live total, not the stale cache.
-      const periodDate = active_from || oldestDate;
-      const capacityAmount = capacity.is_synced
-        ? capacity.getActiveAmount(periodDate, "month", section.getChildren())
-        : capacity.month;
-      const isInfinite = Math.abs(capacityAmount) === MAX_FLOAT;
-      const budgetCapacity = budget.getActiveCapacity(periodDate);
-      if (isInfinite) {
-        const override = MAX_FLOAT * (capacityAmount > 0 ? 1 : -1);
-        capacityData.get(budgetCapacity.id).children_total = override;
-      } else {
-        capacityData.get(budgetCapacity.id).children_total += capacityAmount;
-      }
+  // Sum each child's amount active at `date`. A single infinite child
+  // (±MAX_FLOAT) poisons the whole bucket to the sentinel, matching the
+  // BudgetDonut's `isChildrenInfinite` guard and Capacity.getActiveAmount.
+  // getActiveAmount already resolves synced children to their derived sum and
+  // non-synced children to the stored `month` of the version active at `date`.
+  const sumActiveAt = (children: (Section | Category)[], date: Date): number => {
+    let total = 0;
+    for (const child of children) {
+      const amount = child.getActiveAmount(date, "month");
+      if (Math.abs(amount) === MAX_FLOAT) return amount > 0 ? MAX_FLOAT : -MAX_FLOAT;
+      total += amount;
+    }
+    return total;
+  };
+
+  budgets.forEach((budget) => {
+    const budgetSections = sections.filter((s) => s.budget_id === budget.id);
+    const budgetCategories = budgetSections.flatMap((s) =>
+      categories.filter((c) => c.section_id === s.id),
+    );
+    budget.capacities.forEach((capacity) => {
+      const date = capacity.active_from || oldestDate;
+      const summary = capacityData.get(capacity.id);
+      summary.children_total = sumActiveAt(budgetSections, date);
+      summary.grand_children_total = sumActiveAt(budgetCategories, date);
     });
   });
 
-  categories.forEach((category) => {
-    const section = sections.get(category.section_id);
-    if (!section) return;
-    const budget = budgets.get(section.budget_id);
-    if (!budget) return;
-    category.capacities.forEach((capacity) => {
-      const { active_from } = capacity;
-      const capacityAmount = capacity.month;
-      const isInfinite = Math.abs(capacityAmount) === MAX_FLOAT;
-      const sectionCapacity = section.getActiveCapacity(active_from || oldestDate);
-      const budgetCapacity = budget.getActiveCapacity(active_from || oldestDate);
-      if (isInfinite) {
-        const override = MAX_FLOAT * (capacityAmount > 0 ? 1 : -1);
-        capacityData.get(sectionCapacity.id).children_total = override;
-        capacityData.get(budgetCapacity.id).grand_children_total = override;
-      } else {
-        capacityData.get(sectionCapacity.id).children_total += capacityAmount;
-        capacityData.get(budgetCapacity.id).grand_children_total += capacityAmount;
-      }
+  sections.forEach((section) => {
+    const sectionCategories = categories.filter((c) => c.section_id === section.id);
+    section.capacities.forEach((capacity) => {
+      const date = capacity.active_from || oldestDate;
+      capacityData.get(capacity.id).children_total = sumActiveAt(sectionCategories, date);
     });
   });
 

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -275,10 +275,25 @@ export const getCapacityData = (
     return total;
   };
 
+  // Group children by parent once (O(sections + categories)) so the aggregation
+  // loops below don't re-scan the full collections per parent.
+  const sectionsByBudget = new Map<string, Section[]>();
+  sections.forEach((section) => {
+    const list = sectionsByBudget.get(section.budget_id);
+    if (list) list.push(section);
+    else sectionsByBudget.set(section.budget_id, [section]);
+  });
+  const categoriesBySection = new Map<string, Category[]>();
+  categories.forEach((category) => {
+    const list = categoriesBySection.get(category.section_id);
+    if (list) list.push(category);
+    else categoriesBySection.set(category.section_id, [category]);
+  });
+
   budgets.forEach((budget) => {
-    const budgetSections = sections.filter((s) => s.budget_id === budget.id);
-    const budgetCategories = budgetSections.flatMap((s) =>
-      categories.filter((c) => c.section_id === s.id),
+    const budgetSections = sectionsByBudget.get(budget.id) || [];
+    const budgetCategories = budgetSections.flatMap(
+      (s) => categoriesBySection.get(s.id) || [],
     );
     budget.capacities.forEach((capacity) => {
       const date = capacity.active_from || oldestDate;
@@ -289,7 +304,7 @@ export const getCapacityData = (
   });
 
   sections.forEach((section) => {
-    const sectionCategories = categories.filter((c) => c.section_id === section.id);
+    const sectionCategories = categoriesBySection.get(section.id) || [];
     section.capacities.forEach((capacity) => {
       const date = capacity.active_from || oldestDate;
       capacityData.get(capacity.id).children_total = sumActiveAt(sectionCategories, date);


### PR DESCRIPTION
## Problem

Closes #590.

`getCapacityData` aggregated a child's (section/category) capacity into its parent's `children_total` / `grand_children_total` by iterating **every historical capacity version** of the child and bucketing each by whichever parent-capacity version was active at that child-version's `active_from`. When a child has **more capacity version boundaries than its parent**, two or more of the child's versions collapse into the *same* parent bucket and are **summed together**.

`BudgetDonut` reads that bucket as a single point-in-time total for its center number / "syncing amount", while its child slices use `child.getActiveAmount(date)` (point-in-time correct). So on the same screen the ring and the center **disagreed** — the center was inflated by the sum of the stale (superseded) child versions.

## Root cause

Each parent capacity version renders its own `BudgetDonut` with `date = capacity.active_from` (`CapacitiesInput/index.tsx:77`) — not the calendar date. So the bucket keyed to a parent version must hold the children's amount **active at that version's `active_from`**, not the running sum of every child version that happens to fall in the parent's span.

## Fix

Rewrite `getCapacityData` to iterate parent capacity versions and set each bucket to the sum of its children's **active** amount at the version's own `active_from` (via `getActiveAmount`, which already resolves synced children to their derived sum and non-synced children to the stored `month` of the version active at that date). Point-in-time and self-consistent with the ring. The `isChildrenSynced` legacy fallthrough (`BudgetFamily.ts:165`) reads the same buckets and is corrected the same way.

Note on the issue's "expected 500": the donut keys to each capacity version's `active_from`, not the calendar date, so for a single "All past" budget capacity the correct center is the section's amount active at epoch (the base version) — which is what the ring already shows. The defect fixed here is the ring/center **contradiction**; the fix makes the center match the ring.

## Tests

Two regression tests in `budgets.test.ts`, both constructed from the issue's minimal repro and asserted against the real `getCapacityData`:

- Section with two versions (base 300, then 500) under a one-version budget → budget `children_total` is 300 (the epoch-active version), was 800 (both summed) before the fix.
- Category with two versions (base 100, then 250) under single-version section+budget → section `children_total` and budget `grand_children_total` are 100, were 350 before the fix.

Verified both tests **fail on `upstream/main`** with exactly the inflated values (800, 350) and pass on this branch. Full client suite: 326 pass / 0 fail. Typecheck + lint clean.

## E2E

See PR comment — driven on the sandbox against the budget-config capacity donut.