### PR TITLE
refactor(client): extract <KeyValue> property-row primitive + migrate 92 rows (#326 phase 5c)

### DIFF
--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -20,6 +20,7 @@ import {
   DynamicCapacityInput,
   Graph,
   HoldingsComposition,
+  KeyValue,
   PerformanceBenchmark,
   InstitutionSpan,
   MoneyLabel,
@@ -130,12 +131,10 @@ export const AccountProperties = ({ account }: Props) => {
     <Properties className="AccountProperties">
       <PropertyLabel>Account&nbsp;Details</PropertyLabel>
       <Property>
-        <Row className="keyValue">
-          <span className="propertyName">Name</span>
+        <KeyValue name="Name">
           <input type="text" value={nameInput} onChange={onChangeNameInput} placeholder={name} />
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Type</span>
+        </KeyValue>
+        <KeyValue name="Type">
           {isManualAccount ? (
             <select value={typeInput} onChange={onChangeTypeInput}>
               {Object.values(AccountType).map((type) => (
@@ -147,33 +146,30 @@ export const AccountProperties = ({ account }: Props) => {
           ) : (
             <span>{toTitleCase(subtype || type)}</span>
           )}
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Institution</span>
+        </KeyValue>
+        <KeyValue name="Institution">
           {isManualAccount ? (
             <span>Manual</span>
           ) : (
             <InstitutionSpan institution_id={account.institution_id} />
           )}
-        </Row>
+        </KeyValue>
       </Property>
       {(!isManualAccount || !!graphData.lines) && <PropertyLabel>Balance</PropertyLabel>}
       {!isManualAccount && (
         <Property>
-          <Row className="keyValue">
-            <span className="propertyName">{currentLabel}</span>
+          <KeyValue name={currentLabel}>
             <span>
               {currencySymbol}&nbsp;
               {currentAmountString}
             </span>
-          </Row>
-          <Row className="keyValue">
-            <span className="propertyName">{pendingLabel}</span>
+          </KeyValue>
+          <KeyValue name={pendingLabel}>
             <span>
               {currencySymbol}&nbsp;
               {pendingAmountString}
             </span>
-          </Row>
+          </KeyValue>
         </Property>
       )}
       {!!graphData.lines && (
@@ -187,8 +183,7 @@ export const AccountProperties = ({ account }: Props) => {
           />
           <br />
           <Property>
-            <Row className="keyValue">
-              <span className="propertyName">{viewDate.toString()}&nbsp;balance</span>
+            <KeyValue name={<>{viewDate.toString()}&nbsp;balance</>}>
               <div className="amount">
                 <DynamicCapacityInput
                   disabled={isBalanceInputDisabled}
@@ -200,7 +195,7 @@ export const AccountProperties = ({ account }: Props) => {
                   onBlur={onChangeBalanceSnapshotInput}
                 />
               </div>
-            </Row>
+            </KeyValue>
           </Property>
         </>
       )}
@@ -210,40 +205,35 @@ export const AccountProperties = ({ account }: Props) => {
         <>
           <PropertyLabel>Balance&nbsp;Graph&nbsp;Options</PropertyLabel>
           <Property>
-            <Row className="keyValue">
-              <span className="propertyName">Use Transactions</span>
+            <KeyValue name="Use Transactions">
               <ToggleInput
                 checked={useTransactionsForGraph}
                 onChange={onClickUseTransactionsForGraph}
               />
-            </Row>
-            <Row className="keyValue">
-              <span className="propertyName">Use Snapshots</span>
+            </KeyValue>
+            <KeyValue name="Use Snapshots">
               <ToggleInput checked={useSnapshotsForGraph} onChange={onClickUseSnapshotsForGraph} />
-            </Row>
+            </KeyValue>
           </Property>
           <PropertyLabel>Account&nbsp;Preference</PropertyLabel>
           <Property>
-            <Row className="keyValue">
-              <span className="propertyName">Default&nbsp;Budget</span>
+            <KeyValue name="Default&nbsp;Budget">
               <select value={selectedBudgetIdLabel} onChange={onChangeBudgetSelect}>
                 <option value="">Select Budget</option>
                 {budgetOptions}
               </select>
-            </Row>
-            <Row className="keyValue">
-              <span className="propertyName">Archive</span>
+            </KeyValue>
+            <KeyValue name="Archive">
               {/* Hide already removes the account from view entirely; archiving
                *  on top adds nothing and would surface in "Show archived (N)"
                *  even though the user's already hidden the row. Disable to
                *  steer the user toward Unhide first if they want a different
                *  classification. Hoie 2026-06-25. */}
               <ToggleInput checked={isArchived} onChange={onClickArchive} disabled={isHidden} />
-            </Row>
-            <Row className="keyValue">
-              <span className="propertyName">Hide</span>
+            </KeyValue>
+            <KeyValue name="Hide">
               <ToggleInput checked={isHidden} onChange={onClickHide} />
-            </Row>
+            </KeyValue>
           </Property>
         </>
       )}
@@ -255,10 +245,9 @@ export const AccountProperties = ({ account }: Props) => {
        *  case so we don't reintroduce a separate Archive section. */}
       {isManualAccount && isArchived && (
         <Property>
-          <Row className="keyValue">
-            <span className="propertyName">Archive</span>
+          <KeyValue name="Archive">
             <ToggleInput checked={isArchived} onChange={onClickArchive} />
-          </Row>
+          </KeyValue>
         </Property>
       )}
       {(isManualAccount || type === AccountType.Investment) && (

--- a/src/client/components/ApiKeyProperties/index.tsx
+++ b/src/client/components/ApiKeyProperties/index.tsx
@@ -1,6 +1,15 @@
 import { useCallback, useEffect, useState } from "react";
 import type { ApiKeyJSON } from "server";
-import { call, PATH, Properties, Property, PropertyLabel, Row, useAppContext } from "client";
+import {
+  call,
+  KeyValue,
+  PATH,
+  Properties,
+  Property,
+  PropertyLabel,
+  Row,
+  useAppContext,
+} from "client";
 import "./index.css";
 
 type KeyView = Omit<ApiKeyJSON, "key_hash" | "revoked_at">;
@@ -107,10 +116,9 @@ export const ApiKeyProperties = () => {
           <Row>
             <span className="apiKeyCopyOnceTitle">Copy this key — it will not be shown again.</span>
           </Row>
-          <Row className="keyValue">
-            <span className="propertyName">Key</span>
+          <KeyValue name="Key">
             <code className="apiKeyPlaintext">{justCreated.plaintext}</code>
-          </Row>
+          </KeyValue>
         </Property>
         <PropertyLabel>&nbsp;</PropertyLabel>
         <Property>
@@ -135,8 +143,7 @@ export const ApiKeyProperties = () => {
       <Properties className="ApiKeyProperties">
         <PropertyLabel>New&nbsp;API&nbsp;Key</PropertyLabel>
         <Property>
-          <Row className="keyValue">
-            <span className="propertyName">Name</span>
+          <KeyValue name="Name">
             <input
               type="text"
               placeholder="e.g. claoie-suggester"
@@ -145,9 +152,8 @@ export const ApiKeyProperties = () => {
               disabled={creating}
               maxLength={255}
             />
-          </Row>
-          <Row className="keyValue">
-            <span className="propertyName">Scope</span>
+          </KeyValue>
+          <KeyValue name="Scope">
             <select value={scope} onChange={(e) => setScope(e.target.value)} disabled={creating}>
               {SCOPE_OPTIONS.map((o) => (
                 <option key={o.value} value={o.value}>
@@ -155,7 +161,7 @@ export const ApiKeyProperties = () => {
                 </option>
               ))}
             </select>
-          </Row>
+          </KeyValue>
           {error && (
             <Row>
               <span className="apiKeyError">{error}</span>
@@ -225,31 +231,25 @@ export const ApiKeyProperties = () => {
     <Properties className="ApiKeyProperties">
       <PropertyLabel>API&nbsp;Key&nbsp;Details</PropertyLabel>
       <Property>
-        <Row className="keyValue">
-          <span className="propertyName">Name</span>
+        <KeyValue name="Name">
           <span>{apiKey.name}</span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Prefix</span>
+        </KeyValue>
+        <KeyValue name="Prefix">
           <code className="apiKeyPrefix">{apiKey.key_prefix}…</code>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Scopes</span>
+        </KeyValue>
+        <KeyValue name="Scopes">
           <span>{apiKey.scopes.join(", ")}</span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Created</span>
+        </KeyValue>
+        <KeyValue name="Created">
           <span>{formatDate(apiKey.created_at)}</span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Last&nbsp;Used</span>
+        </KeyValue>
+        <KeyValue name="Last&nbsp;Used">
           <span>{formatDate(apiKey.last_used_at)}</span>
-        </Row>
+        </KeyValue>
         {apiKey.expires_at && (
-          <Row className="keyValue">
-            <span className="propertyName">Expires</span>
+          <KeyValue name="Expires">
             <span>{formatDate(apiKey.expires_at)}</span>
-          </Row>
+          </KeyValue>
         )}
       </Property>
       <PropertyLabel>&nbsp;</PropertyLabel>

--- a/src/client/components/BalanceChartProperties.tsx
+++ b/src/client/components/BalanceChartProperties.tsx
@@ -16,6 +16,7 @@ import {
   PropertyLabel,
   Property,
   Row,
+  KeyValue,
 } from "client";
 
 interface BalanceChartPropertiesProps {
@@ -101,12 +102,10 @@ export const BalanceChartProperties = ({ chart, children }: BalanceChartProperti
     <Properties>
       <PropertyLabel>Chart&nbsp;Profile</PropertyLabel>
       <Property>
-        <Row className="keyValue">
-          <span className="propertyName">Chart&nbsp;Name</span>
+        <KeyValue name="Chart&nbsp;Name">
           <input value={nameInput} onChange={onChangeName} aria-label="Chart name" />
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Chart&nbsp;Type</span>
+        </KeyValue>
+        <KeyValue name="Chart&nbsp;Type">
           <select value={selectedType} onChange={onChangeType}>
             {Object.values(ChartType).map((v) => {
               const chartTypeName = getChartTypeName(v);
@@ -117,7 +116,7 @@ export const BalanceChartProperties = ({ chart, children }: BalanceChartProperti
               );
             })}
           </select>
-        </Row>
+        </KeyValue>
       </Property>
 
       <PropertyLabel>Selected&nbsp;Accounts&nbsp;&&nbsp;Budgets</PropertyLabel>

--- a/src/client/components/ConnectionProperties/ConnectedAccountRow.tsx
+++ b/src/client/components/ConnectionProperties/ConnectedAccountRow.tsx
@@ -1,6 +1,6 @@
 import { MouseEventHandler } from "react";
 import { ItemProvider, toTitleCase } from "common";
-import { Account, Item, PATH, Property, Row, useAppContext } from "client";
+import { Account, Item, KeyValue, PATH, Property, Row, useAppContext } from "client";
 
 interface Props {
   item: Item;
@@ -21,19 +21,16 @@ export const ConnectedAccountRow = ({ item, account }: Props) => {
 
   return (
     <Property>
-      <Row className="keyValue">
-        <span className="propertyName">Name</span>
+      <KeyValue name="Name">
         <span>{custom_name || name}</span>
-      </Row>
-      <Row className="keyValue">
-        <span className="propertyName">Type</span>
+      </KeyValue>
+      <KeyValue name="Type">
         <span>{toTitleCase(type)}</span>
-      </Row>
+      </KeyValue>
       {!isManualItem && !!subtype && (
-        <Row className="keyValue">
-          <span className="propertyName">Subtype</span>
+        <KeyValue name="Subtype">
           <span>{toTitleCase(subtype)}</span>
-        </Row>
+        </KeyValue>
       )}
       <Row className="button">
         <button onClick={onClickDetails}>See&nbsp;Details</button>

--- a/src/client/components/ConnectionProperties/index.tsx
+++ b/src/client/components/ConnectionProperties/index.tsx
@@ -10,6 +10,7 @@ import {
   TransactionDictionary,
   call,
   InstitutionSpan,
+  KeyValue,
   PlaidLinkButton,
   Properties,
   PropertyLabel,
@@ -131,23 +132,19 @@ export const ConnectionProperties = ({ item }: Props) => {
       <PropertyLabel>Connection&nbsp;Detail</PropertyLabel>
       <Property>
         {!!institution_id && (
-          <Row className="keyValue">
-            <span className="propertyName">Institution</span>
+          <KeyValue name="Institution">
             <InstitutionSpan institution_id={institution_id} />
-          </Row>
+          </KeyValue>
         )}
-        <Row className="keyValue">
-          <span className="propertyName">Last&nbsp;Updated</span>
+        <KeyValue name="Last&nbsp;Updated">
           <span>{updated || "Unknown"}</span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Status</span>
+        </KeyValue>
+        <KeyValue name="Status">
           <span>{status ? toTitleCase(status) : "Unknown"}</span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Connection&nbsp;Provider</span>
+        </KeyValue>
+        <KeyValue name="Connection&nbsp;Provider">
           <span>{toUpperCamelCase(provider)}</span>
-        </Row>
+        </KeyValue>
       </Property>
       {accountRows}
       <PropertyLabel>&nbsp;</PropertyLabel>

--- a/src/client/components/FlowChartProperties.tsx
+++ b/src/client/components/FlowChartProperties.tsx
@@ -16,6 +16,7 @@ import {
   PropertyLabel,
   Property,
   Row,
+  KeyValue,
 } from "client";
 
 interface FlowChartPropertiesProps {
@@ -97,12 +98,10 @@ export const FlowChartProperties = ({ chart, children }: FlowChartPropertiesProp
     <Properties>
       <PropertyLabel>Chart&nbsp;Profile</PropertyLabel>
       <Property>
-        <Row className="keyValue">
-          <span className="propertyName">Chart&nbsp;Name</span>
+        <KeyValue name="Chart&nbsp;Name">
           <input value={nameInput} onChange={onChangeName} />
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Chart&nbsp;Type</span>
+        </KeyValue>
+        <KeyValue name="Chart&nbsp;Type">
           <select value={selectedType} onChange={onChangeType}>
             {Object.values(ChartType).map((v) => {
               const chartTypeName = getChartTypeName(v);
@@ -113,7 +112,7 @@ export const FlowChartProperties = ({ chart, children }: FlowChartPropertiesProp
               );
             })}
           </select>
-        </Row>
+        </KeyValue>
       </Property>
 
       <PropertyLabel>Selected&nbsp;Accounts</PropertyLabel>

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -24,6 +24,7 @@ import {
   PropertyLabel,
   Property,
   Row,
+  KeyValue,
   indexedDb,
   StoreName,
 } from "client";
@@ -610,10 +611,9 @@ export const HoldingProperties = () => {
       <Properties className="HoldingProperties">
         <PropertyLabel>Holding</PropertyLabel>
         <Property>
-          <Row className="keyValue">
-            <span className="propertyName">Missing&nbsp;account&nbsp;context</span>
+          <KeyValue name="Missing&nbsp;account&nbsp;context">
             <span></span>
-          </Row>
+          </KeyValue>
         </Property>
       </Properties>
     );
@@ -629,8 +629,7 @@ export const HoldingProperties = () => {
             cascade via descendant selectors. */}
         <Property>
           <form onSubmit={onSubmitNew}>
-            <Row className="keyValue">
-              <span className="propertyName">Ticker</span>
+            <KeyValue name="Ticker">
               <div className="tickerField">
                 <input
                   type="text"
@@ -643,12 +642,11 @@ export const HoldingProperties = () => {
                   {tickerStatus === "validating" ? "…" : "Check"}
                 </button>
               </div>
-            </Row>
+            </KeyValue>
             {tickerMessage && (
               <Row className={`tickerFeedback ${tickerStatus}`}>{tickerMessage}</Row>
             )}
-            <Row className="keyValue">
-              <span className="propertyName">Quantity</span>
+            <KeyValue name="Quantity">
               <input
                 type="number"
                 placeholder="0"
@@ -657,9 +655,8 @@ export const HoldingProperties = () => {
                 value={form.quantity}
                 onChange={onChangeField("quantity")}
               />
-            </Row>
-            <Row className="keyValue">
-              <span className="propertyName">Cost&nbsp;basis&nbsp;(opt)</span>
+            </KeyValue>
+            <KeyValue name="Cost&nbsp;basis&nbsp;(opt)">
               <input
                 type="number"
                 placeholder="Total $ paid (all shares)"
@@ -668,15 +665,14 @@ export const HoldingProperties = () => {
                 value={form.costBasis}
                 onChange={onChangeField("costBasis")}
               />
-            </Row>
-            <Row className="keyValue">
-              <span className="propertyName">Snapshot&nbsp;date</span>
+            </KeyValue>
+            <KeyValue name="Snapshot&nbsp;date">
               <input
                 type="date"
                 value={snapshotDateInput}
                 onChange={(e) => setSnapshotDateInput(e.target.value)}
               />
-            </Row>
+            </KeyValue>
             {submitError && <Row className="formError">{submitError}</Row>}
             <Row className="button">
               <button type="submit" className="colored">
@@ -717,32 +713,28 @@ export const HoldingProperties = () => {
     <Properties className="HoldingProperties">
       <PropertyLabel>Holding</PropertyLabel>
       <Property>
-        <Row className="keyValue">
-          <span className="propertyName">Ticker</span>
+        <KeyValue name="Ticker">
           <span>{bucketInfo.primaryLabel}</span>
-        </Row>
+        </KeyValue>
         {bucketInfo.name && (
-          <Row className="keyValue">
-            <span className="propertyName">Name</span>
+          <KeyValue name="Name">
             <span>{bucketInfo.name}</span>
-          </Row>
+          </KeyValue>
         )}
-        <Row className="keyValue">
-          <span className="propertyName">{isCash ? "Amount" : "Quantity"}</span>
+        <KeyValue name={isCash ? "Amount" : "Quantity"}>
           <span>
             {numberToCommaString(aggregate.totalQuantity, isCash ? 2 : 4)}
             {isCash && <span className="currencyMeta">&nbsp;{currencySymbol}</span>}
           </span>
-        </Row>
+        </KeyValue>
         {!isCash && (
-          <Row className="keyValue">
-            <span className="propertyName">Cost&nbsp;basis&nbsp;(avg)</span>
+          <KeyValue name="Cost&nbsp;basis&nbsp;(avg)">
             <span>
               {aggregate.avgCostBasis !== null
                 ? numberToCommaString(aggregate.avgCostBasis, 4)
                 : "—"}
             </span>
-          </Row>
+          </KeyValue>
         )}
       </Property>
 
@@ -771,8 +763,7 @@ export const HoldingProperties = () => {
               <span className="snapshotMeta">&nbsp;·&nbsp;{snap.holding.security_id}</span>
             </PropertyLabel>
             <Property>
-              <Row className="keyValue">
-                <span className="propertyName">{isCash ? "Amount" : "Quantity"}</span>
+              <KeyValue name={isCash ? "Amount" : "Quantity"}>
                 {isReadOnly ? (
                   <span>
                     {edit.quantity || "—"}
@@ -793,10 +784,9 @@ export const HoldingProperties = () => {
                     {isCash && <span className="currencyMeta">{currencySymbol}</span>}
                   </span>
                 )}
-              </Row>
+              </KeyValue>
               {!isCash && (
-                <Row className="keyValue">
-                  <span className="propertyName">Cost&nbsp;basis</span>
+                <KeyValue name="Cost&nbsp;basis">
                   {isReadOnly ? (
                     <span>{edit.costBasis || "—"}</span>
                   ) : (
@@ -809,10 +799,9 @@ export const HoldingProperties = () => {
                       onBlur={onBlurCostBasis(snap, edit.costBasis)}
                     />
                   )}
-                </Row>
+                </KeyValue>
               )}
-              <Row className="keyValue">
-                <span className="propertyName">Snapshot&nbsp;date</span>
+              <KeyValue name="Snapshot&nbsp;date">
                 {isReadOnly ? (
                   <span>{edit.date || "—"}</span>
                 ) : (
@@ -823,7 +812,7 @@ export const HoldingProperties = () => {
                     onBlur={onBlurDate(snap, edit.date)}
                   />
                 )}
-              </Row>
+              </KeyValue>
               {edit.error && <Row className="formError">{edit.error}</Row>}
               {!isReadOnly && (
                 <Row className="button">

--- a/src/client/components/InvestmentTransactionProperties/index.tsx
+++ b/src/client/components/InvestmentTransactionProperties/index.tsx
@@ -12,7 +12,7 @@ import {
   call,
   indexedDb,
 } from "client";
-import { InstitutionSpan, Properties, Property, PropertyLabel, Row } from "client/components";
+import { InstitutionSpan, KeyValue, Properties, Property, PropertyLabel, Row } from "client/components";
 import type { ValidateTickerResponse } from "server";
 
 interface Props {
@@ -283,8 +283,7 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
     <Properties className="InvestmentTransactionProperties">
       <PropertyLabel>Investment&nbsp;Transaction&nbsp;Details</PropertyLabel>
       <Property>
-        <Row className="keyValue">
-          <span className="propertyName">Date</span>
+        <KeyValue name="Date">
           {isManual ? (
             <input
               type="date"
@@ -301,9 +300,8 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
               })}
             </span>
           )}
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Name</span>
+        </KeyValue>
+        <KeyValue name="Name">
           {isManual ? (
             <input
               type="text"
@@ -315,13 +313,11 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
           ) : (
             <span>{name}</span>
           )}
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Security</span>
+        </KeyValue>
+        <KeyValue name="Security">
           <span>{security?.name || "—"}</span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Ticker</span>
+        </KeyValue>
+        <KeyValue name="Ticker">
           {isManual ? (
             <input
               type="text"
@@ -333,15 +329,13 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
           ) : (
             <span>{security?.ticker_symbol || "—"}</span>
           )}
-        </Row>
+        </KeyValue>
         {isManual && tickerMessage && (
-          <Row className="keyValue">
-            <span className="propertyName">&nbsp;</span>
+          <KeyValue name="&nbsp;">
             <span>{tickerMessage}</span>
-          </Row>
+          </KeyValue>
         )}
-        <Row className="keyValue">
-          <span className="propertyName">Type</span>
+        <KeyValue name="Type">
           {isManual ? (
             <select value={type} onChange={onChangeType}>
               {Object.values(InvestmentTransactionType).map((v) => (
@@ -353,9 +347,8 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
           ) : (
             <span>{toTitleCase(type)}</span>
           )}
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Subtype</span>
+        </KeyValue>
+        <KeyValue name="Subtype">
           {isManual ? (
             <select value={subtype} onChange={onChangeSubtype}>
               {Object.values(InvestmentTransactionSubtype).map((v) => (
@@ -367,9 +360,8 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
           ) : (
             <span>{toTitleCase(subtype)}</span>
           )}
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Quantity</span>
+        </KeyValue>
+        <KeyValue name="Quantity">
           {isManual ? (
             <input
               type="number"
@@ -381,9 +373,8 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
           ) : (
             <span>{numberToCommaString(quantity)}</span>
           )}
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Price</span>
+        </KeyValue>
+        <KeyValue name="Price">
           {isManual ? (
             <input
               type="number"
@@ -397,26 +388,22 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
               {currencySymbol}&nbsp;{numberToCommaString(price)}
             </span>
           )}
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Amount</span>
+        </KeyValue>
+        <KeyValue name="Amount">
           {/* Derived from quantity * price on manual rows (both branches
               render as a span). Plaid rows show the synced amount as
               before. */}
           <span>
             {currencySymbol}&nbsp;{numberToCommaString(amount)}
           </span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Account</span>
+        </KeyValue>
+        <KeyValue name="Account">
           <span>{account?.custom_name || account?.name}</span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Institution</span>
+        </KeyValue>
+        <KeyValue name="Institution">
           {account && <InstitutionSpan institution_id={account?.institution_id} />}
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Memo</span>
+        </KeyValue>
+        <KeyValue name="Memo">
           <input
             type="text"
             value={memoValue}
@@ -424,32 +411,29 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
             onChange={onChangeMemo}
             onBlur={onBlurMemo}
           />
-        </Row>
+        </KeyValue>
       </Property>
       <PropertyLabel>Budgets</PropertyLabel>
       <Property>
-        <Row className="keyValue">
-          <span className="propertyName">Budget</span>
+        <KeyValue name="Budget">
           <div>
             <select value={selectedBudgetIdLabel} onChange={onChangeBudgetSelect}>
               <option value="">Select Budget</option>
               {budgetOptions}
             </select>
           </div>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Section</span>
+        </KeyValue>
+        <KeyValue name="Section">
           <span>{sectionName}</span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Category</span>
+        </KeyValue>
+        <KeyValue name="Category">
           <div className={selectedCategoryIdLabel ? "" : "notification"}>
             <select value={selectedCategoryIdLabel} onChange={onChangeCategorySelect}>
               <option value="">Select Category</option>
               {categoryOptions}
             </select>
           </div>
-        </Row>
+        </KeyValue>
       </Property>
       {isManual && (
         <>

--- a/src/client/components/ProjectionChartProperties.tsx
+++ b/src/client/components/ProjectionChartProperties.tsx
@@ -16,6 +16,7 @@ import {
   PropertyLabel,
   Property,
   Row,
+  KeyValue,
 } from "client";
 import {
   ChangeEventHandler,
@@ -181,12 +182,10 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
     <Properties>
       <PropertyLabel>Chart&nbsp;Profile</PropertyLabel>
       <Property>
-        <Row className="keyValue">
-          <span className="propertyName">Chart&nbsp;Name</span>
+        <KeyValue name="Chart&nbsp;Name">
           <input value={nameInput} onChange={onChangeName} aria-label="Chart name" />
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Chart&nbsp;Type</span>
+        </KeyValue>
+        <KeyValue name="Chart&nbsp;Type">
           <select value={selectedType} onChange={onChangeType}>
             {Object.values(ChartType).map((v) => {
               const chartTypeName = getChartTypeName(v);
@@ -197,7 +196,7 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
               );
             })}
           </select>
-        </Row>
+        </KeyValue>
       </Property>
 
       <PropertyLabel>Selected&nbsp;Accounts</PropertyLabel>
@@ -211,8 +210,7 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
 
       <PropertyLabel>Saving&nbsp;Configuration</PropertyLabel>
       <Property>
-        <Row className="keyValue">
-          <span className="propertyName">Initial&nbsp;Saving</span>
+        <KeyValue name="Initial&nbsp;Saving">
           <div>
             <CapacityInput
               style={{ width: 100 }}
@@ -221,18 +219,16 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
             />
             <span className="small">&nbsp;$</span>
           </div>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Initial&nbsp;Saving&nbsp;as&nbsp;of</span>
+        </KeyValue>
+        <KeyValue name="Initial&nbsp;Saving&nbsp;as&nbsp;of">
           <input
             type="date"
             defaultValue={getDateString(initial_saving.amountAsOf)}
             onBlur={onBlurInitialSavingDate}
             aria-label="Initial saving as of date"
           />
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Monthly&nbsp;Contribution</span>
+        </KeyValue>
+        <KeyValue name="Monthly&nbsp;Contribution">
           <div>
             <CapacityInput
               style={{ width: 100 }}
@@ -241,9 +237,8 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
             />
             <span className="small">&nbsp;$</span>
           </div>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Anual&nbsp;Percentage&nbsp;Yield</span>
+        </KeyValue>
+        <KeyValue name="Anual&nbsp;Percentage&nbsp;Yield">
           <div>
             <CapacityInput
               style={{ width: 100 }}
@@ -255,12 +250,11 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
             />
             <span className="small">&nbsp;%</span>
           </div>
-        </Row>
+        </KeyValue>
       </Property>
       <PropertyLabel>Goal&nbsp;Configuration</PropertyLabel>
       <Property>
-        <Row className="keyValue">
-          <span className="propertyName">Living&nbsp;Cost</span>
+        <KeyValue name="Living&nbsp;Cost">
           <div>
             <CapacityInput
               style={{ width: 100 }}
@@ -269,18 +263,16 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
             />
             <span className="small">&nbsp;$</span>
           </div>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Living&nbsp;Cost&nbsp;as&nbsp;of</span>
+        </KeyValue>
+        <KeyValue name="Living&nbsp;Cost&nbsp;as&nbsp;of">
           <input
             type="date"
             defaultValue={getDateString(living_cost.amountAsOf)}
             onBlur={onBlurLivingCostDate}
             aria-label="Living cost as of date"
           />
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Tax&nbsp;Rate</span>
+        </KeyValue>
+        <KeyValue name="Tax&nbsp;Rate">
           <div>
             <CapacityInput
               style={{ width: 100 }}
@@ -292,9 +284,8 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
             />
             <span className="small">&nbsp;%</span>
           </div>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">YoY&nbsp;Inflation</span>
+        </KeyValue>
+        <KeyValue name="YoY&nbsp;Inflation">
           <div>
             <CapacityInput
               style={{ width: 100 }}
@@ -306,7 +297,7 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
             />
             <span className="small">&nbsp;%</span>
           </div>
-        </Row>
+        </KeyValue>
       </Property>
 
       <PropertyLabel>&nbsp;</PropertyLabel>

--- a/src/client/components/Properties/index.tsx
+++ b/src/client/components/Properties/index.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef } from "react";
+import { ComponentPropsWithoutRef, ReactNode } from "react";
 import "./index.css";
 
 type PropertiesProps = ComponentPropsWithoutRef<"div">;
@@ -65,5 +65,22 @@ export const Row = ({ className, children, ...rest }: RowProps) => {
     <div className={merged} {...rest}>
       {children}
     </div>
+  );
+};
+
+type KeyValueProps = ComponentPropsWithoutRef<"div"> & { name: ReactNode };
+
+/** The canonical labeled property row: a `.propertyName` key span followed by
+ *  its value. `name` is the key; `children` is the value. Renders a
+ *  `<Row className="keyValue">` so the key/value CSS
+ *  (`div.Properties .row.keyValue span.propertyName` / `:last-child`) applies.
+ *  Extra `className` composes after `keyValue`. */
+export const KeyValue = ({ name, className, children, ...rest }: KeyValueProps) => {
+  const merged = className ? `keyValue ${className}` : "keyValue";
+  return (
+    <Row className={merged} {...rest}>
+      <span className="propertyName">{name}</span>
+      {children}
+    </Row>
   );
 };

--- a/src/client/components/TransactionProperties/index.tsx
+++ b/src/client/components/TransactionProperties/index.tsx
@@ -22,6 +22,7 @@ import {
 } from "client";
 import {
   InstitutionSpan,
+  KeyValue,
   Properties,
   Property,
   PropertyLabel,
@@ -335,8 +336,7 @@ export const TransactionProperties = ({ transaction }: Props) => {
     <Properties className="TransactionProperties">
       <PropertyLabel>Transaction&nbsp;Details</PropertyLabel>
       <Property>
-        <Row className="keyValue">
-          <span className="propertyName">Date</span>
+        <KeyValue name="Date">
           {isManual ? (
             <input
               type="date"
@@ -353,13 +353,11 @@ export const TransactionProperties = ({ transaction }: Props) => {
               })}
             </span>
           )}
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Merchant&nbsp;Name</span>
+        </KeyValue>
+        <KeyValue name="Merchant&nbsp;Name">
           <span>{merchant_name}</span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Name</span>
+        </KeyValue>
+        <KeyValue name="Name">
           {isManual ? (
             <input
               type="text"
@@ -371,9 +369,8 @@ export const TransactionProperties = ({ transaction }: Props) => {
           ) : (
             <span>{name}</span>
           )}
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Amount</span>
+        </KeyValue>
+        <KeyValue name="Amount">
           {isManual ? (
             <input
               type="number"
@@ -389,21 +386,17 @@ export const TransactionProperties = ({ transaction }: Props) => {
               {numberToCommaString(Math.abs(amount))}
             </span>
           )}
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Location</span>
+        </KeyValue>
+        <KeyValue name="Location">
           <span>{locations.join(", ")}</span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Account</span>
+        </KeyValue>
+        <KeyValue name="Account">
           <span>{account?.custom_name || account?.name}</span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Institution</span>
+        </KeyValue>
+        <KeyValue name="Institution">
           {account && <InstitutionSpan institution_id={account?.institution_id} />}
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Memo</span>
+        </KeyValue>
+        <KeyValue name="Memo">
           <input
             type="text"
             value={memoValue}
@@ -411,34 +404,31 @@ export const TransactionProperties = ({ transaction }: Props) => {
             onChange={onChangeMemo}
             onBlur={onBlurMemo}
           />
-        </Row>
+        </KeyValue>
       </Property>
       {!splitTransactionInputRows?.length && (
         <>
           <PropertyLabel>Budgets</PropertyLabel>
           <Property>
-            <Row className="keyValue">
-              <span className="propertyName">Budget</span>
+            <KeyValue name="Budget">
               <div>
                 <select value={selectedBudgetIdLabel} onChange={onChangeBudgetSelect}>
                   <option value="">Select Budget</option>
                   {budgetOptions}
                 </select>
               </div>
-            </Row>
-            <Row className="keyValue">
-              <span className="propertyName">Section</span>
+            </KeyValue>
+            <KeyValue name="Section">
               <span>{sectionName}</span>
-            </Row>
-            <Row className="keyValue">
-              <span className="propertyName">Category</span>
+            </KeyValue>
+            <KeyValue name="Category">
               <div className={selectedCategoryIdLabel ? "" : "notification"}>
                 <select value={selectedCategoryIdLabel} onChange={onChangeCategorySelect}>
                   <option value="">Select Category</option>
                   {categoryOptions}
                 </select>
               </div>
-            </Row>
+            </KeyValue>
           </Property>
         </>
       )}
@@ -489,9 +479,7 @@ export const TransactionProperties = ({ transaction }: Props) => {
         )}
         {showPartnerPicker && (
           <>
-            <Row className="keyValue">
-              <span className="propertyName">Pair&nbsp;with</span>
-            </Row>
+            <KeyValue name="Pair&nbsp;with"></KeyValue>
             {partnerCandidates.length === 0 && (
               <Row className="partnerPickerEmpty">
                 <span className="partnerPickerEmptyText">

--- a/src/client/components/TransferProperties/index.tsx
+++ b/src/client/components/TransferProperties/index.tsx
@@ -4,6 +4,7 @@ import type { TransferPair } from "server";
 import { useAppContext, useTransfers } from "client";
 import {
   InstitutionSpan,
+  KeyValue,
   Properties,
   Property,
   PropertyLabel,
@@ -69,16 +70,13 @@ export const TransferProperties = ({ transfer }: Props) => {
       <>
         <PropertyLabel>{label}</PropertyLabel>
         <Property>
-          <Row className="keyValue">
-            <span className="propertyName">Account</span>
+          <KeyValue name="Account">
             <span>{account?.custom_name || account?.name || tx.account_id}</span>
-          </Row>
-          <Row className="keyValue">
-            <span className="propertyName">Institution</span>
+          </KeyValue>
+          <KeyValue name="Institution">
             {account ? <InstitutionSpan institution_id={account.institution_id} /> : <span />}
-          </Row>
-          <Row className="keyValue">
-            <span className="propertyName">Date</span>
+          </KeyValue>
+          <KeyValue name="Date">
             <span>
               {new LocalDate(txDate).toLocaleString("en-US", {
                 month: "long",
@@ -86,26 +84,22 @@ export const TransferProperties = ({ transfer }: Props) => {
                 year: "numeric",
               })}
             </span>
-          </Row>
-          <Row className="keyValue">
-            <span className="propertyName">Merchant&nbsp;Name</span>
+          </KeyValue>
+          <KeyValue name="Merchant&nbsp;Name">
             <span>{tx.merchant_name}</span>
-          </Row>
-          <Row className="keyValue">
-            <span className="propertyName">Name</span>
+          </KeyValue>
+          <KeyValue name="Name">
             <span>{tx.name}</span>
-          </Row>
+          </KeyValue>
           {txLocations.length > 0 && (
-            <Row className="keyValue">
-              <span className="propertyName">Location</span>
+            <KeyValue name="Location">
               <span>{txLocations.join(", ")}</span>
-            </Row>
+            </KeyValue>
           )}
           {tx.label?.memo && (
-            <Row className="keyValue">
-              <span className="propertyName">Memo</span>
+            <KeyValue name="Memo">
               <span>{tx.label.memo}</span>
-            </Row>
+            </KeyValue>
           )}
         </Property>
       </>
@@ -116,15 +110,13 @@ export const TransferProperties = ({ transfer }: Props) => {
     <Properties className="TransferProperties">
       <PropertyLabel>Transfer&nbsp;Details</PropertyLabel>
       <Property>
-        <Row className="keyValue">
-          <span className="propertyName">Type</span>
+        <KeyValue name="Type">
           <span className="transferChip transferChipConfirmed">
             <TransferArrowIcon size={12} />
             &nbsp;Transfer
           </span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Date</span>
+        </KeyValue>
+        <KeyValue name="Date">
           <span>
             {new LocalDate(date).toLocaleString("en-US", {
               month: "long",
@@ -132,15 +124,14 @@ export const TransferProperties = ({ transfer }: Props) => {
               year: "numeric",
             })}
           </span>
-        </Row>
-        <Row className="keyValue">
-          <span className="propertyName">Amount</span>
+        </KeyValue>
+        <KeyValue name="Amount">
           <span className="transferAmountInline">
             <TransferArrowIcon size={12} />
             &nbsp;{currencySymbol}&nbsp;
             {numberToCommaString(displayAmount)}
           </span>
-        </Row>
+        </KeyValue>
       </Property>
       {renderSide("From", outgoing, fromAccount)}
       {renderSide("To", incoming, toAccount)}


### PR DESCRIPTION
## What

Extract a `<KeyValue>` common component into the `Properties` shell family and migrate every hand-rolled labeled property row onto it. Closes the largest remaining hand-rolled markup pattern for the #326 design-component effort.

## Why

The labeled property row was written by hand at **92 sites** across 10 property panels:

```tsx
<Row className="keyValue">
  <span className="propertyName">Ticker</span>
  <span>{value}</span>
</Row>
```

Every author had to remember **both** the `keyValue` and `propertyName` class tokens; nothing enforced the convention (Principle 3 — boundaries should enforce, not request). It's exactly the "contributor doesn't know what CSS to apply" problem #326 was filed against, and the single most-repeated markup shape left after the earlier shell phases.

## What changed

- New `KeyValue` in `components/Properties/index.tsx` (same file as `Properties`/`PropertyLabel`/`Property`/`Row`, exported via the same barrel):

  ```tsx
  export const KeyValue = ({ name, className, children, ...rest }) => (
    <Row className={className ? `keyValue ${className}` : "keyValue"} {...rest}>
      <span className="propertyName">{name}</span>
      {children}
    </Row>
  );
  ```

  `name` is `ReactNode` (labels include plain text, `&nbsp;` text, and JSX expressions like `{isCash ? "Amount" : "Quantity"}`).

- Migrated all 92 conforming rows in: AccountProperties, ApiKeyProperties, BalanceChartProperties, ConnectionProperties (+ConnectedAccountRow), FlowChartProperties, HoldingProperties, InvestmentTransactionProperties, ProjectionChartProperties, TransactionProperties, TransferProperties.

- **DOM is byte-identical** — the component emits `<div class="row keyValue"><span class="propertyName">{name}</span>{value}</div>`, the exact string the sites hand-wrote, so `div.Properties .row.keyValue span.propertyName` and `:last-child` CSS apply unchanged. (Verified `&nbsp;` in a JSX string attribute decodes to the same ` ` as text children under esbuild/vite.)

- The **3 ChartAccountsPage** `keyValue` rows are **not** label/value pairs (they hold a `<div>` + `<ToggleInput>`, no `propertyName` key), so they stay as raw `<Row>` — forcing them into `KeyValue` would be the wrong abstraction.

Net **−59 LOC** (221 insertions, 280 deletions).

Refs #326.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (exit 0)
- [x] `bun run build-client` — built
- [x] `bun test src` — 1080 pass / 0 fail / 2 skip
- [x] Global invariant: `<KeyValue>` used 92×; only the 3 ChartAccountsPage toggle rows remain as raw `keyValue` (intended).
- [x] **UI E2E** — sandbox, real click-chains at 390×844 mobile, screenshots eye-checked (full disposition in the review reply):
  - **AccountProperties** (account-detail via account-row click): 4 `keyValue` rows render label-left / value-right.
  - **TransactionProperties** (transaction-detail via `.TransactionRow` click): 11 `keyValue` rows.
  - **ConnectionProperties** (connection-detail via `button.connection`): 10 `keyValue` rows incl. nested `ConnectedAccountRow`.
  - All 25 live rows: 0 non-conforming; every row computes `display:flex; justify-content:space-between` — CSS binds identically to baseline.

