### PR TITLE
feat(client): router preserves view_date + date-picker modal (View Date UI)

### DIFF
--- a/src/client/components/App/AppContext.tsx
+++ b/src/client/components/App/AppContext.tsx
@@ -14,7 +14,7 @@ const AppContext = ({ initialUser, children }: Props) => {
   const [user, setUser] = useState<MaskedUser | undefined>(initialUser);
 
   const router = useRouter(screenType);
-  const [viewDate, setViewDate] = useViewDate(router);
+  const [viewDate, setViewDate, resetViewDate] = useViewDate(router);
 
   const status = reduceStatuses(data?.status, calculations?.status);
 
@@ -30,9 +30,21 @@ const AppContext = ({ initialUser, children }: Props) => {
       router,
       viewDate,
       setViewDate,
+      resetViewDate,
       screenType,
     }),
-    [data, setData, calculations, calculate, status, user, router, viewDate, screenType],
+    [
+      data,
+      setData,
+      calculations,
+      calculate,
+      status,
+      user,
+      router,
+      viewDate,
+      resetViewDate,
+      screenType,
+    ],
   );
 
   return <Context.Provider value={contextValue}>{children}</Context.Provider>;

--- a/src/client/components/DatePickerModal/index.css
+++ b/src/client/components/DatePickerModal/index.css
@@ -10,32 +10,26 @@ div.DatePickerModal {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 10px;
 }
 
 div.DatePickerModal > div.panel {
   background-color: #292929;
   border: 1px solid #666;
   border-radius: 12px;
-  padding: 16px 18px;
-  min-width: 260px;
-  max-width: 360px;
-  width: 100%;
+  padding-bottom: 10px;
+  width: calc(100% - 20px);
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 10px;
+  overflow: hidden;
 }
 
 div.DatePickerModal > div.panel > div.header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-}
-
-div.DatePickerModal > div.panel > div.header > h3 {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
+  border-bottom: 1px solid #666;
+  padding: 10px;
 }
 
 div.DatePickerModal > div.panel > div.header > button.closeButton {
@@ -48,40 +42,42 @@ div.DatePickerModal > div.panel > div.header > button.closeButton {
 div.DatePickerModal > div.panel > div.dateInput {
   display: flex;
   justify-content: center;
-  padding: 4px 0;
+  align-items: center;
 }
 
 div.DatePickerModal > div.panel > div.dateInput > input {
-  font-size: 22px;
-  font-weight: 700;
+  background-color: #222;
   text-align: center;
-  padding: 6px 10px;
   min-width: 180px;
 }
 
 div.DatePickerModal > div.panel > div.stepper {
-  display: grid;
-  grid-template-columns: 1fr 2fr 1fr;
-  gap: 8px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
 }
 
 div.DatePickerModal > div.panel > div.stepper > button {
-  padding: 10px 0;
-  font-size: 14px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: 44px;
+  background-color: #222;
+}
+
+div.DatePickerModal > div.panel > div.stepper > button.currentButton {
+  padding: 0 16px;
 }
 
 div.DatePickerModal > div.panel > div.intervalRow {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 12px;
-}
-
-div.DatePickerModal > div.panel > div.intervalRow > label {
-  font-size: 14px;
 }
 
 div.DatePickerModal > div.panel > div.intervalRow > select {
   min-width: 120px;
-  padding: 6px 10px;
+  background-color: #222;
 }

--- a/src/client/components/DatePickerModal/index.css
+++ b/src/client/components/DatePickerModal/index.css
@@ -1,0 +1,76 @@
+div.DatePickerModal {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background-color: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+}
+
+div.DatePickerModal > div.panel {
+  background-color: #292929;
+  border: 1px solid #666;
+  border-radius: 12px;
+  padding: 16px 18px;
+  min-width: 260px;
+  max-width: 360px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+div.DatePickerModal > div.panel > div.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+div.DatePickerModal > div.panel > div.header > h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+div.DatePickerModal > div.panel > div.header > button.closeButton {
+  background-color: transparent;
+  font-size: 18px;
+  padding: 4px 8px;
+  line-height: 1;
+}
+
+div.DatePickerModal > div.panel > div.dateLabel {
+  font-size: 22px;
+  font-weight: 700;
+  text-align: center;
+  padding: 8px 0;
+}
+
+div.DatePickerModal > div.panel > div.stepper {
+  display: grid;
+  grid-template-columns: 1fr 2fr 1fr;
+  gap: 8px;
+}
+
+div.DatePickerModal > div.panel > div.stepper > button {
+  padding: 10px 0;
+  font-size: 14px;
+}
+
+div.DatePickerModal > div.panel > div.intervalRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+div.DatePickerModal > div.panel > div.intervalRow > label {
+  font-size: 14px;
+}
+
+div.DatePickerModal > div.panel > div.intervalRow > select {
+  min-width: 120px;
+  padding: 6px 10px;
+}

--- a/src/client/components/DatePickerModal/index.css
+++ b/src/client/components/DatePickerModal/index.css
@@ -45,11 +45,18 @@ div.DatePickerModal > div.panel > div.header > button.closeButton {
   line-height: 1;
 }
 
-div.DatePickerModal > div.panel > div.dateLabel {
+div.DatePickerModal > div.panel > div.dateInput {
+  display: flex;
+  justify-content: center;
+  padding: 4px 0;
+}
+
+div.DatePickerModal > div.panel > div.dateInput > input {
   font-size: 22px;
   font-weight: 700;
   text-align: center;
-  padding: 8px 0;
+  padding: 6px 10px;
+  min-width: 180px;
 }
 
 div.DatePickerModal > div.panel > div.stepper {

--- a/src/client/components/DatePickerModal/index.css
+++ b/src/client/components/DatePickerModal/index.css
@@ -1,7 +1,11 @@
 div.DatePickerModal {
   position: fixed;
   inset: 0;
-  z-index: 200;
+  /* Above everything: Header's fixed viewController is z-index 800,
+   * Router's page panels are 500–520. Modal needs to sit above them
+   * all so the SVG chart paths from the underlying Dashboard/Budgets
+   * page don't intercept clicks on the stepper buttons. */
+  z-index: 1000;
   background-color: rgba(0, 0, 0, 0.55);
   display: flex;
   align-items: center;

--- a/src/client/components/DatePickerModal/index.tsx
+++ b/src/client/components/DatePickerModal/index.tsx
@@ -101,7 +101,7 @@ export const DatePickerModal = ({ onClose }: Props) => {
     >
       <div className="panel">
         <div className="header">
-          <h3>View&nbsp;Date</h3>
+          <div>Select&nbsp;View&nbsp;Date</div>
           <button className="closeButton" onClick={onClose} aria-label="Close view date">
             <CloseIcon size={14} />
           </button>
@@ -113,6 +113,7 @@ export const DatePickerModal = ({ onClose }: Props) => {
            * end via `ViewDate.setInterval`), but keeping the same
            * picker widget avoids UI shape change on interval flip. */}
           <input
+            id="view-date-picker"
             type="month"
             aria-label={interval === "year" ? "Year (month ignored)" : "Month"}
             value={monthInputValue}

--- a/src/client/components/DatePickerModal/index.tsx
+++ b/src/client/components/DatePickerModal/index.tsx
@@ -1,0 +1,103 @@
+import { KeyboardEvent, useEffect } from "react";
+import { Interval, ViewDate } from "common";
+import { useAppContext } from "client";
+import "./index.css";
+
+interface Props {
+  onClose: () => void;
+}
+
+/**
+ * Modal wrapping the view-date controls: current-period label, prev /
+ * current / next stepper, and month/year interval selector. Opened by
+ * the button rendered in `Header`.
+ *
+ * Structure:
+ *
+ *     View Date
+ *     [Jul 2026]
+ *     [<] [Current] [>]
+ *     Interval: [month] v
+ *
+ * The Current button calls `resetViewDate()` to REMOVE the URL param
+ * rather than writing today's period. See the `resetViewDate` doc in
+ * `context.ts` for the "bookmark clean" rationale.
+ */
+export const DatePickerModal = ({ onClose }: Props) => {
+  const { viewDate, setViewDate, resetViewDate } = useAppContext();
+  const interval = viewDate.getInterval();
+  const dateLabel = viewDate.toString(
+    interval === "year" ? undefined : { year: "numeric", month: "long" },
+  );
+
+  const onPrev = () => setViewDate((v) => v.clone().previous());
+  const onNext = () => setViewDate((v) => v.clone().next());
+  const onCurrent = () => resetViewDate();
+  const onChangeInterval = (next: Interval) => {
+    setViewDate((v) => {
+      const clone = new ViewDate(v.getInterval(), v.getEndDate());
+      clone.setInterval(next);
+      return clone;
+    });
+  };
+
+  // Escape closes the modal — matches PageFilterTitle's dismissal shape.
+  useEffect(() => {
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const onBackdropKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="DatePickerModal"
+      role="dialog"
+      aria-modal="true"
+      aria-label="View date"
+      onClick={onClose}
+      onKeyDown={onBackdropKeyDown}
+      tabIndex={-1}
+    >
+      <div className="panel" onClick={(e) => e.stopPropagation()}>
+        <div className="header">
+          <h3>View&nbsp;Date</h3>
+          <button className="closeButton" onClick={onClose} aria-label="Close view date">
+            ✕
+          </button>
+        </div>
+        <div className="dateLabel">{dateLabel}</div>
+        <div className="stepper">
+          <button onClick={onPrev} aria-label="Previous period">
+            ◀
+          </button>
+          <button className="currentButton" onClick={onCurrent}>
+            Current
+          </button>
+          <button onClick={onNext} aria-label="Next period">
+            ▶
+          </button>
+        </div>
+        <div className="intervalRow">
+          <label htmlFor="interval-select">Interval</label>
+          <select
+            id="interval-select"
+            value={interval}
+            onChange={(e) => onChangeInterval(e.target.value as Interval)}
+          >
+            <option value="month">Month</option>
+            <option value="year">Year</option>
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/client/components/DatePickerModal/index.tsx
+++ b/src/client/components/DatePickerModal/index.tsx
@@ -1,6 +1,7 @@
 import { KeyboardEvent, useEffect } from "react";
 import { Interval, ViewDate } from "common";
 import { useAppContext } from "client";
+import { ChevronLeftIcon, ChevronRightIcon, CloseIcon } from "client/components";
 import "./index.css";
 
 interface Props {
@@ -71,19 +72,19 @@ export const DatePickerModal = ({ onClose }: Props) => {
         <div className="header">
           <h3>View&nbsp;Date</h3>
           <button className="closeButton" onClick={onClose} aria-label="Close view date">
-            ✕
+            <CloseIcon size={14} />
           </button>
         </div>
         <div className="dateLabel">{dateLabel}</div>
         <div className="stepper">
           <button onClick={onPrev} aria-label="Previous period">
-            ◀
+            <ChevronLeftIcon size={14} />
           </button>
           <button className="currentButton" onClick={onCurrent}>
             Current
           </button>
           <button onClick={onNext} aria-label="Next period">
-            ▶
+            <ChevronRightIcon size={14} />
           </button>
         </div>
         <div className="intervalRow">

--- a/src/client/components/DatePickerModal/index.tsx
+++ b/src/client/components/DatePickerModal/index.tsx
@@ -1,5 +1,5 @@
 import { KeyboardEvent, useEffect } from "react";
-import { Interval, ViewDate } from "common";
+import { getYearMonthString, Interval, parseYearMonthString, ViewDate } from "common";
 import { useAppContext } from "client";
 import { ChevronLeftIcon, ChevronRightIcon, CloseIcon } from "client/components";
 import "./index.css";
@@ -27,9 +27,9 @@ interface Props {
 export const DatePickerModal = ({ onClose }: Props) => {
   const { viewDate, setViewDate, resetViewDate } = useAppContext();
   const interval = viewDate.getInterval();
-  const dateLabel = viewDate.toString(
-    interval === "year" ? undefined : { year: "numeric", month: "long" },
-  );
+  const endDate = viewDate.getEndDate();
+  const monthInputValue = getYearMonthString(endDate);
+  const yearInputValue = endDate.getFullYear();
 
   const onPrev = () => setViewDate((v) => v.clone().previous());
   const onNext = () => setViewDate((v) => v.clone().next());
@@ -40,6 +40,16 @@ export const DatePickerModal = ({ onClose }: Props) => {
       clone.setInterval(next);
       return clone;
     });
+  };
+  const onChangeMonthInput = (value: string) => {
+    const date = parseYearMonthString(value);
+    if (!date) return;
+    setViewDate((v) => new ViewDate(v.getInterval(), date));
+  };
+  const onChangeYearInput = (value: string) => {
+    const year = parseInt(value);
+    if (!year || year < 1970 || year > 9999) return;
+    setViewDate((v) => new ViewDate(v.getInterval(), new Date(year, 0)));
   };
 
   // Escape closes the modal — matches PageFilterTitle's dismissal shape.
@@ -52,6 +62,13 @@ export const DatePickerModal = ({ onClose }: Props) => {
   }, [onClose]);
 
   const onBackdropKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    // Only handle Enter/Space when the backdrop ITSELF is the target
+    // (activation of the outer div's keyboard "button" affordance).
+    // Reviewoie #624 caught the earlier version treating bubbled events
+    // as backdrop activations — Enter on Prev/Current/Next inside the
+    // panel called preventDefault + onClose, breaking keyboard operation
+    // of every control in the modal.
+    if (e.target !== e.currentTarget) return;
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
       onClose();
@@ -64,18 +81,38 @@ export const DatePickerModal = ({ onClose }: Props) => {
       role="dialog"
       aria-modal="true"
       aria-label="View date"
-      onClick={onClose}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
       onKeyDown={onBackdropKeyDown}
       tabIndex={-1}
     >
-      <div className="panel" onClick={(e) => e.stopPropagation()}>
+      <div className="panel">
         <div className="header">
           <h3>View&nbsp;Date</h3>
           <button className="closeButton" onClick={onClose} aria-label="Close view date">
             <CloseIcon size={14} />
           </button>
         </div>
-        <div className="dateLabel">{dateLabel}</div>
+        <div className="dateInput">
+          {interval === "month" ? (
+            <input
+              type="month"
+              aria-label="Month"
+              value={monthInputValue}
+              onChange={(e) => onChangeMonthInput(e.target.value)}
+            />
+          ) : (
+            <input
+              type="number"
+              aria-label="Year"
+              min={1970}
+              max={9999}
+              value={yearInputValue}
+              onChange={(e) => onChangeYearInput(e.target.value)}
+            />
+          )}
+        </div>
         <div className="stepper">
           <button onClick={onPrev} aria-label="Previous period">
             <ChevronLeftIcon size={14} />

--- a/src/client/components/DatePickerModal/index.tsx
+++ b/src/client/components/DatePickerModal/index.tsx
@@ -27,9 +27,7 @@ interface Props {
 export const DatePickerModal = ({ onClose }: Props) => {
   const { viewDate, setViewDate, resetViewDate } = useAppContext();
   const interval = viewDate.getInterval();
-  const endDate = viewDate.getEndDate();
-  const monthInputValue = getYearMonthString(endDate);
-  const yearInputValue = endDate.getFullYear();
+  const monthInputValue = getYearMonthString(viewDate.getEndDate());
 
   const onPrev = () => setViewDate((v) => v.clone().previous());
   const onNext = () => setViewDate((v) => v.clone().next());
@@ -45,11 +43,6 @@ export const DatePickerModal = ({ onClose }: Props) => {
     const date = parseYearMonthString(value);
     if (!date) return;
     setViewDate((v) => new ViewDate(v.getInterval(), date));
-  };
-  const onChangeYearInput = (value: string) => {
-    const year = parseInt(value);
-    if (!year || year < 1970 || year > 9999) return;
-    setViewDate((v) => new ViewDate(v.getInterval(), new Date(year, 0)));
   };
 
   // Escape closes the modal — matches PageFilterTitle's dismissal shape.
@@ -95,23 +88,17 @@ export const DatePickerModal = ({ onClose }: Props) => {
           </button>
         </div>
         <div className="dateInput">
-          {interval === "month" ? (
-            <input
-              type="month"
-              aria-label="Month"
-              value={monthInputValue}
-              onChange={(e) => onChangeMonthInput(e.target.value)}
-            />
-          ) : (
-            <input
-              type="number"
-              aria-label="Year"
-              min={1970}
-              max={9999}
-              value={yearInputValue}
-              onChange={(e) => onChangeYearInput(e.target.value)}
-            />
-          )}
+          {/* Native month picker for both intervals. In year mode
+           * the specific month within the year is irrelevant to the
+           * calculation surface (`getEndDate` still returns the year's
+           * end via `ViewDate.setInterval`), but keeping the same
+           * picker widget avoids UI shape change on interval flip. */}
+          <input
+            type="month"
+            aria-label={interval === "year" ? "Year (month ignored)" : "Month"}
+            value={monthInputValue}
+            onChange={(e) => onChangeMonthInput(e.target.value)}
+          />
         </div>
         <div className="stepper">
           <button onClick={onPrev} aria-label="Previous period">

--- a/src/client/components/DatePickerModal/index.tsx
+++ b/src/client/components/DatePickerModal/index.tsx
@@ -54,6 +54,19 @@ export const DatePickerModal = ({ onClose }: Props) => {
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
+  // Lock body scroll while the modal is open — otherwise the underlying
+  // page (Dashboard chart rows, Budgets list, etc.) still scrolls behind
+  // the backdrop, which reads as broken modal semantics. Restore the
+  // previous overflow value on unmount so the app-level style isn't
+  // permanently overridden (matches how most modal libraries handle it).
+  useEffect(() => {
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, []);
+
   const onBackdropKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     // Only handle Enter/Space when the backdrop ITSELF is the target
     // (activation of the outer div's keyboard "button" affordance).

--- a/src/client/components/DatePickerModal/index.tsx
+++ b/src/client/components/DatePickerModal/index.tsx
@@ -54,16 +54,22 @@ export const DatePickerModal = ({ onClose }: Props) => {
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  // Lock body scroll while the modal is open — otherwise the underlying
-  // page (Dashboard chart rows, Budgets list, etc.) still scrolls behind
-  // the backdrop, which reads as broken modal semantics. Restore the
-  // previous overflow value on unmount so the app-level style isn't
-  // permanently overridden (matches how most modal libraries handle it).
+  // Lock scroll while the modal is open — otherwise the underlying
+  // page (Dashboard chart rows, Budgets list, etc.) still scrolls
+  // behind the backdrop, which reads as broken modal semantics. Have
+  // to lock BOTH `html` and `body`: in this app's CSS shape, `<html>`
+  // is the scroll root, so `body { overflow: hidden }` alone doesn't
+  // stop user wheel/touch scrolling. Restore both previous values on
+  // unmount so the app-level styles aren't permanently overridden.
   useEffect(() => {
-    const previous = document.body.style.overflow;
+    const html = document.documentElement;
+    const prevHtml = html.style.overflow;
+    const prevBody = document.body.style.overflow;
+    html.style.overflow = "hidden";
     document.body.style.overflow = "hidden";
     return () => {
-      document.body.style.overflow = previous;
+      html.style.overflow = prevHtml;
+      document.body.style.overflow = prevBody;
     };
   }, []);
 

--- a/src/client/components/Header/index.css
+++ b/src/client/components/Header/index.css
@@ -59,10 +59,6 @@ div.Header > .viewController > div > div.datePicker {
   align-items: center;
 }
 
-div.Header > .viewController > div > div.datePicker > input {
-  text-align: center;
-}
-
 div.Header > .viewController > div > .backButton {
   width: 25px;
 }

--- a/src/client/components/Header/index.tsx
+++ b/src/client/components/Header/index.tsx
@@ -1,18 +1,18 @@
-import { MouseEventHandler, ReactNode } from "react";
+import { MouseEventHandler, ReactNode, useState } from "react";
 import { useAppContext, PATH, ScreenType } from "client";
 import {
   ArrowLeftIcon,
   BankIcon,
   ChartIcon,
+  DatePickerModal,
   HamburgerIcon,
   ListIcon,
   RecieptIcon,
 } from "client/components";
-import { getYearMonthString, parseYearMonthString, ViewDate } from "common";
 import "./index.css";
 
 export const Header = () => {
-  const { user, router, viewDate, setViewDate, screenType } = useAppContext();
+  const { user, router, viewDate, screenType } = useAppContext();
 
   const { path, params, go, back } = router;
 
@@ -49,7 +49,11 @@ export const Header = () => {
   const classNames = ["Header"];
   if (screenType !== ScreenType.Narrow) classNames.push("wideScreen");
 
-  const datePickerValue = getYearMonthString(viewDate.getEndDate());
+  const [datePickerOpen, setDatePickerOpen] = useState(false);
+  const interval = viewDate.getInterval();
+  const datePickerLabel = viewDate.toString(
+    interval === "year" ? undefined : { year: "numeric", month: "long" },
+  );
 
   return (
     <div className={classNames.join(" ")} style={{ display: user ? undefined : "none" }}>
@@ -63,17 +67,14 @@ export const Header = () => {
             )}
           </div>
           <div className="datePicker">
-            <input
-              id="view_date_picker"
-              type="month"
-              value={datePickerValue}
-              onChange={(e) => {
-                const value = e.target.value;
-                const date = parseYearMonthString(value);
-                if (!date) return;
-                setViewDate((oldViewDate) => new ViewDate(oldViewDate.getInterval(), date));
-              }}
-            />
+            <button
+              className="datePickerTrigger"
+              onClick={() => setDatePickerOpen(true)}
+              aria-haspopup="dialog"
+              aria-expanded={datePickerOpen}
+            >
+              {datePickerLabel}
+            </button>
           </div>
           <div className="hamburger">
             <a href={PATH.CONFIG} onClick={onClickHamburger}>
@@ -82,6 +83,7 @@ export const Header = () => {
           </div>
         </div>
       </div>
+      {datePickerOpen && <DatePickerModal onClose={() => setDatePickerOpen(false)} />}
       <div className="navigators" style={{ height: navigatorsHeight }}>
         <div className="centerBox">
           <Navigator target={DASHBOARD} subPages={[CHART_DETAIL, CHART_ACCOUNTS]}>

--- a/src/client/components/Icons.tsx
+++ b/src/client/components/Icons.tsx
@@ -169,3 +169,13 @@ export const CheckIcon = ({ size }: IconProps) => (
     />
   </svg>
 );
+
+// Font Awesome Free v7 xmark — plain X mark used for close affordances.
+export const CloseIcon = ({ size }: IconProps) => (
+  <svg xmlns="http://www.w3.org/2000/svg" height={size} width={size} viewBox="0 0 384 512">
+    <path
+      fill="currentColor"
+      d="M342.6 150.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L192 210.7 86.6 105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L146.7 256 41.4 361.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L192 301.3l105.4 105.4c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L237.3 256l105.4-105.4z"
+    />
+  </svg>
+);

--- a/src/client/components/Icons.tsx
+++ b/src/client/components/Icons.tsx
@@ -106,7 +106,13 @@ export const ChevronDownIcon = ({ size }: IconProps) => (
 );
 
 export const ChevronRightIcon = ({ size }: IconProps) => (
-  <svg xmlns="http://www.w3.org/2000/svg" height={size} width={size} viewBox="0 0 512 512">
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    style={{ position: "relative", left: "2px" }}
+    height={size}
+    width={size}
+    viewBox="0 0 512 512"
+  >
     <path
       fill="currentColor"
       d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"
@@ -115,7 +121,13 @@ export const ChevronRightIcon = ({ size }: IconProps) => (
 );
 
 export const ChevronLeftIcon = ({ size }: IconProps) => (
-  <svg xmlns="http://www.w3.org/2000/svg" height={size} width={size} viewBox="0 0 512 512">
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    style={{ position: "relative", left: "2px" }}
+    height={size}
+    width={size}
+    viewBox="0 0 512 512"
+  >
     <path
       fill="currentColor"
       d="M9.4 233.4c-12.5 12.5-12.5 32.8 0 45.3l192 192c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3L77.3 256 246.6 86.6c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0l-192 192z"

--- a/src/client/components/index.ts
+++ b/src/client/components/index.ts
@@ -4,6 +4,7 @@ export * from "./PageTitle";
 export * from "./PageFilterTitle";
 export * from "./Placeholder";
 export * from "./AddButton";
+export * from "./DatePickerModal";
 export * from "./HoldingProperties";
 export * from "./InvestmentTransactionProperties";
 export * from "./ErrorBoundary";

--- a/src/client/lib/hooks/context.ts
+++ b/src/client/lib/hooks/context.ts
@@ -26,6 +26,12 @@ export interface ContextType {
   router: ClientRouter;
   viewDate: ViewDate;
   setViewDate: Dispatch<SetStateAction<ViewDate>>;
+  /** Clear the `view_date` URL param entirely (Current mode) — different
+   * from `setViewDate(new ViewDate("month"))` which writes today's
+   * period explicitly. Used by the date-picker modal's Current button
+   * so a bookmark to `/dashboard` (no param) stays anchored to "now"
+   * rather than freezing to the current period at bookmark time. */
+  resetViewDate: () => void;
   screenType: ScreenType;
 }
 

--- a/src/client/lib/hooks/router.ts
+++ b/src/client/lib/hooks/router.ts
@@ -83,6 +83,15 @@ export interface ClientRouter {
 
 export type GoOptions = NavigateOptions & {
   params?: URLSearchParams;
+  /**
+   * `router.go()` copies `view_date` from the current URL into the new
+   * params by default, so cross-page navigation stays anchored to the
+   * period the user was viewing. Pass `preserveViewDate: false` to
+   * bypass — needed for `useViewDate`'s `resetViewDate` (the modal's
+   * Current button) which wants to REMOVE the param entirely, not have
+   * it re-injected.
+   */
+  preserveViewDate?: boolean;
 };
 
 export interface NavigateOptions {
@@ -291,7 +300,7 @@ export const useRouter = (screenType: ScreenType): ClientRouter => {
 
   const go = useCallback(
     (target: PATH, options?: GoOptions) => {
-      const { params: providedParams, animate = true } = options || {};
+      const { params: providedParams, animate = true, preserveViewDate = true } = options || {};
       isAnimationEnabled.current = animate;
       setDirection("forward");
 
@@ -299,14 +308,17 @@ export const useRouter = (screenType: ScreenType): ClientRouter => {
       // expect the period they're viewing to persist as they move
       // between pages — jumping from `/budgets?view_date=2026-05` to a
       // detail view or the accounts page should keep them anchored to
-      // May 2026 rather than snapping back to the current month. If the
-      // caller explicitly set `view_date` in `options.params` (e.g. the
-      // date-picker modal), that wins. If the current URL has NO
-      // `view_date` (Current mode — implicit "now"), we don't inject
-      // one so bookmarks stay clean (`/dashboard` bookmarked in Current
-      // mode always shows the current period).
+      // May 2026 rather than snapping back to the current month.
+      //
+      // Skip preservation when:
+      // - Caller sets `preserveViewDate: false` — explicit opt-out for
+      //   `resetViewDate` (the modal's Current button), which wants to
+      //   REMOVE the param entirely, not have it re-injected.
+      // - Caller supplies `view_date` in `options.params` — caller wins.
+      // - Current URL has NO `view_date` (Current mode = implicit "now")
+      //   — no injection, so bookmarks stay clean.
       const finalParams = new URLSearchParams(providedParams);
-      if (!finalParams.has("view_date")) {
+      if (preserveViewDate && !finalParams.has("view_date")) {
         const currentViewDate = currentParamsRef.current.get("view_date");
         if (currentViewDate) finalParams.set("view_date", currentViewDate);
       }

--- a/src/client/lib/hooks/router.ts
+++ b/src/client/lib/hooks/router.ts
@@ -291,16 +291,33 @@ export const useRouter = (screenType: ScreenType): ClientRouter => {
 
   const go = useCallback(
     (target: PATH, options?: GoOptions) => {
-      const { params: newParams, animate = true } = options || {};
+      const { params: providedParams, animate = true } = options || {};
       isAnimationEnabled.current = animate;
       setDirection("forward");
+
+      // Preserve `view_date` across every cross-page navigation. Users
+      // expect the period they're viewing to persist as they move
+      // between pages — jumping from `/budgets?view_date=2026-05` to a
+      // detail view or the accounts page should keep them anchored to
+      // May 2026 rather than snapping back to the current month. If the
+      // caller explicitly set `view_date` in `options.params` (e.g. the
+      // date-picker modal), that wins. If the current URL has NO
+      // `view_date` (Current mode — implicit "now"), we don't inject
+      // one so bookmarks stay clean (`/dashboard` bookmarked in Current
+      // mode always shows the current period).
+      const finalParams = new URLSearchParams(providedParams);
+      if (!finalParams.has("view_date")) {
+        const currentViewDate = currentParamsRef.current.get("view_date");
+        if (currentViewDate) finalParams.set("view_date", currentViewDate);
+      }
+
       // Same-path navigation (control changes query params on the
       // currently-mounted page) preserves DOM state. Let the caller
       // handle scroll — see the `skipScrollRestore` comment on
       // `transition` above.
       const skipScrollRestore = target === currentPathRef.current;
-      transition(target, newParams || new URLSearchParams(), skipScrollRestore);
-      window.history.pushState("", "", getURLString(target, newParams));
+      transition(target, finalParams, skipScrollRestore);
+      window.history.pushState("", "", getURLString(target, finalParams));
     },
     [transition],
   );

--- a/src/client/lib/hooks/viewDate.ts
+++ b/src/client/lib/hooks/viewDate.ts
@@ -56,5 +56,16 @@ export const useViewDate = (router: ClientRouter) => {
     [viewDate, path, params, go],
   );
 
-  return [viewDate, setViewDate] as const;
+  // Explicit "Current mode" — remove the URL param entirely rather than
+  // setting it to today's period. A bookmark to `/dashboard` with no
+  // `view_date` param always shows the CURRENT period (whatever "now"
+  // is when the bookmark opens), while `/dashboard?view_date=2026-07`
+  // is frozen to that period even on a bookmark loaded in 2027.
+  const resetViewDate = useCallback(() => {
+    const newParams = new URLSearchParams(params);
+    newParams.delete("view_date");
+    go(path, { params: newParams, animate: false });
+  }, [path, params, go]);
+
+  return [viewDate, setViewDate, resetViewDate] as const;
 };

--- a/src/client/lib/hooks/viewDate.ts
+++ b/src/client/lib/hooks/viewDate.ts
@@ -64,7 +64,10 @@ export const useViewDate = (router: ClientRouter) => {
   const resetViewDate = useCallback(() => {
     const newParams = new URLSearchParams(params);
     newParams.delete("view_date");
-    go(path, { params: newParams, animate: false });
+    // Explicit opt-out: `go()`'s default view_date preservation would
+    // re-inject the current URL's `view_date` back into `newParams`
+    // since it isn't set. This writer wants the param GONE.
+    go(path, { params: newParams, animate: false, preserveViewDate: false });
   }, [path, params, go]);
 
   return [viewDate, setViewDate, resetViewDate] as const;


### PR DESCRIPTION
## Summary

Two behavior changes bundled per Hoie's Discord requests 2026-07-09:

1. **`router.go()` preserves `view_date` across pages.** Every cross-page navigation now carries the current URL's `view_date` unless the caller explicitly supplies one.
2. **Header's `<input type="month">` replaced with a button that opens a `<DatePickerModal>`.** Restores year interval + prev/current/next stepper in a purpose-built control.

## 1 — `view_date` persistence

Users expect the period they're viewing to persist as they move between pages — jumping from `/budgets?view_date=2026-05` to `/accounts` should keep them anchored to May 2026 instead of snapping back to the current month.

Rules in `router.go()`:

- Caller supplies `view_date` in `options.params` → caller wins.
- Current URL has NO `view_date` (Current mode — implicit "now") → no injection, bookmarks stay clean.
- Otherwise → copy the current URL's `view_date` into the new params.

## 2 — Date-picker modal

Header renders `<button className="datePickerTrigger">Jul 2026</button>`. Click opens the modal:

```
View Date                                     ✕
Jul 2026
[◀]     [Current]     [▶]
Interval    [Month ▾]
```

- **Prev / Next** step by the current interval (month or year).
- **Current** button REMOVES the `view_date` URL param entirely, matching Hoie's ask *"When [current] button is clicked, remove the view date param. This is different from setting the param as current month string. It's useful for bookmarks."*
- **Interval selector**: month / year. Bookmarked year URLs (`?view_date=2026`) still work via the existing `parseViewDateString` branch.
- **Dismissal**: backdrop click, Close button, or Escape key.

## New surface

- `resetViewDate()` on the `useViewDate` return tuple + the `ContextType`. Clears the `view_date` URL param entirely — semantically different from `setViewDate(new ViewDate("month"))` (which writes today's period explicitly). Wired to the modal's Current button.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun --bun eslint src` clean
- [x] `bun test src/client` → 324 / 0
- [ ] Sandbox — verify:
  - `/dashboard?view_date=2026-05` → click Accounts navigator → URL becomes `/accounts?view_date=2026-05` (preserved).
  - Click date button → modal opens, shows current label + stepper + interval selector.
  - Click Current → URL loses `view_date` param.
  - Click ▶ → URL updates to next month/year.
  - Change interval to Year → label switches to `2026`, URL becomes `?view_date=2026`.
  - Escape closes modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
