### PR TITLE
refactor(client): introduce useMutate(Model) — generic CRUD hook (#326 phase 5f)

### DIFF
--- a/src/client/components/BalanceChartProperties.tsx
+++ b/src/client/components/BalanceChartProperties.tsx
@@ -3,15 +3,11 @@ import { ChartType } from "common";
 import {
   BalanceChart,
   Chart,
-  ChartDictionary,
-  Data,
-  call,
   PATH,
   useAppContext,
   useDebounce,
+  useMutate,
   getChartTypeName,
-  indexedDb,
-  StoreName,
   DeleteButton,
   Properties,
   PropertyLabel,
@@ -30,30 +26,17 @@ export const BalanceChartProperties = ({ chart, children }: BalanceChartProperti
   const { name, chart_id, type, configuration } = chart;
   const { account_ids, budget_ids } = configuration;
 
-  const { data, setData } = useAppContext();
+  const { data } = useAppContext();
   const { accounts, budgets } = data;
 
   const [nameInput, setNameInput] = useState(name);
   const [selectedType, setSelectedType] = useState<ChartType>(type);
 
   const updateDebouncer = useDebounce();
+  const mutate = useMutate(Chart);
 
-  const updateChart = async (updatedChart: Partial<Chart>) => {
-    const r = await call.post("/api/chart", { chart_id, ...updatedChart });
-    if (r.status === "success") {
-      setData((oldData) => {
-        const newData = new Data(oldData);
-        const newChart = new Chart({ ...chart, ...updatedChart });
-        indexedDb.save(newChart).catch(console.error);
-        const newCharts = new ChartDictionary(newData.charts);
-        newCharts.set(chart_id, newChart);
-        newData.charts = newCharts;
-        return newData;
-      });
-    } else {
-      console.error(r.message);
-      throw new Error(r.message);
-    }
+  const updateChart = (updatedChart: Partial<Chart>) => {
+    return mutate.update(new Chart({ ...chart, ...updatedChart }));
   };
 
   const onChangeName: ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -81,21 +64,8 @@ export const BalanceChartProperties = ({ chart, children }: BalanceChartProperti
   }).length;
 
   const onClickRemove: MouseEventHandler<HTMLButtonElement> = async () => {
-    const r = await call.delete(`/api/chart?id=${chart_id}`);
-    if (r.status === "success") {
-      setData((oldData) => {
-        const newData = new Data(oldData);
-        const newCharts = new ChartDictionary(newData.charts);
-        indexedDb.remove(StoreName.charts, chart_id).catch(console.error);
-        newCharts.delete(chart_id);
-        newData.charts = newCharts;
-        return newData;
-      });
-      router.back();
-    } else {
-      console.error(r.message);
-      throw new Error(r.message);
-    }
+    await mutate.delete(chart_id);
+    router.back();
   };
 
   return (

--- a/src/client/components/FlowChartProperties.tsx
+++ b/src/client/components/FlowChartProperties.tsx
@@ -3,15 +3,11 @@ import { ChartType } from "common";
 import {
   FlowChart,
   Chart,
-  ChartDictionary,
-  Data,
-  call,
   PATH,
   useAppContext,
   useDebounce,
+  useMutate,
   getChartTypeName,
-  indexedDb,
-  StoreName,
   DeleteButton,
   Properties,
   PropertyLabel,
@@ -30,30 +26,17 @@ export const FlowChartProperties = ({ chart, children }: FlowChartPropertiesProp
   const { name, chart_id, type, configuration } = chart;
   const { account_ids } = configuration;
 
-  const { data, setData } = useAppContext();
+  const { data } = useAppContext();
   const { accounts } = data;
 
   const [nameInput, setNameInput] = useState(name);
   const [selectedType, setSelectedType] = useState<ChartType>(type);
 
   const updateDebouncer = useDebounce();
+  const mutate = useMutate(Chart);
 
-  const updateChart = async (updatedChart: Partial<Chart>) => {
-    const r = await call.post("/api/chart", { chart_id, ...updatedChart });
-    if (r.status === "success") {
-      setData((oldData) => {
-        const newData = new Data(oldData);
-        const newChart = new Chart({ ...chart, ...updatedChart });
-        indexedDb.save(newChart).catch(console.error);
-        const newCharts = new ChartDictionary(newData.charts);
-        newCharts.set(chart_id, newChart);
-        newData.charts = newCharts;
-        return newData;
-      });
-    } else {
-      console.error(r.message);
-      throw new Error(r.message);
-    }
+  const updateChart = (updatedChart: Partial<Chart>) => {
+    return mutate.update(new Chart({ ...chart, ...updatedChart }));
   };
 
   const onChangeName: ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -77,21 +60,8 @@ export const FlowChartProperties = ({ chart, children }: FlowChartPropertiesProp
   }).length;
 
   const onClickRemove: MouseEventHandler<HTMLButtonElement> = async () => {
-    const r = await call.delete(`/api/chart?id=${chart_id}`);
-    if (r.status === "success") {
-      setData((oldData) => {
-        const newData = new Data(oldData);
-        const newCharts = new ChartDictionary(newData.charts);
-        indexedDb.remove(StoreName.charts, chart_id).catch(console.error);
-        newCharts.delete(chart_id);
-        newData.charts = newCharts;
-        return newData;
-      });
-      router.back();
-    } else {
-      console.error(r.message);
-      throw new Error(r.message);
-    }
+    await mutate.delete(chart_id);
+    router.back();
   };
 
   return (

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -13,6 +13,7 @@ import {
   PATH,
   useAppContext,
   useHoldingDivergence,
+  useMutate,
   useTransactionEntry,
   buildPriceAt,
   Data,
@@ -27,7 +28,6 @@ import {
   Row,
   KeyValue,
   indexedDb,
-  StoreName,
 } from "client";
 import { CASH_TICKER } from "../HoldingsComposition";
 import { HoldingSnapshotPostResponse, ValidateTickerResponse } from "server";
@@ -58,6 +58,7 @@ interface SecurityInfo {
 
 export const HoldingProperties = () => {
   const { router, viewDate, data, setData, calculations } = useAppContext();
+  const holdingSnapshotMutate = useMutate(HoldingSnapshot);
 
   const activeParams = router.getActiveParams(PATH.HOLDING_DETAIL);
   const accountId = activeParams.get("account_id") || "";
@@ -582,25 +583,16 @@ export const HoldingProperties = () => {
 
   const onClickDeleteSnap = (snap: HoldingSnapshot) => async () => {
     const removedId = snap.snapshot.snapshot_id;
-    const r = await call.delete(`/api/snapshots/holding?id=${removedId}`).catch(console.error);
-    if (r?.status !== "success") {
+    try {
+      await holdingSnapshotMutate.delete(removedId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to delete holding";
       setSnapEdits((prev) => ({
         ...prev,
-        [removedId]: {
-          ...prev[removedId],
-          error: r?.message || "Failed to delete holding",
-        },
+        [removedId]: { ...prev[removedId], error: message },
       }));
       return;
     }
-    setData((oldData) => {
-      const newData = new Data(oldData);
-      indexedDb.remove(StoreName.holdingSnapshots, removedId).catch(console.error);
-      const next = new HoldingSnapshotDictionary(newData.holdingSnapshots);
-      next.delete(removedId);
-      newData.holdingSnapshots = next;
-      return newData;
-    });
     // If we just deleted the last underlying snapshot, the bucket is empty
     // and there's nothing more to render — go back.
     if (bucketSnapshots.length <= 1) goBackToAccount();

--- a/src/client/components/InvestmentTransactionProperties/index.tsx
+++ b/src/client/components/InvestmentTransactionProperties/index.tsx
@@ -5,10 +5,10 @@ import {
   Data,
   InvestmentTransaction,
   InvestmentTransactionDictionary,
-  StoreName,
   TransactionLabel,
   useAppContext,
   useBudgetCategorySelect,
+  useMutate,
   call,
   indexedDb,
 } from "client";
@@ -29,6 +29,7 @@ interface Props {
 
 export const InvestmentTransactionProperties = ({ investmentTransaction }: Props) => {
   const { data, setData, router } = useAppContext();
+  const investmentTransactionMutate = useMutate(InvestmentTransaction);
   const { accounts, sections, categories, securities } = data;
 
   const {
@@ -451,21 +452,7 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
               <DeleteButton
                 confirmMessage="Delete this investment transaction? This can't be undone."
                 onClick={async () => {
-                  const r = await call.delete(
-                    "/api/investment-transaction?" +
-                      new URLSearchParams({ investment_transaction_id }).toString(),
-                  );
-                  if (r.status !== "success") return;
-                  setData((oldData) => {
-                    const next = new Data(oldData);
-                    const dict = new InvestmentTransactionDictionary(oldData.investmentTransactions);
-                    dict.delete(investment_transaction_id);
-                    next.investmentTransactions = dict;
-                    indexedDb
-                      .remove(StoreName.investmentTransactions, investment_transaction_id)
-                      .catch(console.error);
-                    return next;
-                  });
+                  await investmentTransactionMutate.delete(investment_transaction_id);
                   router.back();
                 }}
               >

--- a/src/client/components/ProjectionChartProperties.tsx
+++ b/src/client/components/ProjectionChartProperties.tsx
@@ -1,17 +1,13 @@
 import { ChartType, getDateString, LocalDate } from "common";
 import {
   Chart,
-  ChartDictionary,
-  Data,
   ProjectionChart,
-  call,
   CapacityInput,
   PATH,
   useAppContext,
   useDebounce,
+  useMutate,
   getChartTypeName,
-  indexedDb,
-  StoreName,
   DeleteButton,
   Properties,
   PropertyLabel,
@@ -45,30 +41,17 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
     year_over_year_inflation,
   } = configuration;
 
-  const { data, setData } = useAppContext();
+  const { data } = useAppContext();
   const { accounts } = data;
 
   const [selectedType, setSelectedType] = useState<ChartType>(type);
   const [nameInput, setNameInput] = useState(name);
 
   const updateDebouncer = useDebounce();
+  const mutate = useMutate(Chart);
 
-  const updateChart = async (updatedChart: Partial<Chart>) => {
-    const r = await call.post("/api/chart", { chart_id, ...updatedChart });
-    if (r.status === "success") {
-      setData((oldData) => {
-        const newData = new Data(oldData);
-        const newChart = new Chart({ ...chart, ...updatedChart });
-        indexedDb.save(newChart).catch(console.error);
-        const newCharts = new ChartDictionary(newData.charts);
-        newCharts.set(chart_id, newChart);
-        newData.charts = newCharts;
-        return newData;
-      });
-    } else {
-      console.error(r.message);
-      throw new Error(r.message);
-    }
+  const updateChart = (updatedChart: Partial<Chart>) => {
+    return mutate.update(new Chart({ ...chart, ...updatedChart }));
   };
 
   const onChangeName: ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -161,21 +144,8 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
   }).length;
 
   const onClickRemove: MouseEventHandler<HTMLButtonElement> = async () => {
-    const r = await call.delete(`/api/chart?id=${chart_id}`);
-    if (r.status === "success") {
-      setData((oldData) => {
-        const newData = new Data(oldData);
-        const newCharts = new ChartDictionary(newData.charts);
-        indexedDb.remove(StoreName.charts, chart_id).catch(console.error);
-        newCharts.delete(chart_id);
-        newData.charts = newCharts;
-        return newData;
-      });
-      router.back();
-    } else {
-      console.error(r.message);
-      throw new Error(r.message);
-    }
+    await mutate.delete(chart_id);
+    router.back();
   };
 
   return (

--- a/src/client/components/TransactionProperties/index.tsx
+++ b/src/client/components/TransactionProperties/index.tsx
@@ -10,12 +10,12 @@ import {
   Data,
   SplitTransaction,
   SplitTransactionDictionary,
-  StoreName,
   Transaction,
   TransactionDictionary,
   TransactionLabel,
   useAppContext,
   useBudgetCategorySelect,
+  useMutate,
   useTransfers,
   call,
   indexedDb,
@@ -46,6 +46,7 @@ interface Props {
 
 export const TransactionProperties = ({ transaction }: Props) => {
   const { data, setData, calculations, router } = useAppContext();
+  const transactionMutate = useMutate(Transaction);
   const transferActions = useTransfers();
   const { transactionFamilies } = calculations;
   const { accounts, sections, categories, transfers } = data;
@@ -566,16 +567,7 @@ export const TransactionProperties = ({ transaction }: Props) => {
               <DeleteButton
                 confirmMessage="Delete this transaction? This can't be undone."
                 onClick={async () => {
-                  const r = await call.delete("/api/transaction?" + new URLSearchParams({ transaction_id }).toString());
-                  if (r.status !== "success") return;
-                  setData((oldData) => {
-                    const next = new Data(oldData);
-                    const dict = new TransactionDictionary(oldData.transactions);
-                    dict.delete(transaction_id);
-                    next.transactions = dict;
-                    indexedDb.remove(StoreName.transactions, transaction_id).catch(console.error);
-                    return next;
-                  });
+                  await transactionMutate.delete(transaction_id);
                   router.back();
                 }}
               >

--- a/src/client/lib/hooks/index.ts
+++ b/src/client/lib/hooks/index.ts
@@ -10,4 +10,5 @@ export * from "./useVooHistory";
 export * from "./useBudgetCategorySelect";
 export * from "./useTransactionEntry";
 export * from "./useMultiSelectQueryFilter";
+export * from "./useMutate";
 export * from "./viewDate";

--- a/src/client/lib/hooks/useMutate.ts
+++ b/src/client/lib/hooks/useMutate.ts
@@ -1,0 +1,108 @@
+import { useCallback, useMemo } from "react";
+import { call, useAppContext, indexedDb, StoreName, Data } from "client";
+import type { Dictionary } from "client/lib/models/Data";
+
+/**
+ * Contract every mutable client model exposes so `useMutate` can drive
+ * its CRUD from just the class reference:
+ *
+ * - `apiPath` — POST/DELETE target under `/api`.
+ * - `dataField` — the `Data` field that holds this model's dictionary.
+ *   Values match `StoreName.*` verbatim (`"charts"`, `"transactions"`,
+ *   …), so we don't need a separate StoreName static.
+ */
+export interface MutableModel<T extends { readonly id: string }> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  new (...args: any[]): T;
+  readonly apiPath: string;
+  readonly dataField: keyof Data;
+}
+
+export interface MutateApi<T> {
+  /** Upserts on the server, adds the instance to state + IDB. */
+  create: (instance: T) => Promise<void>;
+  /** Upserts on the server, replaces the instance in state + IDB. */
+  update: (instance: T) => Promise<void>;
+  /** DELETEs by id, removes from state + IDB. */
+  delete: (id: string) => Promise<void>;
+}
+
+/**
+ * Generic client-side mutation hook. `useMutate(Chart)` returns the
+ * `{ create, update, delete }` API for that model — the hook centralizes
+ * the await-call, status check, error log/throw, and the state + IDB
+ * update pattern that would otherwise repeat verbatim at every
+ * mutation site.
+ *
+ * `create` and `update` share the server contract (server routes are
+ * upsert-by-id via POST), so both call the same code path here; the
+ * split exists at the interface level for reader clarity at call
+ * sites. Deletes go through DELETE `?id=…`.
+ *
+ * The state update writes back through the SAME dictionary constructor
+ * that Data currently holds, so callers don't need to import the
+ * per-model Dictionary class — the hook reads it off the live
+ * dictionary's prototype.
+ *
+ * Not covered here: cascading deletes (Account, Connection) that touch
+ * more than one dictionary — those keep their bespoke handlers until
+ * we design a cascade extension.
+ */
+export const useMutate = <T extends { readonly id: string }>(
+  Model: MutableModel<T>,
+): MutateApi<T> => {
+  const { setData } = useAppContext();
+
+  const upsert = useCallback(
+    async (instance: T) => {
+      const r = await call.post(Model.apiPath, instance);
+      if (r.status !== "success") {
+        console.error(r.message);
+        throw new Error(r.message);
+      }
+      setData((oldData) => {
+        const newData = new Data(oldData);
+        const current = newData[Model.dataField] as unknown as Dictionary<T>;
+        const DictCtor = current.constructor as new (
+          source?: Iterable<readonly [string, T]>,
+        ) => Dictionary<T>;
+        const next = new DictCtor(current);
+        next.set(instance.id, instance);
+        indexedDb
+          .save(instance as unknown as Parameters<typeof indexedDb.save>[0])
+          .catch(console.error);
+        (newData[Model.dataField] as unknown as Dictionary<T>) = next;
+        return newData;
+      });
+    },
+    [Model, setData],
+  );
+
+  const del = useCallback(
+    async (id: string) => {
+      const r = await call.delete(`${Model.apiPath}?id=${id}`);
+      if (r.status !== "success") {
+        console.error(r.message);
+        throw new Error(r.message);
+      }
+      setData((oldData) => {
+        const newData = new Data(oldData);
+        const current = newData[Model.dataField] as unknown as Dictionary<T>;
+        const DictCtor = current.constructor as new (
+          source?: Iterable<readonly [string, T]>,
+        ) => Dictionary<T>;
+        const next = new DictCtor(current);
+        next.delete(id);
+        indexedDb.remove(Model.dataField as StoreName, id).catch(console.error);
+        (newData[Model.dataField] as unknown as Dictionary<T>) = next;
+        return newData;
+      });
+    },
+    [Model, setData],
+  );
+
+  return useMemo(
+    () => ({ create: upsert, update: upsert, delete: del }),
+    [upsert, del],
+  );
+};

--- a/src/client/lib/hooks/useMutate.ts
+++ b/src/client/lib/hooks/useMutate.ts
@@ -1,21 +1,17 @@
 import { useCallback, useMemo } from "react";
-import { call, useAppContext, indexedDb, StoreName, Data } from "client";
-import type { Dictionary } from "client/lib/models/Data";
+import { call, useAppContext, indexedDb, Data } from "client";
+import type { StoredModel } from "client/lib/indexed-db/service";
 
 /**
  * Contract every mutable client model exposes so `useMutate` can drive
- * its CRUD from just the class reference:
- *
- * - `apiPath` — POST/DELETE target under `/api`.
- * - `dataField` — the `Data` field that holds this model's dictionary.
- *   Values match `StoreName.*` verbatim (`"charts"`, `"transactions"`,
- *   …), so we don't need a separate StoreName static.
+ * its CRUD from just the class reference. Model class carries only its
+ * API root; the model → `Data` slot / `StoreName` / `Dictionary` mapping
+ * lives on `Data` itself (see `Data.dictOf` / `storeNameOf` / `set`).
  */
-export interface MutableModel<T extends { readonly id: string }> {
+export interface MutableModel<T extends StoredModel> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   new (...args: any[]): T;
   readonly apiPath: string;
-  readonly dataField: keyof Data;
 }
 
 export interface MutateApi<T> {
@@ -39,18 +35,15 @@ export interface MutateApi<T> {
  * split exists at the interface level for reader clarity at call
  * sites. Deletes go through DELETE `?id=…`.
  *
- * The state update writes back through the SAME dictionary constructor
- * that Data currently holds, so callers don't need to import the
- * per-model Dictionary class — the hook reads it off the live
- * dictionary's prototype.
+ * State updates go through `Data.dictOf(Model).clone()` + `Data.set` —
+ * the model → slot mapping lives on `Data`, so the hook body has no
+ * casts and no per-model wiring beyond `Model.apiPath`.
  *
  * Not covered here: cascading deletes (Account, Connection) that touch
  * more than one dictionary — those keep their bespoke handlers until
  * we design a cascade extension.
  */
-export const useMutate = <T extends { readonly id: string }>(
-  Model: MutableModel<T>,
-): MutateApi<T> => {
+export const useMutate = <T extends StoredModel>(Model: MutableModel<T>): MutateApi<T> => {
   const { setData } = useAppContext();
 
   const upsert = useCallback(
@@ -62,16 +55,10 @@ export const useMutate = <T extends { readonly id: string }>(
       }
       setData((oldData) => {
         const newData = new Data(oldData);
-        const current = newData[Model.dataField] as unknown as Dictionary<T>;
-        const DictCtor = current.constructor as new (
-          source?: Iterable<readonly [string, T]>,
-        ) => Dictionary<T>;
-        const next = new DictCtor(current);
-        next.set(instance.id, instance);
-        indexedDb
-          .save(instance as unknown as Parameters<typeof indexedDb.save>[0])
-          .catch(console.error);
-        (newData[Model.dataField] as unknown as Dictionary<T>) = next;
+        const newDict = newData.dictOf(Model).clone();
+        newDict.set(instance.id, instance);
+        newData.set(newDict);
+        indexedDb.save(instance).catch(console.error);
         return newData;
       });
     },
@@ -87,22 +74,15 @@ export const useMutate = <T extends { readonly id: string }>(
       }
       setData((oldData) => {
         const newData = new Data(oldData);
-        const current = newData[Model.dataField] as unknown as Dictionary<T>;
-        const DictCtor = current.constructor as new (
-          source?: Iterable<readonly [string, T]>,
-        ) => Dictionary<T>;
-        const next = new DictCtor(current);
-        next.delete(id);
-        indexedDb.remove(Model.dataField as StoreName, id).catch(console.error);
-        (newData[Model.dataField] as unknown as Dictionary<T>) = next;
+        const newDict = newData.dictOf(Model).clone();
+        newDict.delete(id);
+        newData.set(newDict);
+        indexedDb.remove(newData.storeNameOf(Model), id).catch(console.error);
         return newData;
       });
     },
     [Model, setData],
   );
 
-  return useMemo(
-    () => ({ create: upsert, update: upsert, delete: del }),
-    [upsert, del],
-  );
+  return useMemo(() => ({ create: upsert, update: upsert, delete: del }), [upsert, del]);
 };

--- a/src/client/lib/indexed-db/service.ts
+++ b/src/client/lib/indexed-db/service.ts
@@ -401,7 +401,7 @@ export const saveAllCalculations = async (data: Calculations) => {
   ]);
 };
 
-type StoredModel =
+export type StoredModel =
   | Account
   | Holding
   | Security

--- a/src/client/lib/models/Chart.ts
+++ b/src/client/lib/models/Chart.ts
@@ -17,6 +17,9 @@ type ChartConfiguration =
   | FlowChartConfiguration;
 
 export class Chart {
+  static readonly apiPath = "/api/chart";
+  static readonly dataField = "charts" as const;
+
   get id() {
     return this.chart_id;
   }

--- a/src/client/lib/models/Chart.ts
+++ b/src/client/lib/models/Chart.ts
@@ -18,7 +18,6 @@ type ChartConfiguration =
 
 export class Chart {
   static readonly apiPath = "/api/chart";
-  static readonly dataField = "charts" as const;
 
   get id() {
     return this.chart_id;

--- a/src/client/lib/models/Data.test.ts
+++ b/src/client/lib/models/Data.test.ts
@@ -1,0 +1,83 @@
+import { test, expect, describe } from "bun:test";
+import {
+  Data,
+  Dictionary,
+  ChartDictionary,
+  TransactionDictionary,
+  InvestmentTransactionDictionary,
+  HoldingSnapshotDictionary,
+} from "./Data";
+import { Chart, Transaction, InvestmentTransaction, HoldingSnapshot } from ".";
+
+// `useMutate` does `data.dictOf(Model).clone()` → mutate → `data.set(dict)`, and
+// `Data.set` dispatches on `instanceof <Sub>Dictionary`. So `clone()` MUST return
+// the concrete subclass — a base-`Dictionary` clone falls through to `Data.set`'s
+// `unknown dictionary` throw, and because that runs inside the `setData` updater
+// it surfaces at render. Guard both halves: the clone's class and the round-trip.
+
+describe("Dictionary.clone keeps the concrete subclass", () => {
+  const factories = [
+    ["ChartDictionary", () => new ChartDictionary(), ChartDictionary],
+    ["TransactionDictionary", () => new TransactionDictionary(), TransactionDictionary],
+    [
+      "InvestmentTransactionDictionary",
+      () => new InvestmentTransactionDictionary(),
+      InvestmentTransactionDictionary,
+    ],
+    ["HoldingSnapshotDictionary", () => new HoldingSnapshotDictionary(), HoldingSnapshotDictionary],
+  ] as const;
+
+  factories.forEach(([name, make, Ctor]) => {
+    test(`${name}.clone() is an instanceof ${name}, not a bare Dictionary`, () => {
+      const clone = make().clone();
+      expect(clone).toBeInstanceOf(Ctor);
+      // A base-Dictionary instance is NOT an instanceof any subclass, so this
+      // pins the regression precisely.
+      expect(clone.constructor.name).toBe(name);
+    });
+
+    test(`Data.set accepts a cloned ${name} without throwing`, () => {
+      const data = new Data();
+      expect(() => data.set(make().clone())).not.toThrow();
+    });
+  });
+
+  test("clone copies existing entries", () => {
+    const source = new ChartDictionary();
+    const chart = new Chart();
+    source.set(chart.id, chart);
+    const clone = source.clone();
+    expect(clone).toBeInstanceOf(ChartDictionary);
+    expect(clone.size).toBe(1);
+    expect(clone.get(chart.id)).toBe(chart);
+  });
+});
+
+describe("Data.dictOf → clone → set round-trip (the useMutate flow)", () => {
+  test("dictOf returns the concrete subclass for each wired model", () => {
+    const data = new Data();
+    expect(data.dictOf(Chart)).toBeInstanceOf(ChartDictionary);
+    expect(data.dictOf(Transaction)).toBeInstanceOf(TransactionDictionary);
+    expect(data.dictOf(InvestmentTransaction)).toBeInstanceOf(InvestmentTransactionDictionary);
+    expect(data.dictOf(HoldingSnapshot)).toBeInstanceOf(HoldingSnapshotDictionary);
+  });
+
+  test("upsert path: dictOf(Chart).clone() + set lands the instance in data.charts", () => {
+    const data = new Data();
+    const chart = new Chart();
+    const dict: Dictionary = data.dictOf(Chart).clone();
+    dict.set(chart.id, chart);
+    expect(() => data.set(dict)).not.toThrow();
+    expect(data.charts.get(chart.id)).toBe(chart);
+  });
+
+  test("delete path: dictOf(Chart).clone() + delete + set evicts from data.charts", () => {
+    const data = new Data();
+    const chart = new Chart();
+    data.charts.set(chart.id, chart);
+    const dict: Dictionary = data.dictOf(Chart).clone();
+    dict.delete(chart.id);
+    expect(() => data.set(dict)).not.toThrow();
+    expect(data.charts.has(chart.id)).toBe(false);
+  });
+});

--- a/src/client/lib/models/Data.ts
+++ b/src/client/lib/models/Data.ts
@@ -66,7 +66,13 @@ export class Dictionary<T = any, S extends Dictionary<T> = any> extends Map<stri
     return clone;
   };
 
-  clone = () => new Dictionary<T>(this) as S;
+  // Construct via `this.constructor`, not `new Dictionary(...)`, so the clone
+  // keeps the concrete subclass — `Data.set` dispatches on `instanceof`, and a
+  // base-Dictionary clone would fall through to its `unknown dictionary` throw.
+  clone = (): S => {
+    const Ctor = this.constructor as new (init: Iterable<readonly [string, T]>) => S;
+    return new Ctor(this);
+  };
 
   override set = (key: string, value: T) => {
     if (environment === "server") {

--- a/src/client/lib/models/Data.ts
+++ b/src/client/lib/models/Data.ts
@@ -1,4 +1,5 @@
 import { assign, ValueOf, environment } from "common";
+import { StoreName } from "client/lib/indexed-db/accessor";
 import { Account } from "./Account";
 import { Holding, Institution, Security, Status } from "./miscellaneous";
 import { BudgetFamily, BudgetFamilyType } from "./BudgetFamily";
@@ -12,6 +13,8 @@ import { Item } from "./Item";
 import { Chart } from "./Chart";
 import { AccountSnapshot, HoldingSnapshot, SecuritySnapshot } from "./Snapshot";
 import type { TransferPair } from "server";
+import type { MutableModel } from "client/lib/hooks/useMutate";
+import type { StoredModel } from "client/lib/indexed-db/service";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class Dictionary<T = any, S extends Dictionary<T> = any> extends Map<string, T> {
@@ -235,6 +238,53 @@ export class Data {
   update = (init: Partial<Data>) => {
     assign(this, init);
   };
+
+  /** Fetch a Model's dictionary from this `Data`. Overloads keep call
+   *  sites precisely typed (`data.dictOf(Chart)` → `ChartDictionary`,
+   *  etc.); the impl dispatches on the class ref. Extend both the
+   *  overload list AND the impl switch to wire a new model into
+   *  `useMutate`.
+   *
+   *  Central mapping for `useMutate` — the model-to-slot dispatch lives
+   *  here alongside the field declarations, so a new model only needs
+   *  entries in `dictOf` / `storeNameOf` / `set` below (no per-model
+   *  static plumbing on the Model class itself). */
+  dictOf(Model: typeof Chart): ChartDictionary;
+  dictOf(Model: typeof Transaction): TransactionDictionary;
+  dictOf(Model: typeof InvestmentTransaction): InvestmentTransactionDictionary;
+  dictOf(Model: typeof HoldingSnapshot): HoldingSnapshotDictionary;
+  dictOf<T extends StoredModel>(Model: MutableModel<T>): Dictionary<T>;
+  dictOf<T extends StoredModel>(Model: MutableModel<T>): Dictionary<T> {
+    if (Model === Chart) return this.charts as unknown as Dictionary<T>;
+    if (Model === Transaction) return this.transactions as unknown as Dictionary<T>;
+    if (Model === InvestmentTransaction)
+      return this.investmentTransactions as unknown as Dictionary<T>;
+    if (Model === HoldingSnapshot) return this.holdingSnapshots as unknown as Dictionary<T>;
+    throw new Error(`Data.dictOf: no dictionary for ${Model.name}`);
+  }
+
+  /** IDB `StoreName` for a Model — same inline mapping shape as
+   *  `dictOf`. Kept here (not on the Model class) so all model →
+   *  slot / store wiring lives in this one file. */
+  storeNameOf<T extends StoredModel>(Model: MutableModel<T>): StoreName {
+    if (Model === Chart) return StoreName.charts;
+    if (Model === Transaction) return StoreName.transactions;
+    if (Model === InvestmentTransaction) return StoreName.investmentTransactions;
+    if (Model === HoldingSnapshot) return StoreName.holdingSnapshots;
+    throw new Error(`Data.storeNameOf: no store for ${Model.name}`);
+  }
+
+  /** Write a Dictionary back to its slot. `instanceof` dispatch so
+   *  callers don't need to pass the Model class again — the Dictionary
+   *  knows its own type via its constructor. */
+  set(dict: Dictionary): void {
+    if (dict instanceof ChartDictionary) this.charts = dict;
+    else if (dict instanceof TransactionDictionary) this.transactions = dict;
+    else if (dict instanceof InvestmentTransactionDictionary)
+      this.investmentTransactions = dict;
+    else if (dict instanceof HoldingSnapshotDictionary) this.holdingSnapshots = dict;
+    else throw new Error(`Data.set: unknown dictionary ${dict.constructor.name}`);
+  }
 }
 
 export const globalData = new Data();

--- a/src/client/lib/models/InvestmentTransaction.ts
+++ b/src/client/lib/models/InvestmentTransaction.ts
@@ -5,7 +5,6 @@ import { TransactionLabel } from "./Transaction";
 
 export class InvestmentTransaction implements JSONInvestmentTransaction {
   static readonly apiPath = "/api/investment-transaction";
-  static readonly dataField = "investmentTransactions" as const;
 
   get id() {
     return this.investment_transaction_id;

--- a/src/client/lib/models/InvestmentTransaction.ts
+++ b/src/client/lib/models/InvestmentTransaction.ts
@@ -4,6 +4,9 @@ import { getRandomId, getDateTimeString, assign, JSONInvestmentTransaction } fro
 import { TransactionLabel } from "./Transaction";
 
 export class InvestmentTransaction implements JSONInvestmentTransaction {
+  static readonly apiPath = "/api/investment-transaction";
+  static readonly dataField = "investmentTransactions" as const;
+
   get id() {
     return this.investment_transaction_id;
   }

--- a/src/client/lib/models/Snapshot.ts
+++ b/src/client/lib/models/Snapshot.ts
@@ -39,6 +39,9 @@ export class AccountSnapshot implements JSONAccountSnapshot {
 }
 
 export class HoldingSnapshot implements JSONHoldingSnapshot {
+  static readonly apiPath = "/api/snapshots/holding";
+  static readonly dataField = "holdingSnapshots" as const;
+
   get id() {
     return this.snapshot.snapshot_id;
   }

--- a/src/client/lib/models/Snapshot.ts
+++ b/src/client/lib/models/Snapshot.ts
@@ -40,7 +40,6 @@ export class AccountSnapshot implements JSONAccountSnapshot {
 
 export class HoldingSnapshot implements JSONHoldingSnapshot {
   static readonly apiPath = "/api/snapshots/holding";
-  static readonly dataField = "holdingSnapshots" as const;
 
   get id() {
     return this.snapshot.snapshot_id;

--- a/src/client/lib/models/Transaction.ts
+++ b/src/client/lib/models/Transaction.ts
@@ -40,6 +40,9 @@ export class TransactionLabel implements JSONTransactionLabel {
 }
 
 export class Transaction implements JSONTransaction {
+  static readonly apiPath = "/api/transaction";
+  static readonly dataField = "transactions" as const;
+
   get id() {
     return this.transaction_id;
   }

--- a/src/client/lib/models/Transaction.ts
+++ b/src/client/lib/models/Transaction.ts
@@ -41,7 +41,6 @@ export class TransactionLabel implements JSONTransactionLabel {
 
 export class Transaction implements JSONTransaction {
   static readonly apiPath = "/api/transaction";
-  static readonly dataField = "transactions" as const;
 
   get id() {
     return this.transaction_id;

--- a/src/client/pages/ChartAccountsPage.tsx
+++ b/src/client/pages/ChartAccountsPage.tsx
@@ -2,20 +2,18 @@ import { ChangeEventHandler } from "react";
 import { ChartType, MAX_FLOAT, numberToCommaString, UNSORTED_BUDGET_ID } from "common";
 import {
   useAppContext,
-  call,
+  useMutate,
   PATH,
-  ChartDictionary,
-  Data,
   BalanceChartConfiguration,
   Chart,
   ProjectionChartConfiguration,
   FlowChartConfiguration,
-  indexedDb,
 } from "client";
 import { ToggleInput, Properties, PropertyLabel, Property, Row } from "client/components";
 
 export const ChartAccountsPage = () => {
-  const { data, setData, router, viewDate } = useAppContext();
+  const { data, router, viewDate } = useAppContext();
+  const chartMutate = useMutate(Chart);
   const { charts } = data;
 
   const params = router.getActiveParams(PATH.CHART_ACCOUNTS);
@@ -52,21 +50,7 @@ export const ChartAccountsPage = () => {
         } else {
           updatedConfiguration = new FlowChartConfiguration(updated);
         }
-        const r = await call.post("/api/chart", { chart_id, configuration: updatedConfiguration });
-        if (r.status === "success") {
-          setData((oldData) => {
-            const newData = new Data(oldData);
-            const newChart = new Chart({ ...chart, configuration: updatedConfiguration });
-            indexedDb.save(newChart).catch(console.error);
-            const newCharts = new ChartDictionary(newData.charts);
-            newCharts.set(chart_id, newChart);
-            newData.charts = newCharts;
-            return newData;
-          });
-        } else {
-          console.error(r.message);
-          throw new Error(r.message);
-        }
+        await chartMutate.update(new Chart({ ...chart, configuration: updatedConfiguration }));
       };
 
       return (
@@ -94,21 +78,7 @@ export const ChartAccountsPage = () => {
         type === ChartType.BALANCE
           ? new BalanceChartConfiguration(updatedFields)
           : new FlowChartConfiguration(updatedFields);
-      const r = await call.post("/api/chart", { chart_id, configuration: updatedConfiguration });
-      if (r.status === "success") {
-        setData((oldData) => {
-          const newData = new Data(oldData);
-          const newChart = new Chart({ ...chart, configuration: updatedConfiguration });
-          indexedDb.save(newChart).catch(console.error);
-          const newCharts = new ChartDictionary(newData.charts);
-          newCharts.set(chart_id, newChart);
-          newData.charts = newCharts;
-          return newData;
-        });
-      } else {
-        console.error(r.message);
-        throw new Error(r.message);
-      }
+      await chartMutate.update(new Chart({ ...chart, configuration: updatedConfiguration }));
     };
 
   // Synthetic "Others" toggle (Flow chart only) for transactions whose

--- a/src/server/routes/accounts/delete-investment-transaction.ts
+++ b/src/server/routes/accounts/delete-investment-transaction.ts
@@ -24,7 +24,7 @@ export const deleteInvestmentTransactionRoute = new Route(
     const { user } = req.session;
     if (!user) return { status: "failed", message: "Request user is not authenticated." };
 
-    const idResult = requireQueryString(req, "investment_transaction_id");
+    const idResult = requireQueryString(req, "id");
     if (!idResult.success) return validationError(idResult.error!);
     const investment_transaction_id = idResult.data!;
 

--- a/src/server/routes/accounts/delete-transaction.ts
+++ b/src/server/routes/accounts/delete-transaction.ts
@@ -23,7 +23,7 @@ export const deleteTransactionRoute = new Route("DELETE", "/transaction", async 
   const { user } = req.session;
   if (!user) return { status: "failed", message: "Request user is not authenticated." };
 
-  const idResult = requireQueryString(req, "transaction_id");
+  const idResult = requireQueryString(req, "id");
   if (!idResult.success) return validationError(idResult.error!);
   const transaction_id = idResult.data!;
 


### PR DESCRIPTION
## Summary

Replaces the initial `useChartDelete` sketch with a generic hook per Hoie's design: `useMutate(Model)` reads static metadata off the model class and returns `{ create, update, delete }`. Each site becomes one line at the call site instead of a 15-line copy of "call, status-check, setData, new Dict, dict.set/delete, indexedDb.save/remove, cast field".

## Design — model class carries its own routing

```ts
class Chart {
  static readonly apiPath = "/api/chart";
  static readonly dataField = "charts" as const;
  // …
}

const chartMutate = useMutate(Chart);
chartMutate.delete(chart_id);
chartMutate.update(new Chart({ ...chart, name: newName }));
```

- `apiPath: string` — POST/DELETE target under `/api`.
- `dataField: keyof Data` — the `Data` field holding this model's dictionary. Values match `StoreName.*` verbatim so IDB store is derivable from the same static.

Dictionary constructor is read off the live state (`newData[dataField].constructor`), so callers don't need to import `ChartDictionary` / `TransactionDictionary` / etc. Every model class exposes `.id`, so `instance.id` is the universal key.

## Sites migrated (10 in this PR)

- 3× chart delete + 3× chart update: Balance / Flow / Projection Chart Properties.
- 2× chart update: ChartAccountsPage account/budget toggles.
- Transaction delete: TransactionProperties.
- Investment-transaction delete: InvestmentTransactionProperties.
- Holding-snapshot delete: HoldingProperties.

## Server route normalization

Two DELETE routes had non-uniform query keys — normalized to `?id=` so `useMutate` builds one URL shape:

- `/transaction` DELETE: `transaction_id` → `id`.
- `/investment-transaction` DELETE: `investment_transaction_id` → `id`.

Both routes had no dedicated tests; the FE was the only caller and is migrated in the same commit.

## Not covered — follow-up scope

- **Cascading deletes** (Account → transactions + accountSnapshots; Connection/Item → items + accounts + transactions). These update more than one dictionary; the generic hook shape doesn't cleanly express them without another design decision (multi-dict cascade spec on the Model class, or a bespoke hook composed on top of `useMutate`). Left as bespoke handlers for now.
- **ApiKey** — no client model class exists; delete goes through a plain object. Would need a client `ApiKey` class before adopting.
- Other mutation shapes (login/session, transfer pairs, budgets/categories/sections/items) — same abstraction applies, just wasn't in this PR's cut. Each is a mechanical migration when needed.

## Test plan

- [x] Typecheck: clean.
- [x] Lint: clean.
- [x] Unit tests: 1082 pass / 0 fail.
- [ ] E2E on sandbox: drive chart create + update + delete; transaction delete on a manual row; investment-transaction delete on a manual row; holding-snapshot delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)