### PR TITLE
fix(budgets): pin config donut to month interval — Year view no longer 12×-scales the capacity input

### DIFF
--- a/src/client/components/BudgetProperties/CapacitiesInput/BudgetDonut.tsx
+++ b/src/client/components/BudgetProperties/CapacitiesInput/BudgetDonut.tsx
@@ -34,9 +34,13 @@ const BudgetDonut = ({
   defaultCapacityInput,
   onChangeAmount,
 }: Props) => {
-  const { calculations, viewDate } = useAppContext();
+  const { calculations } = useAppContext();
   const { capacityData } = calculations;
-  const interval = viewDate.getInterval();
+  // The capacity config surface is month-only: capacities are stored/edited as
+  // `capacity.month`, `onChangeAmount` writes the raw field into `.month`, and
+  // `capacityData` sums in month units. The donut must pin month regardless of
+  // the global Year interval, or the year-scaled input feeds a month writer.
+  const interval = "month";
   const capacity = budgetLike.getActiveCapacity(date);
   const { children_total, grand_children_total } = capacityData.get(capacity.id);
   const children = budgetLike.getChildren().sort((a, b) => {


### PR DESCRIPTION
## What

Fixes the config-donut interval mismatch introduced once the global View Date gained a **Year** interval (#624). `BudgetProperties/CapacitiesInput/BudgetDonut.tsx` read `viewDate.getInterval()`, so at Year interval it scaled the parent capacity input and the child ring to **year** units (`month × 12`) via the `Capacity.year` getter — while the donut-center aggregate (`capacityData`, which sums in month) and the `.month` edit handler stayed in **month** units.

Two consequences at Year interval (Month renders correctly):

- **Display:** parent/children scale to year while the center aggregate stays month → a false over/under alert (`parentDiff = 12·M − M = 11·M`) plus garbled `childDiff` filler rows under every child.
- **12× save corruption:** `CapacityInput` is uncontrolled (`defaultValue`) and `onChangeAmount` writes the raw field into `capacity.month`. Opening a config page while already in Year mode (e.g. a `?view_date=YYYY` bookmark) shows the year-scaled figure; a focus-blur-Save then persists `12·M` as the **monthly** capacity — a silent 12× inflation.

## Fix

The config surface is inherently month-only: the sibling `CapacitiesInput` hardcodes `const interval = "month"`, `onChangeAmount` writes `.month`, and `getCapacityData`'s `sumActiveAt` sums in month. `BudgetDonut` was the lone consumer reading the global interval. Pin it to month:

```ts
const interval = "month";
```

This realigns the parent input, the child ring, and the `capacityData` center all to month, so the over/under alert and breakdown stay self-consistent and the input can no longer feed a year figure into a `.month` writer. `viewDate` is now unused in the component and was dropped from the `useAppContext()` destructure. No product ask exists for a year-scaled config view; if one ever arises it's a larger change (interval-aware `getCapacityData` + convert-on-write).

## Regression coverage

The defect is component-local (the interval BudgetDonut consumes); the `Capacity.year` getter itself is correct and stays year-aware for the year-scaled surfaces (LabeledBar / budget detail). There is no client render-test harness today — a rendered-component guard asserting "donut center == sum of child ring at both intervals" is blocked on #597 (rendered-hook harness). The regression evidence is the E2E below driving the real donut at **both** intervals, cross-checked against an `upstream/main` baseline.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` (Capacity + budgets calc suites) — 47 pass / 0 fail
- [x] **UI E2E** — sandbox, 390×844 mobile, admin login; real click-chain `/budgets` → budget bar → ✎ (budget config `/budget-config`), no deep-linking. Multi-section finite budget (`632200…`, three sections). Screenshots eye-checked:
  - **Fixed branch, Month interval:** parent input `<M>`, alert `+ <diff>`, three section rows `<a>/<b>/<c>` — self-consistent (`pr-631-config-month.png`).
  - **Fixed branch, Year interval** (interval flipped to Year via the header date-picker `<select>` → `?view_date=YYYY`): donut renders **byte-identical** to Month — same input `<M>`, same `+ <diff>` alert, same three section rows. Only the header label changes (`2026` vs `July 2026`) (`pr-631-config-year.png`).
  - **Baseline `upstream/main`, Year interval** (same budget, same nav): reproduces the bug — false `− <11×-ish>` over/under alert and year-scaled breakdown (each section ≈ **12×** its month row) with large red filler (`pr-631-baseline-year.png`). Baseline Month matches the fixed Month exactly.
  - **12× save-corruption path** (fresh config mount while already in Year mode — the bookmark case): baseline parent input `defaultValue` = **≈12× the monthly value** (would persist into `.month` on blur+Save); fixed branch input = the correct **month** value.
- [x] reviewoie (budget-reviewer) — **clean, 0 blocking findings**; traced all four `interval` consumers as legitimately month-only and confirmed the fix repairs (not just avoids) the `isSyncedInput`/`childDiff`/`parentDiff` branches.

Closes #630
