### PR TITLE
feat(snapshots): account snapshot management page — view/add/edit/delete in range

### DIFF
--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -125,6 +125,12 @@ export const AccountProperties = ({ account }: Props) => {
     router.go(PATH.CONNECTION_DETAIL, { params });
   };
 
+  const onClickSnapshots = () => {
+    const params = new URLSearchParams();
+    params.append("account_id", account_id);
+    router.go(PATH.SNAPSHOTS, { params });
+  };
+
   const latestViewDate = new ViewDate(viewDate.getInterval());
   const isBalanceInputDisabled =
     !isManualAccount && viewDate.getEndDate() >= latestViewDate.getEndDate();
@@ -270,6 +276,7 @@ export const AccountProperties = ({ account }: Props) => {
       <PropertyLabel>Navigate</PropertyLabel>
       <Property>
         <ButtonRow onClick={onClickConnectionDetail}>See&nbsp;Connection&nbsp;Details</ButtonRow>
+        <ButtonRow onClick={onClickSnapshots}>Manage&nbsp;Snapshots</ButtonRow>
         {screenType === ScreenType.Narrow && (
           <ButtonRow onClick={onClickTransactions}>See&nbsp;Transactions</ButtonRow>
         )}

--- a/src/client/components/App/Router.tsx
+++ b/src/client/components/App/Router.tsx
@@ -15,6 +15,7 @@ import {
   ChartAccountsPage,
   AccountDetailPage,
   HoldingDetailPage,
+  SnapshotsPage,
   ApiKeyDetailPage,
 } from "client/pages";
 import { Spinner } from "./Spinner";
@@ -27,6 +28,7 @@ const getPage = (path: string) => {
   if (path === PATH.ACCOUNTS) return <AccountsPage />;
   if (path === PATH.ACCOUNT_DETAIL) return <AccountDetailPage />;
   if (path === PATH.HOLDING_DETAIL) return <HoldingDetailPage />;
+  if (path === PATH.SNAPSHOTS) return <SnapshotsPage />;
   if (path === PATH.TRANSACTIONS) return <TransactionsPage />;
   if (path === PATH.TRANSACTION_DETAIL) return <TransactionDetailPage />;
   if (path === PATH.CONFIG) return <ConfigPage />;

--- a/src/client/lib/hooks/router.ts
+++ b/src/client/lib/hooks/router.ts
@@ -12,6 +12,7 @@ export enum PATH {
   ACCOUNTS = "accounts",
   ACCOUNT_DETAIL = "account-detail",
   HOLDING_DETAIL = "holding-detail",
+  SNAPSHOTS = "snapshots",
   TRANSACTIONS = "transactions",
   TRANSACTION_DETAIL = "transaction-detail",
   CONFIG = "config",
@@ -48,6 +49,7 @@ const getHighLevelPage = (path: string): PATH | undefined => {
     case PATH.ACCOUNTS:
     case PATH.ACCOUNT_DETAIL:
     case PATH.HOLDING_DETAIL:
+    case PATH.SNAPSHOTS:
       return PATH.ACCOUNTS;
     case PATH.TRANSACTIONS:
     case PATH.TRANSACTION_DETAIL:

--- a/src/client/pages/SnapshotsPage/index.tsx
+++ b/src/client/pages/SnapshotsPage/index.tsx
@@ -1,5 +1,5 @@
-import { FormEventHandler, useMemo, useState } from "react";
-import { ViewDate } from "common";
+import { Fragment, FormEventHandler, useMemo, useRef, useState } from "react";
+import { getDateString, LocalDate } from "common";
 import {
   call,
   PATH,
@@ -19,20 +19,7 @@ import {
   KeyValue,
 } from "client";
 import { SnapshotPostResponse } from "server";
-
-const toDateInputValue = (d: Date) => d.toISOString().split("T")[0];
-
-const toIsoDateInput = (raw: string | null | undefined): string => {
-  if (!raw) return "";
-  const date = new Date(raw);
-  return Number.isNaN(date.getTime()) ? raw.slice(0, 10) : toDateInputValue(date);
-};
-
-/** A snapshot belongs on the page when its date falls inside the current view range. */
-const isInRange = (isoDate: string, viewDate: ViewDate) => {
-  const d = new Date(isoDate);
-  return d >= viewDate.getStartDate() && d <= viewDate.getEndDate();
-};
+import { dateInputValue, isInRange, hasDateCollision } from "./lib";
 
 interface RowEdit {
   value: string;
@@ -53,11 +40,26 @@ const AccountSnapshotsManager = ({ accountId }: { accountId: string }) => {
 
   const account = accounts.get(accountId);
 
+  // Every snapshot for this account (id + date), for one-per-day collision
+  // checks — not scoped to the view range, since a date edit can move a
+  // snapshot onto a day outside the current window.
+  const accountSnaps = useMemo(() => {
+    const all: { id: string; date: string }[] = [];
+    accountSnapshots.forEach((snap) => {
+      if (snap.account.account_id === accountId) {
+        all.push({ id: snap.snapshot.snapshot_id, date: snap.snapshot.date });
+      }
+    });
+    return all;
+  }, [accountSnapshots, accountId]);
+
   const bucket = useMemo(() => {
+    const start = viewDate.getStartDate();
+    const end = viewDate.getEndDate();
     const list: AccountSnapshot[] = [];
     accountSnapshots.forEach((snap) => {
       if (snap.account.account_id !== accountId) return;
-      if (!isInRange(snap.snapshot.date, viewDate)) return;
+      if (!isInRange(snap.snapshot.date, start, end)) return;
       list.push(snap);
     });
     return list.sort((a, b) => (a.snapshot.date < b.snapshot.date ? 1 : -1));
@@ -65,8 +67,9 @@ const AccountSnapshotsManager = ({ accountId }: { accountId: string }) => {
 
   const [edits, setEdits] = useState<Record<string, RowEdit>>({});
   const [addValue, setAddValue] = useState("");
-  const [addDate, setAddDate] = useState(toDateInputValue(viewDate.getEndDate()));
+  const [addDate, setAddDate] = useState(getDateString(viewDate.getEndDate()));
   const [addError, setAddError] = useState("");
+  const saving = useRef<Set<string>>(new Set());
 
   const goBack = () => {
     const params = new URLSearchParams();
@@ -79,51 +82,70 @@ const AccountSnapshotsManager = ({ accountId }: { accountId: string }) => {
 
   const saveSnapshot = async (snap: AccountSnapshot, edit: RowEdit) => {
     const oldId = snap.snapshot.snapshot_id;
+    const originalValue = String(snap.account.balances.current ?? "");
+    const dateChanged = dateInputValue(snap.snapshot.date) !== edit.date;
+    // No-op check first, so blurring an untouched row (incl. a null balance
+    // rendered as "") never trips the numeric validation below.
+    if (edit.value === originalValue && !dateChanged) return;
+
     const numericValue = parseFloat(edit.value);
     if (Number.isNaN(numericValue)) return setRowError(oldId, "Balance must be a number");
     if (!edit.date) return setRowError(oldId, "Date is required");
-
-    const newDate = new Date(edit.date).toISOString();
-    const noChange =
-      numericValue === snap.account.balances.current &&
-      toIsoDateInput(snap.snapshot.date) === edit.date;
-    if (noChange) return;
-
-    const newAccount = new Account({
-      ...snap.account,
-      balances: { ...snap.account.balances, current: numericValue },
-    });
-    const r = await call
-      .post<SnapshotPostResponse>("/api/snapshot", {
-        account: newAccount,
-        snapshot: { date: newDate },
-      })
-      .catch(console.error);
-    const newId = r?.body?.snapshot_id;
-    if (r?.status !== "success" || !newId) {
-      return setRowError(oldId, r?.message || "Failed to save snapshot");
+    if (dateChanged && hasDateCollision(accountSnaps, edit.date, oldId)) {
+      return setRowError(oldId, "A snapshot already exists on that date");
     }
+    if (saving.current.has(oldId)) return;
+    saving.current.add(oldId);
 
-    // The account snapshot id is derived from `${account_id}-${date}`, so a
-    // date edit lands under a new id — drop the stale row it left behind.
-    if (newId !== oldId) await call.delete(`/api/snapshot?id=${oldId}`).catch(console.error);
-
-    setData((oldData) => {
-      const newData = new Data(oldData);
-      const next = new AccountSnapshotDictionary(newData.accountSnapshots);
-      if (newId !== oldId) {
-        next.delete(oldId);
-        indexedDb.remove(StoreName.accountSnapshots, oldId).catch(console.error);
-      }
-      const newSnapshot = new AccountSnapshot({
-        snapshot: new Snapshot({ snapshot_id: newId, date: newDate }),
-        account: newAccount,
+    try {
+      // Bare `YYYY-MM-DD` — the server's `LocalDate` reads it as local
+      // midnight, so the derived `${account_id}-${YYYYMMDD}` id lands on the
+      // day the user picked (an ISO string would shift it a day in PST).
+      const newDate = new LocalDate(edit.date).toISOString();
+      const newAccount = new Account({
+        ...snap.account,
+        balances: { ...snap.account.balances, current: numericValue },
       });
-      next.set(newId, newSnapshot);
-      indexedDb.save(newSnapshot).catch(console.error);
-      newData.accountSnapshots = next;
-      return newData;
-    });
+      const r = await call
+        .post<SnapshotPostResponse>("/api/snapshot", {
+          account: newAccount,
+          snapshot: { date: edit.date },
+        })
+        .catch(console.error);
+      const newId = r?.body?.snapshot_id;
+      if (r?.status !== "success" || !newId) {
+        return setRowError(oldId, r?.message || "Failed to save snapshot");
+      }
+
+      // A date edit lands under a new id — only evict the stale row once the
+      // server confirms its deletion, so a failed DELETE can't desync the
+      // cache from the server (which would resurrect it on the next sync).
+      let oldDeleted = false;
+      if (newId !== oldId) {
+        const dr = await call.delete(`/api/snapshot?id=${oldId}`).catch(console.error);
+        oldDeleted = dr?.status === "success";
+        if (!oldDeleted) setRowError(oldId, "Saved, but failed to remove the old-date snapshot");
+      }
+
+      setData((oldData) => {
+        const newData = new Data(oldData);
+        const next = new AccountSnapshotDictionary(newData.accountSnapshots);
+        if (newId !== oldId && oldDeleted) {
+          next.delete(oldId);
+          indexedDb.remove(StoreName.accountSnapshots, oldId).catch(console.error);
+        }
+        const newSnapshot = new AccountSnapshot({
+          snapshot: new Snapshot({ snapshot_id: newId, date: newDate }),
+          account: newAccount,
+        });
+        next.set(newId, newSnapshot);
+        indexedDb.save(newSnapshot).catch(console.error);
+        newData.accountSnapshots = next;
+        return newData;
+      });
+    } finally {
+      saving.current.delete(oldId);
+    }
   };
 
   const deleteSnapshot = (snap: AccountSnapshot) => async () => {
@@ -147,8 +169,11 @@ const AccountSnapshotsManager = ({ accountId }: { accountId: string }) => {
     const numericValue = parseFloat(addValue);
     if (Number.isNaN(numericValue)) return setAddError("Balance must be a number");
     if (!addDate) return setAddError("Date is required");
+    if (hasDateCollision(accountSnaps, addDate, "")) {
+      return setAddError("A snapshot already exists on that date");
+    }
 
-    const newDate = new Date(addDate).toISOString();
+    const newDate = new LocalDate(addDate).toISOString();
     const newAccount = new Account({
       ...account,
       balances: { ...account.balances, current: numericValue },
@@ -156,7 +181,7 @@ const AccountSnapshotsManager = ({ accountId }: { accountId: string }) => {
     const r = await call
       .post<SnapshotPostResponse>("/api/snapshot", {
         account: newAccount,
-        snapshot: { date: newDate },
+        snapshot: { date: addDate },
       })
       .catch(console.error);
     const newId = r?.body?.snapshot_id;
@@ -199,41 +224,46 @@ const AccountSnapshotsManager = ({ accountId }: { accountId: string }) => {
         const id = snap.snapshot.snapshot_id;
         const edit = edits[id] ?? {
           value: String(snap.account.balances.current ?? ""),
-          date: toIsoDateInput(snap.snapshot.date),
+          date: dateInputValue(snap.snapshot.date),
           error: "",
         };
         const setEdit = (patch: Partial<RowEdit>) =>
           setEdits((prev) => ({ ...prev, [id]: { ...edit, ...patch } }));
+        // Fragment keeps each per-snapshot <PropertyLabel> + <Property> pair as
+        // DIRECT children of <Properties> so the `div.Properties > .propertyLabel`
+        // / `> .property` direct-child styling applies (no wrapper div).
         return (
-          <Property key={id}>
+          <Fragment key={id}>
             <PropertyLabel>Snapshot&nbsp;{idx + 1}</PropertyLabel>
-            <KeyValue name="Balance">
-              <input
-                type="number"
-                step="any"
-                value={edit.value}
-                onChange={(e) => setEdit({ value: e.target.value, error: "" })}
-                onBlur={() => saveSnapshot(snap, edit)}
-              />
-            </KeyValue>
-            <KeyValue name="Date">
-              <input
-                type="date"
-                value={edit.date}
-                onChange={(e) => setEdit({ date: e.target.value, error: "" })}
-                onBlur={() => saveSnapshot(snap, edit)}
-              />
-            </KeyValue>
-            {edit.error && <Row className="formError">{edit.error}</Row>}
-            <Row className="button">
-              <DeleteButton
-                confirmMessage="Delete this account snapshot?"
-                onClick={deleteSnapshot(snap)}
-              >
-                Delete&nbsp;this&nbsp;snapshot
-              </DeleteButton>
-            </Row>
-          </Property>
+            <Property>
+              <KeyValue name="Balance">
+                <input
+                  type="number"
+                  step="any"
+                  value={edit.value}
+                  onChange={(e) => setEdit({ value: e.target.value, error: "" })}
+                  onBlur={() => saveSnapshot(snap, edit)}
+                />
+              </KeyValue>
+              <KeyValue name="Date">
+                <input
+                  type="date"
+                  value={edit.date}
+                  onChange={(e) => setEdit({ date: e.target.value, error: "" })}
+                  onBlur={() => saveSnapshot(snap, edit)}
+                />
+              </KeyValue>
+              {edit.error && <Row className="formError">{edit.error}</Row>}
+              <Row className="button">
+                <DeleteButton
+                  confirmMessage="Delete this account snapshot?"
+                  onClick={deleteSnapshot(snap)}
+                >
+                  Delete&nbsp;this&nbsp;snapshot
+                </DeleteButton>
+              </Row>
+            </Property>
+          </Fragment>
         );
       })}
 

--- a/src/client/pages/SnapshotsPage/index.tsx
+++ b/src/client/pages/SnapshotsPage/index.tsx
@@ -1,0 +1,295 @@
+import { FormEventHandler, useMemo, useState } from "react";
+import { ViewDate } from "common";
+import {
+  call,
+  PATH,
+  useAppContext,
+  Data,
+  indexedDb,
+  StoreName,
+  Account,
+  AccountSnapshot,
+  AccountSnapshotDictionary,
+  Snapshot,
+  DeleteButton,
+  Properties,
+  PropertyLabel,
+  Property,
+  Row,
+  KeyValue,
+} from "client";
+import { SnapshotPostResponse } from "server";
+
+const toDateInputValue = (d: Date) => d.toISOString().split("T")[0];
+
+const toIsoDateInput = (raw: string | null | undefined): string => {
+  if (!raw) return "";
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? raw.slice(0, 10) : toDateInputValue(date);
+};
+
+/** A snapshot belongs on the page when its date falls inside the current view range. */
+const isInRange = (isoDate: string, viewDate: ViewDate) => {
+  const d = new Date(isoDate);
+  return d >= viewDate.getStartDate() && d <= viewDate.getEndDate();
+};
+
+interface RowEdit {
+  value: string;
+  date: string;
+  error: string;
+}
+
+/**
+ * Management surface Hoie requested in the closed PR #600 discussion on #599:
+ * rather than auto-picking the "most accurate" account snapshot, let the user
+ * see every snapshot in the view range and delete the bad one — e.g. the
+ * cash-only `account_balance` snapshot that craters an investment account's
+ * balance graph for a month.
+ */
+const AccountSnapshotsManager = ({ accountId }: { accountId: string }) => {
+  const { data, viewDate, setData, router } = useAppContext();
+  const { accountSnapshots, accounts } = data;
+
+  const account = accounts.get(accountId);
+
+  const bucket = useMemo(() => {
+    const list: AccountSnapshot[] = [];
+    accountSnapshots.forEach((snap) => {
+      if (snap.account.account_id !== accountId) return;
+      if (!isInRange(snap.snapshot.date, viewDate)) return;
+      list.push(snap);
+    });
+    return list.sort((a, b) => (a.snapshot.date < b.snapshot.date ? 1 : -1));
+  }, [accountSnapshots, accountId, viewDate]);
+
+  const [edits, setEdits] = useState<Record<string, RowEdit>>({});
+  const [addValue, setAddValue] = useState("");
+  const [addDate, setAddDate] = useState(toDateInputValue(viewDate.getEndDate()));
+  const [addError, setAddError] = useState("");
+
+  const goBack = () => {
+    const params = new URLSearchParams();
+    params.set("account_id", accountId);
+    router.go(PATH.ACCOUNT_DETAIL, { params });
+  };
+
+  const setRowError = (id: string, error: string) =>
+    setEdits((prev) => ({ ...prev, [id]: { ...prev[id], error } }));
+
+  const saveSnapshot = async (snap: AccountSnapshot, edit: RowEdit) => {
+    const oldId = snap.snapshot.snapshot_id;
+    const numericValue = parseFloat(edit.value);
+    if (Number.isNaN(numericValue)) return setRowError(oldId, "Balance must be a number");
+    if (!edit.date) return setRowError(oldId, "Date is required");
+
+    const newDate = new Date(edit.date).toISOString();
+    const noChange =
+      numericValue === snap.account.balances.current &&
+      toIsoDateInput(snap.snapshot.date) === edit.date;
+    if (noChange) return;
+
+    const newAccount = new Account({
+      ...snap.account,
+      balances: { ...snap.account.balances, current: numericValue },
+    });
+    const r = await call
+      .post<SnapshotPostResponse>("/api/snapshot", {
+        account: newAccount,
+        snapshot: { date: newDate },
+      })
+      .catch(console.error);
+    const newId = r?.body?.snapshot_id;
+    if (r?.status !== "success" || !newId) {
+      return setRowError(oldId, r?.message || "Failed to save snapshot");
+    }
+
+    // The account snapshot id is derived from `${account_id}-${date}`, so a
+    // date edit lands under a new id — drop the stale row it left behind.
+    if (newId !== oldId) await call.delete(`/api/snapshot?id=${oldId}`).catch(console.error);
+
+    setData((oldData) => {
+      const newData = new Data(oldData);
+      const next = new AccountSnapshotDictionary(newData.accountSnapshots);
+      if (newId !== oldId) {
+        next.delete(oldId);
+        indexedDb.remove(StoreName.accountSnapshots, oldId).catch(console.error);
+      }
+      const newSnapshot = new AccountSnapshot({
+        snapshot: new Snapshot({ snapshot_id: newId, date: newDate }),
+        account: newAccount,
+      });
+      next.set(newId, newSnapshot);
+      indexedDb.save(newSnapshot).catch(console.error);
+      newData.accountSnapshots = next;
+      return newData;
+    });
+  };
+
+  const deleteSnapshot = (snap: AccountSnapshot) => async () => {
+    const id = snap.snapshot.snapshot_id;
+    const r = await call.delete(`/api/snapshot?id=${id}`).catch(console.error);
+    if (r?.status !== "success") return setRowError(id, r?.message || "Failed to delete snapshot");
+    setData((oldData) => {
+      const newData = new Data(oldData);
+      const next = new AccountSnapshotDictionary(newData.accountSnapshots);
+      next.delete(id);
+      indexedDb.remove(StoreName.accountSnapshots, id).catch(console.error);
+      newData.accountSnapshots = next;
+      return newData;
+    });
+  };
+
+  const onSubmitAdd: FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+    setAddError("");
+    if (!account) return setAddError("Account context is missing");
+    const numericValue = parseFloat(addValue);
+    if (Number.isNaN(numericValue)) return setAddError("Balance must be a number");
+    if (!addDate) return setAddError("Date is required");
+
+    const newDate = new Date(addDate).toISOString();
+    const newAccount = new Account({
+      ...account,
+      balances: { ...account.balances, current: numericValue },
+    });
+    const r = await call
+      .post<SnapshotPostResponse>("/api/snapshot", {
+        account: newAccount,
+        snapshot: { date: newDate },
+      })
+      .catch(console.error);
+    const newId = r?.body?.snapshot_id;
+    if (r?.status !== "success" || !newId) {
+      return setAddError(r?.message || "Failed to add snapshot");
+    }
+    setData((oldData) => {
+      const newData = new Data(oldData);
+      const next = new AccountSnapshotDictionary(newData.accountSnapshots);
+      const newSnapshot = new AccountSnapshot({
+        snapshot: new Snapshot({ snapshot_id: newId, date: newDate }),
+        account: newAccount,
+      });
+      next.set(newId, newSnapshot);
+      indexedDb.save(newSnapshot).catch(console.error);
+      newData.accountSnapshots = next;
+      return newData;
+    });
+    setAddValue("");
+  };
+
+  return (
+    <Properties className="SnapshotsPage">
+      <PropertyLabel>Account&nbsp;Snapshots</PropertyLabel>
+      <Property>
+        <KeyValue name="Account">
+          <span>{account?.custom_name || account?.name || accountId}</span>
+        </KeyValue>
+      </Property>
+
+      {bucket.length === 0 && (
+        <Property>
+          <KeyValue name="No&nbsp;snapshots&nbsp;in&nbsp;this&nbsp;range">
+            <span></span>
+          </KeyValue>
+        </Property>
+      )}
+
+      {bucket.map((snap, idx) => {
+        const id = snap.snapshot.snapshot_id;
+        const edit = edits[id] ?? {
+          value: String(snap.account.balances.current ?? ""),
+          date: toIsoDateInput(snap.snapshot.date),
+          error: "",
+        };
+        const setEdit = (patch: Partial<RowEdit>) =>
+          setEdits((prev) => ({ ...prev, [id]: { ...edit, ...patch } }));
+        return (
+          <Property key={id}>
+            <PropertyLabel>Snapshot&nbsp;{idx + 1}</PropertyLabel>
+            <KeyValue name="Balance">
+              <input
+                type="number"
+                step="any"
+                value={edit.value}
+                onChange={(e) => setEdit({ value: e.target.value, error: "" })}
+                onBlur={() => saveSnapshot(snap, edit)}
+              />
+            </KeyValue>
+            <KeyValue name="Date">
+              <input
+                type="date"
+                value={edit.date}
+                onChange={(e) => setEdit({ date: e.target.value, error: "" })}
+                onBlur={() => saveSnapshot(snap, edit)}
+              />
+            </KeyValue>
+            {edit.error && <Row className="formError">{edit.error}</Row>}
+            <Row className="button">
+              <DeleteButton
+                confirmMessage="Delete this account snapshot?"
+                onClick={deleteSnapshot(snap)}
+              >
+                Delete&nbsp;this&nbsp;snapshot
+              </DeleteButton>
+            </Row>
+          </Property>
+        );
+      })}
+
+      <PropertyLabel>Add&nbsp;Snapshot</PropertyLabel>
+      <Property>
+        <form onSubmit={onSubmitAdd}>
+          <KeyValue name="Balance">
+            <input
+              type="number"
+              step="any"
+              value={addValue}
+              onChange={(e) => setAddValue(e.target.value)}
+              placeholder="0"
+            />
+          </KeyValue>
+          <KeyValue name="Date">
+            <input type="date" value={addDate} onChange={(e) => setAddDate(e.target.value)} />
+          </KeyValue>
+          {addError && <Row className="formError">{addError}</Row>}
+          <Row className="button">
+            <button type="submit">Add</button>
+          </Row>
+        </form>
+      </Property>
+
+      <PropertyLabel>&nbsp;</PropertyLabel>
+      <Property>
+        <Row className="button">
+          <button type="button" onClick={goBack}>
+            Back
+          </button>
+        </Row>
+      </Property>
+    </Properties>
+  );
+};
+
+export const SnapshotsPage = () => {
+  const { router } = useAppContext();
+  const params = router.getActiveParams(PATH.SNAPSHOTS);
+  const accountId = params.get("account_id") || "";
+
+  return (
+    <div className="SnapshotsPage">
+      {accountId ? (
+        <AccountSnapshotsManager accountId={accountId} />
+      ) : (
+        <Properties className="SnapshotsPage">
+          <PropertyLabel>Snapshots</PropertyLabel>
+          <Property>
+            <KeyValue name="Missing&nbsp;account&nbsp;context">
+              <span></span>
+            </KeyValue>
+          </Property>
+        </Properties>
+      )}
+    </div>
+  );
+};

--- a/src/client/pages/SnapshotsPage/lib.test.ts
+++ b/src/client/pages/SnapshotsPage/lib.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "bun:test";
+import { getDateString } from "common";
+import { dateInputValue, isInRange, hasDateCollision } from "./lib";
+
+describe("SnapshotsPage/lib", () => {
+  describe("dateInputValue", () => {
+    it("renders a stored ISO date as a local YYYY-MM-DD", () => {
+      const iso = new Date("2026-07-10T12:00:00Z").toISOString();
+      expect(dateInputValue(iso)).toBe(getDateString(new Date(iso)));
+    });
+
+    it("returns '' for an empty string", () => {
+      expect(dateInputValue("")).toBe("");
+    });
+
+    it("falls back to the first 10 chars when the value is not a real date", () => {
+      expect(dateInputValue("2026-07-10-garbage")).toBe("2026-07-10");
+    });
+  });
+
+  describe("isInRange", () => {
+    const start = new Date("2026-07-01T00:00:00");
+    const end = new Date("2026-07-31T23:59:59");
+
+    it("includes a date inside the range (inclusive bounds)", () => {
+      expect(isInRange(new Date("2026-07-15T00:00:00").toISOString(), start, end)).toBe(true);
+      expect(isInRange(start.toISOString(), start, end)).toBe(true);
+    });
+
+    it("excludes dates before the start and after the end", () => {
+      expect(isInRange(new Date("2026-06-30T00:00:00").toISOString(), start, end)).toBe(false);
+      expect(isInRange(new Date("2026-08-01T00:00:00").toISOString(), start, end)).toBe(false);
+    });
+  });
+
+  describe("hasDateCollision", () => {
+    const snaps = [
+      { id: "a-20260710", date: new Date("2026-07-10T07:00:00Z").toISOString() },
+      { id: "a-20260720", date: new Date("2026-07-20T07:00:00Z").toISOString() },
+    ];
+
+    it("flags a date already occupied by ANOTHER snapshot", () => {
+      // Editing the 07-10 row onto 07-20 collides with the existing 07-20 row.
+      expect(hasDateCollision(snaps, dateInputValue(snaps[1].date), "a-20260710")).toBe(true);
+    });
+
+    it("does not flag the snapshot's own current date (self-exclusion)", () => {
+      expect(hasDateCollision(snaps, dateInputValue(snaps[0].date), "a-20260710")).toBe(false);
+    });
+
+    it("does not flag a free date", () => {
+      expect(hasDateCollision(snaps, "2026-07-25", "a-20260710")).toBe(false);
+    });
+
+    it("treats a create (no excluded id) as colliding with any matching day", () => {
+      expect(hasDateCollision(snaps, dateInputValue(snaps[0].date), "")).toBe(true);
+      expect(hasDateCollision(snaps, "2026-07-25", "")).toBe(false);
+    });
+  });
+});

--- a/src/client/pages/SnapshotsPage/lib.ts
+++ b/src/client/pages/SnapshotsPage/lib.ts
@@ -1,0 +1,26 @@
+import { getDateString } from "common";
+
+/** Render a stored ISO snapshot date as a local `YYYY-MM-DD` for a date input. */
+export const dateInputValue = (iso: string): string => {
+  if (!iso) return "";
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso.slice(0, 10) : getDateString(d);
+};
+
+/** A snapshot belongs on the page when its date falls inside the current view range. */
+export const isInRange = (iso: string, start: Date, end: Date): boolean => {
+  const d = new Date(iso);
+  return d >= start && d <= end;
+};
+
+/**
+ * Account snapshot ids are one-per-day (`${account_id}-${YYYYMMDD}`), so moving
+ * a snapshot onto a day another snapshot already occupies would silently
+ * overwrite it. Detect that before the write so the UI can block it.
+ */
+export const hasDateCollision = (
+  snapshots: { id: string; date: string }[],
+  targetDate: string,
+  excludeId: string,
+): boolean =>
+  snapshots.some((s) => s.id !== excludeId && dateInputValue(s.date) === targetDate);

--- a/src/client/pages/index.ts
+++ b/src/client/pages/index.ts
@@ -5,6 +5,7 @@ export * from "./BudgetConfigPage";
 export * from "./AccountsPage";
 export * from "./AccountDetailPage";
 export * from "./HoldingDetailPage";
+export * from "./SnapshotsPage";
 export * from "./TransactionsPage";
 export * from "./TransactionDetailPage";
 export * from "./ConfigPage";


### PR DESCRIPTION
## What

Adds a **snapshot management page** so the user can view, add, edit, and delete an account's balance snapshots — the surface Hoie requested in the closed PR #600 discussion on #599, instead of an auto-"largest snapshot wins" heuristic.

Reached via a new **Manage Snapshots** button on the account detail page → `SNAPSHOTS?account_id=`. It lists the account's `account_balance` snapshots that fall in the current **view-date range**, sorted newest-first. Each row has an editable **Balance** and **Date** (save-on-blur) plus a **Delete** button, and an **Add** form (balance + date) at the bottom.

This directly resolves #599: the V-dip where a cash-only `account_balance` snapshot craters an investment account's balance graph for a month is fixed by letting the user **delete that one bad snapshot** — Hoie's chosen resolution ("the user could simply delete that one problematic account snapshot").

## Scope / follow-up

Hoie also asked for a holding-snapshot twin (`SNAPSHOTS?holding_id=`). Filed as a follow-up because it carries a design question: the holding **detail page is keyed by a ticker bucket that can aggregate multiple `security_id`s**, so mapping "the holding detail page" to a single `holding_id` snapshot list is ambiguous. Kept out of this PR for a focused, unambiguous diff (scope discipline). See the follow-up issue.

## How it works

- New `PATH.SNAPSHOTS`, grouped under the Accounts high-level tab; wired into `App/Router.tsx` + `pages/index.ts`.
- Reads `account_id` via `router.getActiveParams(PATH.SNAPSHOTS)` (transition-safe param read).
- Reuses the existing account-snapshot write contract: `POST /api/snapshot { account, snapshot:{date} }` (add/edit) and `DELETE /api/snapshot?id=` — same pattern `AccountProperties` already uses for its past-date balance input.
- Optimistic local-cache updates: clones `Data` + `AccountSnapshotDictionary`, sets/deletes the row, mirrors to IndexedDB — no round-trip through `GET /api/snapshots`.
- One-per-day ids (`${account_id}-${YYYYMMDD}`): a date edit lands under a new id, so the handler deletes the stale-id row **after** the server confirms the delete, and a **collision guard** blocks moving a snapshot onto a day another snapshot already occupies (would silently overwrite it). Dates are sent bare (`YYYY-MM-DD`) so the server's `LocalDate` keeps the picked day.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run build-client` — clean
- [x] `bun run test` — 1091 pass / 0 fail (9 new `SnapshotsPage/lib` unit tests: range filter, local date render, one-per-day collision incl. self-exclusion)
- [x] **UI E2E** — sandbox, admin/sandbox, **390×844 mobile viewport**, real click-chains (Accounts nav → `.AccountRow` → **Manage Snapshots** button), screenshots eye-checked:
  - `SNAPSHOTS?account_id=` for a sparse manual investment account, current (July) view. Empty range renders "No snapshots in this range".
  - **Add** two snapshots (distinct in-range dates, synthetic balances) → both rows appear, sorted newest-first.
  - **Edit balance** (save-on-blur) → persists.
  - **Edit date** to a free day (id-swap) → row moves, **exactly 2 rows remain** (old-date row cleaned up, no orphan) — confirmed at the DB: only the new-date row is live, the old-date row is a tombstone.
  - **Collision**: edit a row's date onto a day another snapshot occupies → **blocked** with "A snapshot already exists on that date", still 2 rows, the target row's balance **untouched** (eye-checked screenshot).
  - **Reload** (server re-sync) → both edited values persist.
  - **Delete** each row → list empties; DB shows all as tombstones; unrelated accounts' snapshots and the account's pre-range (June) snapshot untouched.
  - Add-form default date pre-fills the current view's month (local time — no PST day-shift).
  - Per-row `Snapshot N` labels render as proper `.propertyLabel` section headings (direct children of `.Properties`).

Closes #599.
