### PR TITLE
feat(performance): dollar-weighting caption on the MWR widget (#381 item 6)

### DIFF
--- a/src/client/components/PerformanceBenchmark/index.css
+++ b/src/client/components/PerformanceBenchmark/index.css
@@ -111,3 +111,10 @@
   color: var(--amber);
   cursor: help;
 }
+
+.performanceCaption {
+  font-size: 0.75em;
+  color: rgba(255, 255, 255, 0.4);
+  font-style: italic;
+  line-height: 1.35;
+}

--- a/src/client/components/PerformanceBenchmark/index.css
+++ b/src/client/components/PerformanceBenchmark/index.css
@@ -117,4 +117,5 @@
   color: rgba(255, 255, 255, 0.4);
   font-style: italic;
   line-height: 1.35;
+  margin-top: 0.3em;
 }

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -228,6 +228,10 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
       vStart,
       vEnd,
       flowCount: flows.length,
+      // In-window purchases (positive flows). ≥2 signals a steady-
+      // contribution (DCA) pattern, which dollar-weights the MWR — see the
+      // caption render.
+      contributionCount: flows.filter((f) => f.amount > 0).length,
       yearsInWindow,
       mwr,
       mwrGain,
@@ -311,9 +315,19 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
     gapDollars,
     suppressAnnualized,
     isClamped,
+    contributionCount,
     divergentSecurityCount,
     txnExcessSecurityCount,
   } = computed;
+
+  // A steady contributor (≥2 in-window purchases) whose money-weighted return
+  // trails the benchmark's time-weighted return is seeing the effect of *when*
+  // the money went in — later dollars had less time to compound — not weaker
+  // security selection. Shown only when that misread is actually possible: a
+  // negative gap with a multi-contribution stream. A positive gap needs no
+  // such disclaimer.
+  const showDollarWeightingCaption =
+    contributionCount >= 2 && gapPct !== null && gapPct < 0;
 
   // Every value cell renders the same shape: a "total" line on top and, if
   // annualization isn't suppressed for short windows, a per-year line under
@@ -448,6 +462,15 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
             </span>
           )}
         </div>
+
+        {showDollarWeightingCaption && (
+          <div className="performanceCaption">
+            Steady contributions pull your money-weighted return below the
+            benchmark&apos;s time-weighted return even with identical holdings —
+            the gap reflects when you invested (dollar-weighting), not weaker
+            selection.
+          </div>
+        )}
       </Property>
     </>
   );

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -320,14 +320,20 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
     txnExcessSecurityCount,
   } = computed;
 
-  // A steady contributor (≥2 in-window purchases) whose money-weighted return
-  // trails the benchmark's time-weighted return is seeing the effect of *when*
-  // the money went in — later dollars had less time to compound — not weaker
-  // security selection. Shown only when that misread is actually possible: a
-  // negative gap with a multi-contribution stream. A positive gap needs no
-  // such disclaimer.
+  // For a steady contributor (≥2 in-window purchases), part of a negative gap
+  // is dollar-weighting: later contributions had less time to compound, so the
+  // money-weighted return trails the benchmark's time-weighted return even for
+  // identical holdings. That mechanism only pulls the gap *negative* when the
+  // benchmark ROSE over the window — in a falling window steady buying is
+  // cheaper and timing pushes the gap positive, so the caption would be
+  // backwards. Gate on a rising benchmark accordingly. (The gap still mixes
+  // selection and timing, so the copy says "part of", not "all".)
   const showDollarWeightingCaption =
-    contributionCount >= 2 && gapPct !== null && gapPct < 0;
+    contributionCount >= 2 &&
+    gapPct !== null &&
+    gapPct < 0 &&
+    benchmark !== null &&
+    benchmark.cumulative > 0;
 
   // Every value cell renders the same shape: a "total" line on top and, if
   // annualization isn't suppressed for short windows, a per-year line under
@@ -465,9 +471,10 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
 
         {showDollarWeightingCaption && (
           <div className="performanceCaption">
-            Steady contributions pull your money-weighted return below the
-            benchmark&apos;s time-weighted return even with identical holdings —
-            the gap reflects when you invested (dollar-weighting), not weaker
+            With steady contributions in a rising market, part of this gap is
+            dollar-weighting — later contributions had less time to compound, so
+            your money-weighted return trails the benchmark&apos;s time-weighted
+            return even for identical holdings — rather than necessarily weaker
             selection.
           </div>
         )}


### PR DESCRIPTION
## What

Adds a **dollar-weighting caption** to the Investment Performance (MWR) widget — the last self-contained UX item from #381 (item 6).

A user with steady contributions systematically sees their money-weighted return (MWR) trail the benchmark's time-weighted return (TWR) **in a rising market**, even with identical holdings — because later dollars had less time to compound. That's *dollar-weighting*, an artifact of contribution timing, not weaker security selection. Without a note, the negative Diff row reads as "I underperformed the index," which is a misread.

The caption:

> With steady contributions in a rising market, part of this gap is dollar-weighting — later contributions had less time to compound, so your money-weighted return trails the benchmark's time-weighted return even for identical holdings — rather than necessarily weaker selection.

**Shown only when the misread is actually possible:**
- a negative gap (`gapPct < 0`),
- a **rising** benchmark (`benchmark.cumulative > 0`) — in a *falling* window steady buying is cheaper and timing pushes the gap positive, so the mechanism reverses and the caption would be backwards,
- a multi-contribution stream (≥2 in-window purchases).

A positive gap, a falling benchmark, or a lump-sum window needs no disclaimer.

## Design notes

- Rendered as a footnote-style caption line (`.performanceCaption`, same subtle italic grey as `.performanceFootnote`, matching `margin-top`), **not a tooltip** — consistent with the widget's mobile-first, no-hover treatment (the divergence-flag decision, Hoie 2026-07-06, already in this file).
- Zero calculation change. Pure additive UI text gated on already-computed `gapPct` + `benchmark.cumulative` + a new `contributionCount` (count of in-window positive flows). No change to `benchmark.ts`.
- The gap mixes selection (their holdings vs VOO) and timing (MWR vs TWR), so the copy says "part of this gap" / "rather than necessarily weaker selection" — not a definitive attribution.

## Scope

Retires **only item 6** of #381. Items 1 (cash-inclusive MWR), 2 (implausible-return display guard), 3 (benchmark picker), 4 (multi-account aggregation), and 5 (dividend capture) remain — each is either gated on the unresolved Plaid settlement mental model or a product-threshold decision, flagged separately on #381 for your call.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun --bun eslint src` — clean
- [x] `bun run build-client` — built
- [x] `bun test` — 1094 pass / 0 fail
- [x] **reviewoie** — 2 MED accuracy findings (falling-benchmark reversal + causal overclaim) + 1 LOW (margin) — all three applied in the fix commit; re-confirmed by E2E below.
- [x] **UI E2E** — sandbox, admin/sandbox, 390×844 mobile, real row-click into each investment account's detail (`.AccountRow` → `/account-detail`), window picker + viewDate arrows driven live:
  - **Manual investment account, current viewDate, 1Y/3Y/All** — Diff renders **positive** (green) → caption correctly **absent** (positive gap needs no disclaimer).
  - **Chase brokerage, May 2025 viewDate, 1Y** — MWR trails a **rising** VOO by a small negative Diff (red) → caption **renders**. Screenshot eye-checked at 390px: grey italic caption wraps cleanly below the amber footnote, subtle styling matching `.performanceFootnote`, no overflow. This state (negative gap **with** rising benchmark) is exactly the falling-benchmark-reversal guard's positive case — the caption appeared only because VOO was up over the window.
  - Console: no errors (pre-existing localhost `sw.js` ServiceWorker registration warning only).

Refs #381 (item 6 — DCA/dollar-weighting UX copy).
