### PR TITLE
refactor(client): extract <TransactionRowInfo> shared list-row header (#326 phase 5h)

### DIFF
--- a/src/client/components/TransactionRowInfo/index.tsx
+++ b/src/client/components/TransactionRowInfo/index.tsx
@@ -1,0 +1,63 @@
+import { ReactNode } from "react";
+import { currencyCodeToSymbol, LocalDate, numberToCommaString } from "common";
+
+interface Props {
+  /** ISO date string or any Date-parseable value. Rendered as
+   *  `M/D` in en-US locale — every list row uses this shape. */
+  date: string;
+  /** Absolute value drives the display; `amountSign="auto"` prepends
+   *  "+ " when this is negative (app convention: negative = incoming). */
+  amount: number;
+  /** ISO 4217 code, or `""` for unknown. */
+  isoCurrency: string;
+  /** `"auto"` prepends "+ " when `amount < 0`; `"none"` renders the
+   *  absolute value with no sign prefix (transfer bundles). Defaults
+   *  to `"auto"`. */
+  amountSign?: "auto" | "none";
+  /** Extra class on the `.amount` cell (e.g. `"transferAmount"`). */
+  amountClassName?: string;
+  /** Click handler on the whole info block — navigates to the detail
+   *  page in every caller today. */
+  onClickInfo?: () => void;
+  /** Contents of the middle `.merchant_name` cell — each row type
+   *  arranges its own bigText/smallText stack (merchant + account,
+   *  name + account + institution, "Transfer" + from→to, …). */
+  children: ReactNode;
+}
+
+/**
+ * Shared header block for every list-view transaction row:
+ * date · name/subline stack · amount. Wraps the three-column
+ * `.transactionInfo` scaffold that `TransactionRow`,
+ * `InvestmentTransactionRow`, and `TransferRow` all rendered inline.
+ * The row-specific chrome (label controls, transfer controls, empty)
+ * sits outside this primitive as a sibling of `.transactionInfo`
+ * inside `.TransactionRow`.
+ */
+export const TransactionRowInfo = ({
+  date,
+  amount,
+  isoCurrency,
+  amountSign = "auto",
+  amountClassName,
+  onClickInfo,
+  children,
+}: Props) => {
+  const amountClasses = ["amount", amountClassName].filter(Boolean).join(" ");
+  return (
+    <div className="transactionInfo" onClick={onClickInfo}>
+      <div className="authorized_date bigText">
+        {new LocalDate(date).toLocaleString("en-US", {
+          month: "numeric",
+          day: "numeric",
+        })}
+      </div>
+      <div className="merchant_name">{children}</div>
+      <div className={amountClasses}>
+        {amountSign === "auto" && amount < 0 && <>+&nbsp;</>}
+        {currencyCodeToSymbol(isoCurrency)}&nbsp;
+        {numberToCommaString(Math.abs(amount))}
+      </div>
+    </div>
+  );
+};

--- a/src/client/components/TransactionsTable/InvestmentTransactionRow.tsx
+++ b/src/client/components/TransactionsTable/InvestmentTransactionRow.tsx
@@ -1,6 +1,5 @@
-import { numberToCommaString, currencyCodeToSymbol, LocalDate } from "common";
 import { InvestmentTransaction, PATH, useAppContext } from "client";
-import { InstitutionSpan } from "client/components";
+import { InstitutionSpan, TransactionRowInfo } from "client/components";
 
 interface Props {
   investmentTransaction: InvestmentTransaction;
@@ -28,26 +27,18 @@ const InvestmentTransactionRow = ({ investmentTransaction }: Props) => {
 
   return (
     <div className="TransactionRow">
-      <div className="transactionInfo" onClick={onClickInfo}>
-        <div className="authorized_date bigText">
-          {new LocalDate(date).toLocaleString("en-US", {
-            month: "numeric",
-            day: "numeric",
-          })}
+      <TransactionRowInfo
+        date={date}
+        amount={amount}
+        isoCurrency={iso_currency_code || ""}
+        onClickInfo={onClickInfo}
+      >
+        {name && <div className="smallText">{name}</div>}
+        <div className="bigText">{account?.custom_name || account?.name}</div>
+        <div className="smallText">
+          {institution_id && <InstitutionSpan institution_id={institution_id} />}
         </div>
-        <div className="merchant_name">
-          {name && <div className="smallText">{name}</div>}
-          <div className="bigText">{account?.custom_name || account?.name}</div>
-          <div className="smallText">
-            {institution_id && <InstitutionSpan institution_id={institution_id} />}
-          </div>
-        </div>
-        <div className="amount">
-          {amount < 0 && <>+&nbsp;</>}
-          {currencyCodeToSymbol(iso_currency_code || "")}&nbsp;
-          {numberToCommaString(Math.abs(amount))}
-        </div>
-      </div>
+      </TransactionRowInfo>
     </div>
   );
 };

--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -1,5 +1,4 @@
 import { useEffect, ChangeEventHandler, MouseEventHandler } from "react";
-import { numberToCommaString, currencyCodeToSymbol, LocalDate } from "common";
 import {
   useAppContext,
   useBudgetCategorySelect,
@@ -14,7 +13,7 @@ import {
   SplitTransactionDictionary,
   indexedDb,
 } from "client";
-import { CheckIcon } from "client/components";
+import { CheckIcon, TransactionRowInfo } from "client/components";
 import { ApiResponse } from "server";
 import TransferControls from "./TransferControls";
 
@@ -249,32 +248,24 @@ const TransactionRow = ({ transaction }: Props) => {
 
   return (
     <div className="TransactionRow">
-      <div className="transactionInfo" onClick={onClickInfo}>
-        <div className="authorized_date bigText">
-          {new LocalDate(authorized_date || date).toLocaleString("en-US", {
-            month: "numeric",
-            day: "numeric",
-          })}
-        </div>
-        <div className="merchant_name">
-          {!merchant_name && name ? (
-            <div className="bigText">{name}</div>
-          ) : (
-            <>
-              <div className="bigText">{merchant_name}</div>
-              {name && merchant_name?.toLowerCase() !== name.toLowerCase() && (
-                <div className="smallText">{name}</div>
-              )}
-            </>
-          )}
-          <div className="smallText">{account?.custom_name || account?.name}</div>
-        </div>
-        <div className="amount">
-          {amountAfterSplit < 0 && <>+&nbsp;</>}
-          {currencyCodeToSymbol(iso_currency_code || "")}&nbsp;
-          {numberToCommaString(Math.abs(amountAfterSplit))}
-        </div>
-      </div>
+      <TransactionRowInfo
+        date={authorized_date || date}
+        amount={amountAfterSplit}
+        isoCurrency={iso_currency_code || ""}
+        onClickInfo={onClickInfo}
+      >
+        {!merchant_name && name ? (
+          <div className="bigText">{name}</div>
+        ) : (
+          <>
+            <div className="bigText">{merchant_name}</div>
+            {name && merchant_name?.toLowerCase() !== name.toLowerCase() && (
+              <div className="smallText">{name}</div>
+            )}
+          </>
+        )}
+        <div className="smallText">{account?.custom_name || account?.name}</div>
+      </TransactionRowInfo>
       <div className="budgetCategoryActions">
         {suggestedPairId ? (
           <TransferControls

--- a/src/client/components/TransactionsTable/TransferRow.tsx
+++ b/src/client/components/TransactionsTable/TransferRow.tsx
@@ -1,7 +1,5 @@
-import { MouseEventHandler } from "react";
-import { numberToCommaString, currencyCodeToSymbol, LocalDate } from "common";
 import { useAppContext, PATH } from "client";
-import { RightArrowIcon } from "client/components";
+import { RightArrowIcon, TransactionRowInfo } from "client/components";
 import type { JSONTransaction } from "common";
 
 interface Props {
@@ -12,9 +10,9 @@ interface Props {
 /**
  * Bundled single-row presentation of a confirmed transfer pair (#354
  * phase 3). The two paired transactions are folded into one row that
- * shows the date, both accounts (from → to), a `TransferArrowIcon` in
- * place of the +/− amount sign, and a "Transfer" chip where the
- * budget/category selects would normally sit.
+ * shows the date, both accounts (from → to), the pair's absolute
+ * amount (no +/− sign since the money doesn't leave the household),
+ * and a "Transfer" label where the merchant would normally sit.
  *
  * The first transaction in the pair is rendered as the "outgoing" side
  * (negative amount → money leaving) and the second is the "incoming"
@@ -43,7 +41,7 @@ const TransferRow = ({ transactions }: Props) => {
   // Detail-page navigation lands on the outgoing side — that's the row
   // the user would have clicked on the un-bundled view. (The detail
   // page itself surfaces the pair as a unit.)
-  const onClickInfo: MouseEventHandler<HTMLDivElement> = () => {
+  const onClickInfo = () => {
     const params = new URLSearchParams(router.params);
     params.set("transaction_id", outgoing.transaction_id);
     go(PATH.TRANSACTION_DETAIL, { params });
@@ -53,28 +51,23 @@ const TransferRow = ({ transactions }: Props) => {
 
   return (
     <div className="TransactionRow TransferRow">
-      <div className="transactionInfo" onClick={onClickInfo}>
-        <div className="authorized_date bigText">
-          {new LocalDate(date).toLocaleString("en-US", {
-            month: "numeric",
-            day: "numeric",
-          })}
+      <TransactionRowInfo
+        date={date}
+        amount={displayAmount}
+        isoCurrency={isoCurrency}
+        amountSign="none"
+        amountClassName="transferAmount"
+        onClickInfo={onClickInfo}
+      >
+        <div className="bigText">Transfer</div>
+        <div className="smallText">
+          {fromAccount?.custom_name || fromAccount?.name}
+          &nbsp;
+          <RightArrowIcon size={8} />
+          &nbsp;
+          {toAccount?.custom_name || toAccount?.name}
         </div>
-        <div className="merchant_name">
-          <div className="bigText">Transfer</div>
-          <div className="smallText">
-            {fromAccount?.custom_name || fromAccount?.name}
-            &nbsp;
-            <RightArrowIcon size={8} />
-            &nbsp;
-            {toAccount?.custom_name || toAccount?.name}
-          </div>
-        </div>
-        <div className="amount transferAmount">
-          {currencyCodeToSymbol(isoCurrency)}&nbsp;
-          {numberToCommaString(displayAmount)}
-        </div>
-      </div>
+      </TransactionRowInfo>
     </div>
   );
 };

--- a/src/client/components/index.ts
+++ b/src/client/components/index.ts
@@ -12,6 +12,7 @@ export * from "./ErrorBoundary";
 export * from "./PlaidLinkContext";
 export * from "./PlaidLinkButton";
 export * from "./SimpleFinLinkButton";
+export * from "./TransactionRowInfo";
 export * from "./TransactionsTable";
 export * from "./AccountsTable";
 export * from "./AccountProperties";


### PR DESCRIPTION
## Summary

The three list-view row components — `TransactionRow` (324 LOC), `InvestmentTransactionRow` (55), `TransferRow` (82) — all rendered the same `.transactionInfo` scaffold inline: `.authorized_date` big-text on the left, a `.merchant_name` name-and-subline stack in the middle, and a `.amount` cell on the right with the app convention of prepending "+ " on negative amounts.

Extracted `<TransactionRowInfo>` (new `src/client/components/TransactionRowInfo/`). Callers pass `{date, amount, isoCurrency, amountSign?, amountClassName?, onClickInfo?}` and drop the name/subline JSX as children — each row type stacks its own bigText/smallText arrangement.

- `amountSign` defaults to `"auto"` (prepends "+ " when negative); `TransferRow` uses `"none"` because a confirmed transfer's absolute amount doesn't reflect money crossing the household perimeter.
- `amountClassName` composes with the base `.amount`, so `TransferRow` keeps its `.transferAmount` styling hook.
- The row-specific chrome (label controls / transfer confirm-reject / nothing) still sits as a sibling of `<TransactionRowInfo>` inside each row's outer `.TransactionRow` div — nothing changes about the DOM shape below the info block.

Rendered HTML for each row is byte-identical to what shipped: same classes, same nesting, same locale format. Net -24 lines across the three callers.

`SplitTransactionRow` in `TransactionProperties` is intentionally left alone — it's an inline edit form, not a list row, and doesn't share this scaffold.

## Test plan

- [x] typecheck / lint / 1094 unit tests all clean
- [ ] E2E: transactions list renders visually identical across normal transactions, investment transactions, confirmed-transfer bundled rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)