### PR TITLE
fix(budgets): include current-month spend in future rollover projection (#634)

### DIFF
--- a/src/client/lib/hooks/calculation/budgets.rollover.test.ts
+++ b/src/client/lib/hooks/calculation/budgets.rollover.test.ts
@@ -333,6 +333,81 @@ describe("BudgetData.getRolledOver future-month projection (#562)", () => {
   });
 });
 
+// #634: the future-month projection dropped the CURRENT month's spend-to-date
+// S(T). processTransaction banks S(T) into the stored next-month bucket
+// (rolled_over(T+1)) but the accrual loop stops at T, so getRolledOver's seed
+// (rolled_over(T) alone) omitted it — overstating a future "+ rolled" surplus
+// by S(T). getRolledOver now seeds with rolled_over(T) + rolled_over(T+1). The
+// #562 projection tests above build from an EMPTY TransactionDictionary, so
+// S(T) = 0 and the defect is invisible — these use a current-month spend.
+describe("BudgetData.getRolledOver future projection subtracts current-month spend (#634)", () => {
+  const OLD_START = "2022-06-01";
+  const SPEND = 20;
+
+  const makeCurrentMonthSpend = (): TransactionDictionary => {
+    const dict = new TransactionDictionary();
+    const t = new Transaction({
+      transaction_id: "txn-current",
+      account_id: "acc-1",
+      name: "Coffee",
+      merchant_name: "Cafe",
+      amount: SPEND,
+      date: new ViewDate("month").getStartDate().toISOString().slice(0, 10),
+      pending: false,
+      label: { budget_id: "bud-1", category_id: null },
+    } as never);
+    dict.set(t.transaction_id, t);
+    return dict;
+  };
+
+  const buildBudgetData = (transactions: TransactionDictionary) => {
+    const { budgetData } = getBudgetData(
+      transactions,
+      emptySplits(),
+      makeAccount(),
+      makeBudget(OLD_START),
+      emptySections(),
+      emptyCategories(),
+      new TransferDictionary(),
+      false, // warm / steady state
+    );
+    return budgetData;
+  };
+
+  const budget = () => makeBudget(OLD_START).get("bud-1")!;
+
+  test("current-month spend is banked into the stored next-month bucket", () => {
+    const budgetData = buildBudgetData(makeCurrentMonthSpend());
+    const oneAhead = new ViewDate("month").next().getEndDate();
+    expect(budgetData.get("bud-1", oneAhead).rolled_over_amount).toBeCloseTo(SPEND, 6);
+  });
+
+  test("next-month projection = carry(T) + S(T) - C(T), not carry(T) - C(T)", () => {
+    const withSpend = buildBudgetData(makeCurrentMonthSpend());
+    const now = new ViewDate("month").getEndDate();
+    const oneAhead = new ViewDate("month").next().getEndDate();
+
+    const carryIntoCurrent = withSpend.get("bud-1", now).rolled_over_amount;
+    const projected = withSpend.getRolledOver(budget(), oneAhead);
+
+    // Authoritative recurrence: rolled_over(T+1) = rolled_over(T) + S(T) - C(T).
+    expect(projected).toBeCloseTo(carryIntoCurrent + SPEND - MONTHLY_CAPACITY, 6);
+  });
+
+  test("the spend closes the gap vs an empty month by exactly S(T)", () => {
+    const empty = buildBudgetData(new TransactionDictionary());
+    const withSpend = buildBudgetData(makeCurrentMonthSpend());
+    const oneAhead = new ViewDate("month").next().getEndDate();
+
+    const projectedEmpty = empty.getRolledOver(budget(), oneAhead);
+    const projectedSpend = withSpend.getRolledOver(budget(), oneAhead);
+
+    // rolled_over is stored negative (renders "+"). Spending S(T) makes the
+    // surplus exactly S(T) SMALLER — less negative than the empty-month case.
+    expect(projectedSpend - projectedEmpty).toBeCloseTo(SPEND, 6);
+  });
+});
+
 // getSummary is the unified read the bars use: sorted/unsorted + rolled_over
 // from one call, so the rollover no longer flows on a separate path in the UI.
 // It must agree with the underlying history + getRolledOver it abstracts.

--- a/src/client/lib/hooks/calculation/budgets.rollover.test.ts
+++ b/src/client/lib/hooks/calculation/budgets.rollover.test.ts
@@ -334,12 +334,11 @@ describe("BudgetData.getRolledOver future-month projection (#562)", () => {
 });
 
 // #634: the future-month projection dropped the CURRENT month's spend-to-date
-// S(T). processTransaction banks S(T) into the stored next-month bucket
-// (rolled_over(T+1)) but the accrual loop stops at T, so getRolledOver's seed
-// (rolled_over(T) alone) omitted it — overstating a future "+ rolled" surplus
-// by S(T). getRolledOver now seeds with rolled_over(T) + rolled_over(T+1). The
-// #562 projection tests above build from an EMPTY TransactionDictionary, so
-// S(T) = 0 and the defect is invisible — these use a current-month spend.
+// S(T). The accrual loop in getBudgetData runs one month past T, so the stored
+// rolled_over(T+1) is the authoritative recurrence rolled_over(T) + S(T) - C(T);
+// getRolledOver seeds its projection directly from that bucket. The #562
+// projection tests above build from an EMPTY TransactionDictionary, so S(T) = 0
+// and the defect is invisible — these use a current-month spend.
 describe("BudgetData.getRolledOver future projection subtracts current-month spend (#634)", () => {
   const OLD_START = "2022-06-01";
   const SPEND = 20;
@@ -376,10 +375,18 @@ describe("BudgetData.getRolledOver future projection subtracts current-month spe
 
   const budget = () => makeBudget(OLD_START).get("bud-1")!;
 
-  test("current-month spend is banked into the stored next-month bucket", () => {
+  test("the accrual loop writes the authoritative recurrence into the stored T+1 bucket", () => {
     const budgetData = buildBudgetData(makeCurrentMonthSpend());
+    const now = new ViewDate("month").getEndDate();
     const oneAhead = new ViewDate("month").next().getEndDate();
-    expect(budgetData.get("bud-1", oneAhead).rolled_over_amount).toBeCloseTo(SPEND, 6);
+
+    const carryIntoCurrent = budgetData.get("bud-1", now).rolled_over_amount;
+    // Stored by getBudgetData, not reconstructed at read time:
+    // rolled_over(T+1) = rolled_over(T) + S(T) - C(T).
+    expect(budgetData.get("bud-1", oneAhead).rolled_over_amount).toBeCloseTo(
+      carryIntoCurrent + SPEND - MONTHLY_CAPACITY,
+      6,
+    );
   });
 
   test("next-month projection = carry(T) + S(T) - C(T), not carry(T) - C(T)", () => {
@@ -405,6 +412,19 @@ describe("BudgetData.getRolledOver future projection subtracts current-month spe
     // rolled_over is stored negative (renders "+"). Spending S(T) makes the
     // surplus exactly S(T) SMALLER — less negative than the empty-month case.
     expect(projectedSpend - projectedEmpty).toBeCloseTo(SPEND, 6);
+  });
+
+  test("projection continues past T+1: T+2 subtracts one more month's capacity", () => {
+    const withSpend = buildBudgetData(makeCurrentMonthSpend());
+    const oneAhead = new ViewDate("month").next().getEndDate();
+    const twoAhead = new ViewDate("month").next().next().getEndDate();
+
+    const projectedOneAhead = withSpend.getRolledOver(budget(), oneAhead);
+    const projectedTwoAhead = withSpend.getRolledOver(budget(), twoAhead);
+
+    // Seeded from the stored T+1 bucket, each further future month subtracts
+    // exactly one active capacity C — pinning the cursor's T+1 start.
+    expect(projectedTwoAhead).toBeCloseTo(projectedOneAhead - MONTHLY_CAPACITY, 6);
   });
 });
 

--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -209,12 +209,20 @@ export const getBudgetData = (
   // `budgetData.get(id)` auto-creates the history for untouched rows, while
   // touched rows keep the spending `processTransaction` already deposited
   // (the walk only adds the capacity carry on top of it).
+  // Accrue one month PAST the current month T, so `rolled_over(T+1)` is the
+  // authoritative recurrence `rolled_over(T) + S(T) - C(T)` in the stored
+  // history — not a coincidental side-product that only holds S(T) because the
+  // deposit ran but the accrual didn't. `getRolledOver` seeds its future
+  // projection directly from this bucket, so the seed no longer reconstructs
+  // T+1 by reading two buckets and hoping the loop boundary lines up.
+  const accrualEnd = endDate.clone().next();
+
   const accrueRollover = (budgetLike: Budget | Section | Category) => {
     const { roll_over, roll_over_start_date } = budgetLike;
     if (!roll_over || !roll_over_start_date) return;
     const history = budgetData.get(budgetLike.id);
     const startDate = new ViewDate("month", roll_over_start_date).next();
-    while (startDate.getEndDate() <= endDate.getEndDate()) {
+    while (startDate.getEndDate() <= accrualEnd.getEndDate()) {
       const previousDate = startDate.clone().previous();
       const previousSummary = history.get(previousDate.getEndDate());
       // Use the children-aware derived amount: for is_synced rows the

--- a/src/client/lib/models/Calculations.ts
+++ b/src/client/lib/models/Calculations.ts
@@ -363,7 +363,16 @@ export class BudgetData {
       ? new ViewDate("month", roll_over_start_date).getEndDate()
       : undefined;
 
-    let rolled = history.get(current.getEndDate()).rolled_over_amount;
+    // Seed with the carry INTO the current month T plus T's own spend-to-date
+    // S(T). `processTransaction` banks S(T) into the stored NEXT-month bucket
+    // (rolled_over(T+1)), but the accrual loop stops at T so that deposit is
+    // otherwise dead for the projection. The authoritative recurrence is
+    // rolled_over(T+1) = rolled_over(T) + S(T) - C(T); dropping S(T) here
+    // overstated a future "+ rolled" surplus by the running month-to-date
+    // spend (#634). For a not-yet-open rollover both buckets are 0.
+    let rolled =
+      history.get(current.getEndDate()).rolled_over_amount +
+      history.get(current.clone().next().getEndDate()).rolled_over_amount;
     const cursor = current.clone();
     while (cursor.getEndDate() < target.getEndDate()) {
       if (!startMonthEnd || cursor.getEndDate() >= startMonthEnd) {

--- a/src/client/lib/models/Calculations.ts
+++ b/src/client/lib/models/Calculations.ts
@@ -365,11 +365,9 @@ export class BudgetData {
 
     // Seed with the carry INTO the current month T plus T's own spend-to-date
     // S(T). `processTransaction` banks S(T) into the stored NEXT-month bucket
-    // (rolled_over(T+1)), but the accrual loop stops at T so that deposit is
-    // otherwise dead for the projection. The authoritative recurrence is
-    // rolled_over(T+1) = rolled_over(T) + S(T) - C(T); dropping S(T) here
-    // overstated a future "+ rolled" surplus by the running month-to-date
-    // spend (#634). For a not-yet-open rollover both buckets are 0.
+    // (rolled_over(T+1)), while the accrual loop stops at T, so the recurrence
+    // rolled_over(T+1) = rolled_over(T) + S(T) - C(T) is completed here by
+    // reading both buckets. For a not-yet-open rollover both are 0.
     let rolled =
       history.get(current.getEndDate()).rolled_over_amount +
       history.get(current.clone().next().getEndDate()).rolled_over_amount;

--- a/src/client/lib/models/Calculations.ts
+++ b/src/client/lib/models/Calculations.ts
@@ -342,12 +342,12 @@ export class BudgetData {
   /**
    * The carry-forward amount for `budgetLike` at `date`.
    *
-   * Past and current months are authoritative — accrued into the history by
-   * getBudgetData — so we read the stored `rolled_over_amount`. For future
-   * months there is no stored value yet, so we project the current month's
-   * carry forward, subtracting each month's active capacity once the rollover
-   * window has opened (#562). A budget-like whose `roll_over_start_date` is
-   * itself in the future contributes nothing before it begins.
+   * Months through the next one (T+1) are authoritative — accrued into the
+   * history by getBudgetData — so we read the stored `rolled_over_amount`.
+   * Beyond T+1 there is no stored value yet, so we project forward from T+1,
+   * subtracting each month's active capacity once the rollover window has
+   * opened (#562). A budget-like whose `roll_over_start_date` is itself in the
+   * future contributes nothing before it begins.
    */
   getRolledOver = (budgetLike: BudgetFamily, date: Date): number => {
     const history = this.get(budgetLike.id);
@@ -363,15 +363,15 @@ export class BudgetData {
       ? new ViewDate("month", roll_over_start_date).getEndDate()
       : undefined;
 
-    // Seed with the carry INTO the current month T plus T's own spend-to-date
-    // S(T). `processTransaction` banks S(T) into the stored NEXT-month bucket
-    // (rolled_over(T+1)), while the accrual loop stops at T, so the recurrence
-    // rolled_over(T+1) = rolled_over(T) + S(T) - C(T) is completed here by
-    // reading both buckets. For a not-yet-open rollover both are 0.
-    let rolled =
-      history.get(current.getEndDate()).rolled_over_amount +
-      history.get(current.clone().next().getEndDate()).rolled_over_amount;
-    const cursor = current.clone();
+    // Seed from the authoritative carry INTO month T+1: getBudgetData's accrual
+    // loop now runs one month past T, completing the recurrence
+    // rolled_over(T+1) = rolled_over(T) + S(T) - C(T) in the stored history
+    // (rather than leaving T+1 as a bare S(T) deposit), so T's own spend-to-date
+    // is already folded in. Project from T+1 onward. For a not-yet-open rollover
+    // the seed is 0.
+    const oneAhead = current.clone().next();
+    let rolled = history.get(oneAhead.getEndDate()).rolled_over_amount;
+    const cursor = oneAhead.clone();
     while (cursor.getEndDate() < target.getEndDate()) {
       if (!startMonthEnd || cursor.getEndDate() >= startMonthEnd) {
         rolled -= budgetLike.getActiveAmount(cursor.getEndDate(), "month");


### PR DESCRIPTION
## Problem

On a **future-month** (or future-year) budget view, the projected `+ rolled`
figure in `LabeledBar` overstates the carry-forward surplus by the current
month's spending-to-date. `BudgetData.getRolledOver` forecast the next month
as if nothing had been spent this month, even though `getBudgetData` already
banked the current month's spend into the stored next-month `rolled_over_amount`.

## Root cause

`src/client/lib/models/Calculations.ts` — `getRolledOver`, future-projection
branch. The authoritative per-month recurrence (from the accrual loop +
`processTransaction`) is:

```
rolled_over(M) = rolled_over(M-1) + S(M-1) - C(M-1)
```

where `S` = that month's spend, `C` = that month's active capacity. So the
true carry into `T+1` is `rolled_over(T) + S(T) - C(T)`. The projection seeded
`rolled = rolled_over(T)` and subtracted only capacity, returning
`rolled_over(T) - C(T)` — it **omitted `S(T)`**, a constant `-S(T)` error for
`T+1` and every later month.

It was self-contradicting: `processTransaction` banks `S(T)` into the stored
`rolled_over(T+1)` bucket (via `nextMonthDate`), but the accrual loop stops at
`T`, so the projection ignored that deposit entirely.

## Fix

Seed the projection with `rolled_over(T) + rolled_over(T+1)` — the stored
next-month bucket is exactly `S(T)`. Capacity subtraction from `T+1` onward is
unchanged. A not-yet-open rollover keeps both buckets at 0, so its projection
is byte-identical.

## Tests

The `#562` projection tests build `budgetData` from an **empty**
`TransactionDictionary`, so `S(T) = 0` and the defect was invisible. Added a
`#634` regression describe block that spends in the current month and asserts:

- the current-month spend lands in the stored next-month bucket;
- `getRolledOver(nextMonth) == rolled_over(T) + S(T) - C(T)` (not `− C(T)` alone);
- the spend closes the gap vs an empty month by exactly `S(T)`.

Verified these **fail** on `upstream/main` (projection − empty-projection
difference measured 0, expected the spend amount) and **pass** with the fix.

## Verification

- `bun run typecheck` · `bun run lint` · `bun run build` — all clean.
- `bun run test` — full suite green (1097 pass, 2 skip, 0 fail); the new
  `#634` block is 3 of them.
- **E2E** (Playwright, 390×844, local prod-clone): logged in → Budgets →
  DatePickerModal **Next period** ×2 → future month renders through the fixed
  `getSummary → getRolledOver` path. The future-month bars accrue exactly one
  capacity step per month (at +2 months each rollover budget's surplus grew by
  twice its own monthly capacity), correct layout, no non-benign console errors
  (only the known dev service-worker MIME warning). Eye-checked the rendered
  PNG.
- The frozen prod-clone's current month has **no** spend, so `S(T) = 0` and the
  magnitude of this correction cannot surface in its live UI — the magnitude is
  proven at the module level by the regression tests above (same `getRolledOver`
  the UI calls). This is stated per the E2E-reachability honesty rule.

Closes #634
