### PR TITLE
refactor(transactions): centralize label suggestion-state predicates on TransactionLabel

### DIFF
--- a/src/client/lib/hooks/calculation/budgets.ts
+++ b/src/client/lib/hooks/calculation/budgets.ts
@@ -66,7 +66,7 @@ export const getBudgetData = (
     const childrenAmountTotal = transactionFamilies.getChildrenAmountTotal(transaction_id);
     const amountAfterSplit = amount - childrenAmountTotal;
 
-    const { budget_id, category_id, category_confidence } = label;
+    const { budget_id, category_id } = label;
 
     const nextMonthDate = new ViewDate("month", transactionDate).next().getEndDate();
 
@@ -83,7 +83,7 @@ export const getBudgetData = (
     // malformed `confidence=1 AND category_id=null` row falling into the
     // sorted-amount path below where `categories.get(null)` would skip it
     // entirely (contributing to neither bucket).
-    const isConfirmed = category_confidence === 1 && !!category_id;
+    const isConfirmed = label.isConfirmed();
 
     // Calculates unsorted transactions amount for budgets
     if (!isConfirmed) {
@@ -109,7 +109,11 @@ export const getBudgetData = (
       return;
     }
 
-    // Calcuates sorted transactions amount for categories
+    // Calcuates sorted transactions amount for categories.
+    // isConfirmed() is true only when category_id is present (it routes the
+    // malformed confidence=1/category_id=null row into the unsorted branch
+    // above), so this lookup always has a key — the guard makes that explicit.
+    if (!category_id) return;
     const parentCategory = categories.get(category_id);
     if (!parentCategory) return;
     budgetData.add(parentCategory.id, transactionDate, {

--- a/src/client/lib/models/Transaction.ts
+++ b/src/client/lib/models/Transaction.ts
@@ -35,17 +35,13 @@ export class TransactionLabel implements JSONTransactionLabel {
   }
 
   /**
-   * Suggestion-state predicates over `category_confidence` + `category_id`,
-   * per this label's field docstring: 1 → confirmed, 0 < x < 1 → engine
-   * suggestion the user hasn't reviewed. Centralizes the check so the calc
-   * and the TransactionsPage filter read one method instead of respelling
-   * the confidence comparison at each site.
-   *
-   * These are methods on the label — not accessors keyed by transaction_id
-   * on TransactionDictionary — because the budget calc runs them on synthetic
-   * split transactions (`SplitTransaction.toTransaction()`) whose ids are NOT
-   * keys in the dictionary, so a by-id lookup would miss the split's own
-   * label. The label is always in hand, so read it directly.
+   * Suggestion-state predicates that centralize the `category_confidence`
+   * check so the calc and the TransactionsPage filter read one method instead
+   * of respelling it at each site. Methods on the label — not accessors keyed
+   * by transaction_id on TransactionDictionary — because the budget calc runs
+   * them on synthetic split transactions (`SplitTransaction.toTransaction()`)
+   * whose ids are NOT keys in the dictionary, so a by-id lookup would miss the
+   * split's own label. The label is always in hand, so read it directly.
    */
   isConfirmed(): boolean {
     return this.category_confidence === 1 && !!this.category_id;

--- a/src/client/lib/models/Transaction.ts
+++ b/src/client/lib/models/Transaction.ts
@@ -34,6 +34,28 @@ export class TransactionLabel implements JSONTransactionLabel {
     return category.getParent()?.id;
   }
 
+  /**
+   * Suggestion-state predicates over `category_confidence` + `category_id`,
+   * per this label's field docstring: 1 → confirmed, 0 < x < 1 → engine
+   * suggestion the user hasn't reviewed. Centralizes the check so the calc
+   * and the TransactionsPage filter read one method instead of respelling
+   * the confidence comparison at each site.
+   *
+   * These are methods on the label — not accessors keyed by transaction_id
+   * on TransactionDictionary — because the budget calc runs them on synthetic
+   * split transactions (`SplitTransaction.toTransaction()`) whose ids are NOT
+   * keys in the dictionary, so a by-id lookup would miss the split's own
+   * label. The label is always in hand, so read it directly.
+   */
+  isConfirmed(): boolean {
+    return this.category_confidence === 1 && !!this.category_id;
+  }
+
+  isSuggested(): boolean {
+    const confidence = this.category_confidence;
+    return !!(this.category_id && confidence && confidence > 0 && confidence < 1);
+  }
+
   constructor(init?: Partial<TransactionLabel>) {
     assign(this, init);
   }

--- a/src/client/lib/models/TransactionLabel.test.ts
+++ b/src/client/lib/models/TransactionLabel.test.ts
@@ -1,0 +1,40 @@
+import { test, expect, describe } from "bun:test";
+import { TransactionLabel } from "./Transaction";
+
+// The four suggestion-states from JSONTransactionLabel's field docstring,
+// plus the malformed `confidence=1 AND category_id=null` row the calc
+// guards against.
+const label = (init: Partial<TransactionLabel>) => new TransactionLabel(init);
+
+describe("TransactionLabel.isConfirmed", () => {
+  test("true only when confidence is exactly 1 AND a category_id is present", () => {
+    expect(label({ category_id: "cat", category_confidence: 1 }).isConfirmed()).toBe(true);
+  });
+
+  test("false for the unreviewed suggestion, the rejection, and the never-labeled row", () => {
+    expect(label({ category_id: "cat", category_confidence: 0.5 }).isConfirmed()).toBe(false);
+    expect(label({ category_id: null, category_confidence: 0 }).isConfirmed()).toBe(false);
+    expect(label({}).isConfirmed()).toBe(false);
+  });
+
+  test("false for the malformed confidence=1 / category_id=null row (guards categories.get(null))", () => {
+    expect(label({ category_id: null, category_confidence: 1 }).isConfirmed()).toBe(false);
+  });
+});
+
+describe("TransactionLabel.isSuggested", () => {
+  test("true only for a category_id with 0 < confidence < 1", () => {
+    expect(label({ category_id: "cat", category_confidence: 0.5 }).isSuggested()).toBe(true);
+    expect(label({ category_id: "cat", category_confidence: 0.999 }).isSuggested()).toBe(true);
+  });
+
+  test("false at the 0 and 1 boundaries (rejected / confirmed, not suggested)", () => {
+    expect(label({ category_id: "cat", category_confidence: 0 }).isSuggested()).toBe(false);
+    expect(label({ category_id: "cat", category_confidence: 1 }).isSuggested()).toBe(false);
+  });
+
+  test("false without a category_id, and for the never-labeled row", () => {
+    expect(label({ category_id: null, category_confidence: 0.5 }).isSuggested()).toBe(false);
+    expect(label({}).isSuggested()).toBe(false);
+  });
+});

--- a/src/client/pages/TransactionsPage/filter.test.ts
+++ b/src/client/pages/TransactionsPage/filter.test.ts
@@ -67,20 +67,29 @@ const makeCtx = (pairs: TransferPair[] = []): FilterContext => {
 };
 
 describe("isSuggestedLabel", () => {
+  // Build rows through makeTxn so `label` is a real TransactionLabel (as it
+  // always is in production — every row constructor wraps its init label),
+  // which is what `label.isSuggested()` reads.
   test("category_id + confidence in (0,1) → suggested", () => {
-    expect(isSuggestedLabel({ label: { category_id: "c", category_confidence: 0.5 } })).toBe(true);
+    expect(isSuggestedLabel(makeTxn("t1", 0, { category_id: "c", category_confidence: 0.5 }))).toBe(
+      true,
+    );
   });
   test("confidence = 1 → confirmed, not suggested", () => {
-    expect(isSuggestedLabel({ label: { category_id: "c", category_confidence: 1 } })).toBe(false);
+    expect(isSuggestedLabel(makeTxn("t1", 0, { category_id: "c", category_confidence: 1 }))).toBe(
+      false,
+    );
   });
   test("confidence = 0 → rejected, not suggested", () => {
-    expect(isSuggestedLabel({ label: { category_id: "c", category_confidence: 0 } })).toBe(false);
+    expect(isSuggestedLabel(makeTxn("t1", 0, { category_id: "c", category_confidence: 0 }))).toBe(
+      false,
+    );
   });
   test("no category_id → not suggested", () => {
-    expect(isSuggestedLabel({ label: { category_confidence: 0.5 } })).toBe(false);
+    expect(isSuggestedLabel(makeTxn("t1", 0, { category_confidence: 0.5 }))).toBe(false);
   });
   test("null confidence → not suggested", () => {
-    expect(isSuggestedLabel({ label: { category_id: "c", category_confidence: null } })).toBe(
+    expect(isSuggestedLabel(makeTxn("t1", 0, { category_id: "c", category_confidence: null }))).toBe(
       false,
     );
   });

--- a/src/client/pages/TransactionsPage/filter.ts
+++ b/src/client/pages/TransactionsPage/filter.ts
@@ -35,11 +35,7 @@ const isUserLabelConfirmed = (e: Transaction | SplitTransaction): boolean => {
  */
 export const isSuggestedLabel = (
   e: Transaction | SplitTransaction | InvestmentTransaction,
-): boolean => {
-  const c_id = e.label.category_id;
-  const c_conf = e.label.category_confidence;
-  return !!(c_id && c_conf && c_conf > 0 && c_conf < 1);
-};
+): boolean => e.label.isSuggested();
 
 /**
  * Only whole Transactions participate in transfer pairs. A SplitTransaction


### PR DESCRIPTION
## What

Adds `isConfirmed()` / `isSuggested()` to `TransactionLabel` and routes the two sites that respelled the `category_confidence` comparison inline through them. Read-side counterpart to the `TransferDictionary.byTransactionId` predicates from PR 528.

`Closes #532` — the `TransferDictionary` half already shipped; this is the remaining `TransactionDictionary`/label half from your inline review.

## Shape note — label method, not a `TransactionDictionary.byLabel` accessor

The issue sketched `transactions.byLabel.hasConfirmed(transaction_id)` mirroring the transfer accessor. That shape has a footgun at its own named migration target: `getBudgetData` runs the confirmed-check on **synthetic split transactions** (`SplitTransaction.toTransaction()`, `budgets.ts:169`), whose ids are **not keys** in the `TransactionDictionary` — so a by-id lookup returns `undefined` and would silently treat every split's own label as unconfirmed. The label is always in hand (all three row types wrap `label: TransactionLabel`), so the predicate lives on the label and reads it directly. Happy to switch to the dictionary-accessor shape for the whole-transaction sites if you'd prefer — just flagging why the calc site can't use it.

Scoped to the two predicates with real call sites (`isConfirmed`, `isSuggested`); left `isRejected` out until something consumes it.

## Changes

- `TransactionLabel.isConfirmed()` = `category_confidence === 1 && !!category_id`; `isSuggested()` = `category_id && 0 < confidence < 1` — byte-equivalent to the two prior spellings.
- `getBudgetData`: confirmed-gate now `label.isConfirmed()`. The old inline `&& !!category_id` also gave TS an aliased-condition narrow that the opaque method can't; made the confirmed ⟹ `category_id` present invariant explicit with a guard (hardens the boundary rather than relying on flow-analysis).
- `isSuggestedLabel` (TransactionsPage filter) now delegates to `label.isSuggested()` — one canonical suggested-check instead of two.
- `TransactionLabel.test.ts`: 6 tests across all four documented label states + the malformed `confidence=1/category_id=null` row.
- `filter.test.ts`: the `isSuggestedLabel` cases now build rows through `makeTxn` (real `TransactionLabel`, as in production) instead of plain-object labels.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run build` — clean
- [x] `bun run test` — 1100 pass / 2 skip / 0 fail (+6 new label-predicate tests; budgets/rollover/filter suites unchanged assertions still green → behavior-preserving)
- [x] UI E2E — see below (behavior-invariant refactor: budget bars/counts + TransactionsPage suggested rows unchanged)
