### PR TITLE
perf(sync): (user_id, updated) composite index for delta-by-cursor reads (#641)

### DIFF
--- a/src/server/lib/postgres/database.test.ts
+++ b/src/server/lib/postgres/database.test.ts
@@ -394,6 +394,16 @@ describe("DDL builders", () => {
       "CREATE INDEX IF NOT EXISTS custom_idx ON things(name)",
     );
   });
+
+  it("buildCreateIndex builds a composite index over multiple columns", () => {
+    expect(buildCreateIndex("transactions", ["user_id", "updated"])).toBe(
+      "CREATE INDEX IF NOT EXISTS idx_transactions_user_id_updated ON transactions(user_id, updated)",
+    );
+    // A single-element array matches the scalar form exactly (no trailing comma/space).
+    expect(buildCreateIndex("things", ["name"])).toBe(
+      buildCreateIndex("things", "name"),
+    );
+  });
 });
 
 describe("result helpers", () => {

--- a/src/server/lib/postgres/database.ts
+++ b/src/server/lib/postgres/database.ts
@@ -68,9 +68,14 @@ export function buildCreateTable(
   `.trim();
 }
 
-export function buildCreateIndex(tableName: string, column: string, indexName?: string): string {
-  const name = indexName || `idx_${tableName}_${column}`;
-  return `CREATE INDEX IF NOT EXISTS ${name} ON ${tableName}(${column})`;
+export function buildCreateIndex(
+  tableName: string,
+  column: string | string[],
+  indexName?: string,
+): string {
+  const columns = Array.isArray(column) ? column : [column];
+  const name = indexName || `idx_${tableName}_${columns.join("_")}`;
+  return `CREATE INDEX IF NOT EXISTS ${name} ON ${tableName}(${columns.join(", ")})`;
 }
 
 export function prepareParamValue(value: ParamValue): ParamValue {

--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -74,7 +74,8 @@ export const initializePostgres = async (): Promise<void> => {
       await pool.query(createTableSql);
 
       for (const idx of table.indexes) {
-        const createIndexSql = buildCreateIndex(table.name, idx.column);
+        const columns = "columns" in idx ? idx.columns : idx.column;
+        const createIndexSql = buildCreateIndex(table.name, columns);
         await pool.query(createIndexSql);
       }
     }

--- a/src/server/lib/postgres/models/base.ts
+++ b/src/server/lib/postgres/models/base.ts
@@ -33,9 +33,7 @@ export type Constraints = string[];
 
 export type RowValueType = string | number | Date | boolean | null | Object;
 
-export interface IndexDefinition {
-  column: string;
-}
+export type IndexDefinition = { column: string } | { columns: string[] };
 
 export type PropertyChecker<T> = {
   [K in keyof T]: (value: unknown) => boolean;

--- a/src/server/lib/postgres/models/investment_transaction.ts
+++ b/src/server/lib/postgres/models/investment_transaction.ts
@@ -167,7 +167,14 @@ export const investmentTransactionsTable = createTable({
   name: INVESTMENT_TRANSACTIONS,
   primaryKey: INVESTMENT_TRANSACTION_ID,
   schema: invTxSchema,
-  indexes: [{ column: USER_ID }, { column: ACCOUNT_ID }, { column: DATE }],
+  indexes: [
+    { column: USER_ID },
+    { column: ACCOUNT_ID },
+    { column: DATE },
+    // Delta-by-cursor warm sync filters `WHERE user_id = ? AND updated >= ?` on
+    // every app load; the composite keeps the read O(rows-changed). See #641.
+    { columns: [USER_ID, UPDATED] },
+  ],
   ModelClass: InvTxModel,
 });
 

--- a/src/server/lib/postgres/models/snapshot.ts
+++ b/src/server/lib/postgres/models/snapshot.ts
@@ -213,6 +213,9 @@ export const snapshotsTable = createTable({
     // scan + row filter — fine for low-cardinality users but slows down
     // as snapshot history grows. See PR #470 / #445.
     { column: HOLDING_ACCOUNT_ID },
+    // `searchSnapshots` delta reads filter `WHERE user_id = ? AND updated >= ?`
+    // on every app load; the composite keeps the read O(rows-changed). See #641.
+    { columns: [USER_ID, UPDATED] },
   ],
   ModelClass: SnapshotModel,
 });

--- a/src/server/lib/postgres/models/split_transaction.ts
+++ b/src/server/lib/postgres/models/split_transaction.ts
@@ -125,7 +125,14 @@ export const splitTransactionsTable = createTable({
   name: SPLIT_TRANSACTIONS,
   primaryKey: SPLIT_TRANSACTION_ID,
   schema: splitTxSchema,
-  indexes: [{ column: USER_ID }, { column: TRANSACTION_ID }, { column: ACCOUNT_ID }],
+  indexes: [
+    { column: USER_ID },
+    { column: TRANSACTION_ID },
+    { column: ACCOUNT_ID },
+    // Delta-by-cursor warm sync filters `WHERE user_id = ? AND updated >= ?` on
+    // every app load; the composite keeps the read O(rows-changed). See #641.
+    { columns: [USER_ID, UPDATED] },
+  ],
   ModelClass: SplitTransactionModel,
 });
 

--- a/src/server/lib/postgres/models/transaction.ts
+++ b/src/server/lib/postgres/models/transaction.ts
@@ -216,7 +216,16 @@ export const transactionsTable = createTable({
   name: TRANSACTIONS,
   primaryKey: TRANSACTION_ID,
   schema: txSchema,
-  indexes: [{ column: USER_ID }, { column: ACCOUNT_ID }, { column: DATE }, { column: PENDING }],
+  indexes: [
+    { column: USER_ID },
+    { column: ACCOUNT_ID },
+    { column: DATE },
+    { column: PENDING },
+    // Delta-by-cursor warm sync filters `WHERE user_id = ? AND updated >= ?` on
+    // every app load (PR #536). Without a leading-`updated` composite the planner
+    // seq-scans the user's whole table; this keeps the read O(rows-changed). See #641.
+    { columns: [USER_ID, UPDATED] },
+  ],
   ModelClass: TransactionModel,
 });
 


### PR DESCRIPTION
## Summary

Closes #641. The delta-by-cursor warm sync (transactions, PR #536; extended to investment/split transactions + snapshots) filters four tables on `WHERE user_id = ? AND updated >= ?` — a query that fires on **every app load**. None of those tables had an index leading with `updated`, so the planner **seq-scanned each user's entire table** to return the handful of rows changed since the last cursor: `O(user's total rows)` on a hot path that should be `O(rows-changed)`. Rule 13 / Sweep 7 scalability.

## Change

The model index layer was single-column only (`IndexDefinition = { column: string }`), so there was no way to declare a composite `(user_id, updated)` in the model layer — that's why the delta-sync shape shipped without its index. This stays in the framework rather than bypassing it:

- **`IndexDefinition`** widened to `{ column: string } | { columns: string[] }` (`models/base.ts`).
- **`buildCreateIndex`** now accepts `string | string[]` and emits a multi-column `ON table(a, b)` clause; the scalar form is unchanged (`database.ts`).
- **`initialize.ts`** index loop normalizes `column`/`columns` before building.
- Added `{ columns: [USER_ID, UPDATED] }` to `transactions`, `investment_transactions`, `split_transactions`, `snapshots`. Indexes are created idempotently via the existing `CREATE INDEX IF NOT EXISTS` bootstrap — no migration step needed; existing deployments pick it up on next boot.

`getHoldingSnapshots` (ranges on `snapshot_date`, already indexed) is untouched — not part of this issue.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` (eslint whole tree) — clean
- [x] `bun run test` — 1095 pass / 0 fail (added a `buildCreateIndex` composite-index unit test: composite emits `ON transactions(user_id, updated)`; single-element array matches the scalar form byte-for-byte)
- [x] `bun run build` — clean

### EXPLAIN evidence (from #641, prod-clone, 1 user, 6265 transactions)

The representative steady-state delta query (cursor matches 3 changed rows), proven in a rolled-back transaction:

- **Before:** `Seq Scan on transactions … Rows Removed by Filter: 6262`, buffers `hit=1420`, `8.184 ms`.
- **After (composite added):** `Index Scan using idx_transactions_user_id_updated … Index Cond: (user_id = ? AND updated >= ?)`, buffers `hit=6 read=2`, `0.135 ms` (~60x), and the cost stops scaling with the user's total history.

### UI E2E

This PR adds indexes only — no behavioral surface changes, no query results change (identical rows returned, index just serves the same predicate faster). The delta-sync read paths that consume these tables (`/api/transactions?start-date=…`, split-transactions, snapshots) return the same rows before/after; the DDL builder change is covered by the new unit test. A sandbox spin renders the transactions/accounts screens that fire warm sync on mount to confirm no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
