### PR TITLE
feat(transfers): server-side delta delivery for GET /transfers (project updated + opt-in tombstones)

### DIFF
--- a/src/server/lib/postgres/repositories/transfers.ts
+++ b/src/server/lib/postgres/repositories/transfers.ts
@@ -29,10 +29,11 @@ export interface TransferPair {
    *  Optional because the FE's optimistic Mark-as-Transfer path mints a pair
    *  locally before the server's `updated` is known. */
   updated?: string | null;
-  /** True for a tombstone: a soft-deleted pair returned only when the caller
-   *  passes `includeDeleted`, so the FE can evict it from its local cache.
-   *  Tombstones carry no `transactions` (the cascade may have soft-deleted
-   *  them too); `pair_id` + `is_deleted` is all the FE needs to evict. */
+  /** True for a soft-deleted pair. Returned only when the caller passes
+   *  `includeDeleted`. A soft-deleted OR `status='rejected'` pair is an
+   *  eviction signal (empty `transactions`) the FE removes from its cache —
+   *  it evicts on `is_deleted || status === 'rejected'`, so `pair_id` +
+   *  `status` + `is_deleted` is all it needs. */
   is_deleted?: boolean;
 }
 
@@ -74,37 +75,47 @@ export const getTransferPairs = async (
     { orderBy: PAIR_ID, excludeDeleted: !options.includeDeleted },
   );
 
-  // Exclude status='rejected' from the FE response: a rejected pair is
-  // user-marked "no, these don't pair" — the engine remembers it as a
-  // denylist signal but the user shouldn't see the pair in their Transfers
-  // view. Re-confirming a previously-rejected pair goes through
+  if (allPairs.length === 0) return [];
+
+  // A pair is FE-visible only when it's active AND not user-rejected. Both
+  // `is_deleted` (soft-delete / cascade) and `status='rejected'` (user marked
+  // "no, these don't pair") hide a pair from the Transfers view — rejected is
+  // transfers' second FE-hidden axis (transactions/snapshots have only
+  // `is_deleted`). Re-confirming a rejected pair goes through
   // `pairTransactions` (Mark as Transfer), which un-rejects via ON CONFLICT.
-  // Filtered in JS because Table.query expresses only equality / IN filters,
-  // not the `STATUS <> 'rejected'` inequality.
-  const pairs = allPairs.filter((p) => p.status !== "rejected");
+  // Rejection is expressed in JS because Table.query has no `<>` inequality.
+  const isVisible = (p: (typeof allPairs)[number]) =>
+    !p.is_deleted && p.status !== "rejected";
+  const visiblePairs = allPairs.filter(isVisible);
 
-  if (pairs.length === 0) return [];
+  // Under `includeDeleted`, every non-visible pair — soft-deleted OR rejected
+  // — is delivered as an eviction signal so the delta-reducing FE removes it
+  // from its local cache (it evicts on `is_deleted || status === 'rejected'`).
+  // Eviction signals need no transaction resolution: a cascade soft-delete may
+  // have soft-deleted the referenced transactions too (the active-only txn
+  // query below wouldn't find them), and `pair_id` + `status` + `is_deleted` +
+  // `updated` is all the FE needs to evict. On the default path `allPairs`
+  // already excludes soft-deleted at the SQL layer and rejected pairs are
+  // simply omitted, so there are no eviction signals — the response is
+  // active-non-rejected only, byte-for-byte the prior contract plus the
+  // additive `updated` / `is_deleted` fields.
+  const evictions = options.includeDeleted
+    ? allPairs
+        .filter((p) => !isVisible(p))
+        .map(
+          (pair): TransferPair => ({
+            pair_id: pair.pair_id,
+            status: pair.status,
+            transactions: [],
+            updated: pair.updated,
+            is_deleted: !!pair.is_deleted,
+          }),
+        )
+    : [];
 
-  // Tombstones need no transaction resolution — a cascade soft-delete may
-  // have soft-deleted the referenced transactions too, so the active-only
-  // txn query below wouldn't find them. The FE evicts on `pair_id`, so a
-  // tombstone only carries `pair_id` + `is_deleted` + `updated`.
-  const activePairs = pairs.filter((p) => !p.is_deleted);
-  const deletedPairs = pairs.filter((p) => p.is_deleted);
+  if (visiblePairs.length === 0) return evictions;
 
-  const tombstones = deletedPairs.map(
-    (pair): TransferPair => ({
-      pair_id: pair.pair_id,
-      status: pair.status,
-      transactions: [],
-      updated: pair.updated,
-      is_deleted: true,
-    }),
-  );
-
-  if (activePairs.length === 0) return tombstones;
-
-  const txnIds = activePairs.flatMap((p) => [p.transaction_id_a, p.transaction_id_b]);
+  const txnIds = visiblePairs.flatMap((p) => [p.transaction_id_a, p.transaction_id_b]);
 
   const txnModels = await transactionsTable.query(
     { [USER_ID]: user.user_id },
@@ -117,7 +128,7 @@ export const getTransferPairs = async (
     txnById.set(tx.transaction_id, tx);
   }
 
-  const active = activePairs
+  const active = visiblePairs
     .map((pair): TransferPair | null => {
       const a = txnById.get(pair.transaction_id_a);
       const b = txnById.get(pair.transaction_id_b);
@@ -132,7 +143,7 @@ export const getTransferPairs = async (
     })
     .filter((p): p is TransferPair => p !== null);
 
-  return [...active, ...tombstones];
+  return [...active, ...evictions];
 };
 
 /**

--- a/src/server/lib/postgres/repositories/transfers.ts
+++ b/src/server/lib/postgres/repositories/transfers.ts
@@ -23,6 +23,26 @@ export interface TransferPair {
   pair_id: string;
   status: TransferPairStatus;
   transactions: JSONTransaction[];
+  /** Bumped on every mutation (confirm/reject/cascade-delete). Lets the FE
+   *  reduce over a delta by `updated` instead of replacing its cache
+   *  wholesale — same role `updated` plays on transactions/snapshots.
+   *  Optional because the FE's optimistic Mark-as-Transfer path mints a pair
+   *  locally before the server's `updated` is known. */
+  updated?: string | null;
+  /** True for a tombstone: a soft-deleted pair returned only when the caller
+   *  passes `includeDeleted`, so the FE can evict it from its local cache.
+   *  Tombstones carry no `transactions` (the cascade may have soft-deleted
+   *  them too); `pair_id` + `is_deleted` is all the FE needs to evict. */
+  is_deleted?: boolean;
+}
+
+export interface GetTransferPairsOptions {
+  /** When true, soft-deleted (`is_deleted = TRUE`) pairs are INCLUDED as
+   *  tombstones. Defaults to false for backward compatibility — the current
+   *  FE full-fetches and replaces wholesale, so it must NOT receive
+   *  tombstones as active rows. The FE-hook migration (#542 parts 4-5) flips
+   *  its fetch to opt in, mirroring the transactions/snapshots contract. */
+  includeDeleted?: boolean;
 }
 
 /**
@@ -42,11 +62,16 @@ export type ConfirmResult =
  * transactions referenced by each pair so the response shape stays the same
  * as before (one entry per pair, with the two paired transactions inline).
  */
-export const getTransferPairs = async (user: MaskedUser): Promise<TransferPair[]> => {
-  // Table.query auto-excludes soft-deleted rows (supportsSoftDelete).
+export const getTransferPairs = async (
+  user: MaskedUser,
+  options: GetTransferPairsOptions = {},
+): Promise<TransferPair[]> => {
+  // Table.query auto-excludes soft-deleted rows (supportsSoftDelete). When
+  // the caller opts into tombstone delivery, keep them by unsetting the
+  // exclusion — matches the transactions/snapshots delta-delivery contract.
   const allPairs = await transactionPairsTable.query(
     { [USER_ID]: user.user_id },
-    { orderBy: PAIR_ID },
+    { orderBy: PAIR_ID, excludeDeleted: !options.includeDeleted },
   );
 
   // Exclude status='rejected' from the FE response: a rejected pair is
@@ -60,7 +85,26 @@ export const getTransferPairs = async (user: MaskedUser): Promise<TransferPair[]
 
   if (pairs.length === 0) return [];
 
-  const txnIds = pairs.flatMap((p) => [p.transaction_id_a, p.transaction_id_b]);
+  // Tombstones need no transaction resolution — a cascade soft-delete may
+  // have soft-deleted the referenced transactions too, so the active-only
+  // txn query below wouldn't find them. The FE evicts on `pair_id`, so a
+  // tombstone only carries `pair_id` + `is_deleted` + `updated`.
+  const activePairs = pairs.filter((p) => !p.is_deleted);
+  const deletedPairs = pairs.filter((p) => p.is_deleted);
+
+  const tombstones = deletedPairs.map(
+    (pair): TransferPair => ({
+      pair_id: pair.pair_id,
+      status: pair.status,
+      transactions: [],
+      updated: pair.updated,
+      is_deleted: true,
+    }),
+  );
+
+  if (activePairs.length === 0) return tombstones;
+
+  const txnIds = activePairs.flatMap((p) => [p.transaction_id_a, p.transaction_id_b]);
 
   const txnModels = await transactionsTable.query(
     { [USER_ID]: user.user_id },
@@ -73,7 +117,7 @@ export const getTransferPairs = async (user: MaskedUser): Promise<TransferPair[]
     txnById.set(tx.transaction_id, tx);
   }
 
-  return pairs
+  const active = activePairs
     .map((pair): TransferPair | null => {
       const a = txnById.get(pair.transaction_id_a);
       const b = txnById.get(pair.transaction_id_b);
@@ -82,9 +126,13 @@ export const getTransferPairs = async (user: MaskedUser): Promise<TransferPair[]
         pair_id: pair.pair_id,
         status: pair.status,
         transactions: [a, b],
+        updated: pair.updated,
+        is_deleted: false,
       };
     })
     .filter((p): p is TransferPair => p !== null);
+
+  return [...active, ...tombstones];
 };
 
 /**

--- a/src/server/routes/transfers/get-transfers.test.ts
+++ b/src/server/routes/transfers/get-transfers.test.ts
@@ -229,4 +229,55 @@ describe("get-transfers", () => {
     const [pairsSql] = mockQuery.mock.calls[0];
     expect(pairsSql).not.toMatch(/is_deleted IS NULL OR is_deleted = FALSE/);
   });
+
+  test("include-deleted=true delivers rejected (non-deleted) pairs as eviction signals — transfers' second FE-hidden axis", async () => {
+    // A rejected pair is not soft-deleted, but it is FE-hidden. Under the
+    // delta contract it must be delivered as an eviction signal so the
+    // reducing FE removes a pair that flipped suggested/confirmed → rejected.
+    const rejectedPairRow = {
+      pair_id: "p-rej",
+      user_id: "u-1",
+      transaction_id_a: "t-a",
+      transaction_id_b: "t-b",
+      status: "rejected",
+      created_at: "2026-05-01T00:00:00Z",
+      updated: "2026-05-04T08:00:00Z",
+      is_deleted: false,
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [rejectedPairRow], rowCount: 1 });
+
+    const result = await getTransfersRoute.execute(
+      makeReq({ query: { "include-deleted": "true" } }),
+      fakeRes(),
+    );
+
+    expect(result?.status).toBe("success");
+    // Eviction signal carries status='rejected' + is_deleted:false, no txns.
+    expect(result?.body).toEqual([
+      { pair_id: "p-rej", status: "rejected", transactions: [], updated: "2026-05-04T08:00:00Z", is_deleted: false },
+    ]);
+    // No transaction resolution for eviction signals.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  test("default (no include-deleted) omits rejected pairs entirely — not delivered as eviction signals", async () => {
+    const rejectedPairRow = {
+      pair_id: "p-rej",
+      user_id: "u-1",
+      transaction_id_a: "t-a",
+      transaction_id_b: "t-b",
+      status: "rejected",
+      created_at: "2026-05-01T00:00:00Z",
+      updated: "2026-05-04T08:00:00Z",
+      is_deleted: false,
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [rejectedPairRow], rowCount: 1 });
+
+    const result = await getTransfersRoute.execute(makeReq(), fakeRes());
+    // On the wholesale-replace default path, a rejected pair is simply absent
+    // (absence = eviction); it must NOT surface as an eviction-signal row.
+    expect(result?.body).toEqual([]);
+    // No second (txn) query — nothing visible to resolve.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/server/routes/transfers/get-transfers.test.ts
+++ b/src/server/routes/transfers/get-transfers.test.ts
@@ -26,14 +26,19 @@ beforeEach(() => {
   mockQuery.mockReset();
 });
 
-function makeReq(opts: { user?: { user_id: string; username: string } | null } = {}) {
+function makeReq(
+  opts: {
+    user?: { user_id: string; username: string } | null;
+    query?: Record<string, unknown>;
+  } = {},
+) {
   const user = opts.user === undefined ? { user_id: "u-1", username: "test" } : opts.user;
   return {
     method: "GET",
     path: "/transfers",
     url: "http://x/api/transfers",
     headers: {},
-    query: {},
+    query: opts.query ?? {},
     body: undefined,
     session: {
       id: "s-1",
@@ -143,5 +148,85 @@ describe("get-transfers", () => {
     expect(result?.body).toEqual([]);
     const [, values] = mockQuery.mock.calls[0];
     expect(values).toEqual(["u-B"]);
+  });
+
+  test("projects `updated` and `is_deleted: false` on active pairs (delta-delivery contract)", async () => {
+    const pairRow = {
+      pair_id: "p-1",
+      user_id: "u-1",
+      transaction_id_a: "t-a",
+      transaction_id_b: "t-b",
+      status: "confirmed",
+      created_at: "2026-05-01T00:00:00Z",
+      updated: "2026-05-02T09:00:00Z",
+      is_deleted: false,
+    };
+    const txnRow = (id: string) => ({
+      transaction_id: id,
+      user_id: "u-1",
+      account_id: "acc-1",
+      name: "Transfer",
+      merchant_name: null,
+      amount: 0,
+      iso_currency_code: "USD",
+      date: "2026-05-01",
+      pending: false,
+      pending_transaction_id: null,
+      payment_channel: "other",
+      location_country: null,
+      location_region: null,
+      location_city: null,
+      label_budget_id: null,
+      label_category_id: null,
+      label_memo: null,
+      label_category_confidence: null,
+      raw: null,
+      updated: "2026-05-01T00:00:00Z",
+      is_deleted: false,
+      source: "plaid",
+    });
+    mockQuery.mockResolvedValueOnce({ rows: [pairRow], rowCount: 1 });
+    mockQuery.mockResolvedValueOnce({ rows: [txnRow("t-a"), txnRow("t-b")], rowCount: 2 });
+
+    const result = await getTransfersRoute.execute(makeReq(), fakeRes());
+    expect(result?.body?.[0].updated).toBe("2026-05-02T09:00:00Z");
+    expect(result?.body?.[0].is_deleted).toBe(false);
+  });
+
+  test("default (no include-deleted) excludes soft-deleted pairs at the SQL layer", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await getTransfersRoute.execute(makeReq(), fakeRes());
+    const [pairsSql] = mockQuery.mock.calls[0];
+    expect(pairsSql).toMatch(/is_deleted IS NULL OR is_deleted = FALSE/);
+  });
+
+  test("include-deleted=true delivers soft-deleted pairs as tombstones — no txn query, includes deleted at SQL layer", async () => {
+    const deletedPairRow = {
+      pair_id: "p-dead",
+      user_id: "u-1",
+      transaction_id_a: "t-a",
+      transaction_id_b: "t-b",
+      status: "confirmed",
+      created_at: "2026-05-01T00:00:00Z",
+      updated: "2026-05-03T12:00:00Z",
+      is_deleted: true,
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [deletedPairRow], rowCount: 1 });
+
+    const result = await getTransfersRoute.execute(
+      makeReq({ query: { "include-deleted": "true" } }),
+      fakeRes(),
+    );
+
+    expect(result?.status).toBe("success");
+    // Tombstone shape: pair_id + is_deleted + updated, no transactions.
+    expect(result?.body).toEqual([
+      { pair_id: "p-dead", status: "confirmed", transactions: [], updated: "2026-05-03T12:00:00Z", is_deleted: true },
+    ]);
+    // A tombstone needs no transaction resolution — only the pairs SELECT runs.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    // Soft-delete exclusion is dropped so tombstones surface.
+    const [pairsSql] = mockQuery.mock.calls[0];
+    expect(pairsSql).not.toMatch(/is_deleted IS NULL OR is_deleted = FALSE/);
   });
 });

--- a/src/server/routes/transfers/get-transfers.ts
+++ b/src/server/routes/transfers/get-transfers.ts
@@ -8,11 +8,12 @@ export const getTransfersRoute = new Route<TransfersGetResponse>("GET", "/transf
     return { status: "failed", message: "Request user is not authenticated." };
   }
 
-  // Opt-in tombstone delivery. Unlike /transactions and /snapshots — which
-  // hardcode `includeDeleted: true` because their FE reducers were migrated
-  // in the same PR — the transfers FE still full-fetches and replaces its
-  // cache wholesale, so it must NOT receive tombstones as active rows.
-  // Delivery stays behind this param until the FE hook migrates (#542).
+  // Opt-in eviction-signal delivery (soft-deleted + rejected pairs). Unlike
+  // /transactions and /snapshots — which hardcode `includeDeleted: true`
+  // because their FE reducers were migrated in the same PR — the transfers FE
+  // still full-fetches and replaces its cache wholesale, so it must NOT
+  // receive tombstones/rejected pairs as active rows. Delivery stays behind
+  // this param until the FE hook migrates (#542 parts 4-5).
   const includeDeletedResult = optionalQueryString(req, "include-deleted");
   if (!includeDeletedResult.success) return validationError(includeDeletedResult.error!);
 

--- a/src/server/routes/transfers/get-transfers.ts
+++ b/src/server/routes/transfers/get-transfers.ts
@@ -1,4 +1,4 @@
-import { Route, getTransferPairs, TransferPair } from "server";
+import { Route, getTransferPairs, TransferPair, optionalQueryString, validationError } from "server";
 
 export type TransfersGetResponse = TransferPair[];
 
@@ -8,6 +8,16 @@ export const getTransfersRoute = new Route<TransfersGetResponse>("GET", "/transf
     return { status: "failed", message: "Request user is not authenticated." };
   }
 
-  const pairs = await getTransferPairs(user);
+  // Opt-in tombstone delivery. Unlike /transactions and /snapshots — which
+  // hardcode `includeDeleted: true` because their FE reducers were migrated
+  // in the same PR — the transfers FE still full-fetches and replaces its
+  // cache wholesale, so it must NOT receive tombstones as active rows.
+  // Delivery stays behind this param until the FE hook migrates (#542).
+  const includeDeletedResult = optionalQueryString(req, "include-deleted");
+  if (!includeDeletedResult.success) return validationError(includeDeletedResult.error!);
+
+  const pairs = await getTransferPairs(user, {
+    includeDeleted: includeDeletedResult.data === "true",
+  });
   return { status: "success", body: pairs };
 });


### PR DESCRIPTION
## What

Server-side **delta delivery** for `GET /transfers`, mirroring the contract that `/transactions` and `/snapshots` already use — so a future FE hook can reduce over a delta instead of replacing its transfers cache wholesale. This is parts 1 + 3 of #542 (the additive server groundwork); the FE hook migration (parts 4–5) is a deliberate follow-up.

## Changes

- **Project `updated`** on each `TransferPair` in the response. It's already on `transaction_pairs` (bumped on every confirm/reject/cascade-delete) — it just wasn't surfaced. The FE needs it to know when a pair changed.
- **`?include-deleted=true`** query param on `GET /transfers`. When set, soft-deleted pairs are returned as **tombstones** — `{ pair_id, is_deleted: true, updated, transactions: [] }` — so the FE can evict them from its local cache. Tombstones skip transaction resolution because a cascade soft-delete may have soft-deleted the referenced transactions too (the active-only txn query wouldn't find them); `pair_id` is all the FE needs to evict.

## Why opt-in (not unconditional like `/transactions` and `/snapshots`)

Those two routes hardcode `includeDeleted: true` because their FE reducers were migrated to handle tombstones in the same PR. The transfers FE still full-fetches and replaces its cache wholesale — delivering tombstones as active rows would show deleted pairs as live. So delivery stays behind the param until the FE hook migrates (#542 parts 4–5), which flips the fetch to opt in. The new response fields are **optional** so the FE's optimistic Mark-as-Transfer path (which mints a pair locally before the server `updated` is known) still typechecks — this PR touches no FE code.

## Scope

Server only. Backward-compatible: the current FE sends no params, so it gets active-only pairs exactly as before, now with an extra (ignored) `updated`/`is_deleted` field. `getTransferPairs`'s only non-test caller is this route.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` (whole tree) — clean
- [x] `bun test src/server` — 701 pass / 0 fail (7 in `get-transfers.test.ts`, +4 new)
- [x] `bun run build-client` — clean
- [x] **Unit coverage** (`get-transfers.test.ts`):
  - active pair projects `updated` + `is_deleted: false`
  - default (no param) emits the `(is_deleted IS NULL OR is_deleted = FALSE)` exclusion at the SQL layer
  - `include-deleted=true` → soft-deleted pair returns as a tombstone (`transactions: []`), fires **only** the pairs SELECT (no txn query), and drops the soft-delete exclusion
- [x] **API E2E** — sandbox, logged in as admin, deterministic clone fixture (admin has 177 confirmed + N suggested active pairs = 183 visible; 8 soft-deleted = 1 confirmed + 7 suggested; 4 rejected-active):
  - `GET /api/transfers` (default) → **183** pairs, **0 evictions**, **0 rejected**, **0 missing `updated`**. Every pair carries `updated` (string) + `is_deleted: false` + 2 resolved transactions.
  - `GET /api/transfers?include-deleted=true` → **195** pairs = 183 visible + **12 eviction signals**. The 12 split into **8 tombstones** (`is_deleted: true`) + **4 rejected** (`is_deleted: false`, `status: "rejected"`) — transfers' second FE-hidden axis. Every eviction has `transactions: []`, a `pair_id`, `updated` present, and satisfies `is_deleted || status === "rejected"`.
  - **Guards:** the 183 visible in the include-deleted response are byte-identical to the default set (`visibleMatchesDefault: true`); **0 eviction pair_ids leak into the default response** (backward-compat guard for the un-migrated wholesale-replace FE).
- [x] **UI backward-compat** — `/transactions` rendered at 390×844 (screenshot eye-checked, `/tmp/pr-646-transactions.png`): transaction rows + budget/category selectors + suggestion UI render; the transfers-consuming FE (`fetchTransfers` → `data.transfers`) still full-fetches and populates without change. **0 console errors** — the added `updated`/`is_deleted` fields and opt-in eviction delivery don't disturb the current FE.
