### PR TITLE
fix(sync): skip source='manual' investment_transactions in Plaid removal detector

### DIFF
--- a/src/server/lib/compute-tools/sync-plaid.test.ts
+++ b/src/server/lib/compute-tools/sync-plaid.test.ts
@@ -201,6 +201,17 @@ describe("getPlaidRemovedInvestmentTransactions", () => {
     expect(result[0].investment_transaction_id).toBe("inv-2");
   });
 
+  it("does not flag manually-entered (source='manual') transactions as removed", () => {
+    // Manual invest txns can live on a Plaid brokerage (RSU/ESPP) and never appear
+    // in Plaid's incoming list — they must not be soft-deleted by sync. See #647.
+    const incoming: JSONInvestmentTransaction[] = [];
+    const stored = [
+      makeInvTx({ investment_transaction_id: "manual-1", source: "manual" }),
+    ];
+    const result = getPlaidRemovedInvestmentTransactions(incoming, stored);
+    expect(result).toHaveLength(0);
+  });
+
   it("does not flag old transactions (> TWO_WEEKS) as removed", () => {
     const oldDate = new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString().split("T")[0];
     const incoming: JSONInvestmentTransaction[] = [];

--- a/src/server/lib/compute-tools/sync-plaid.ts
+++ b/src/server/lib/compute-tools/sync-plaid.ts
@@ -101,6 +101,7 @@ export const getPlaidRemovedInvestmentTransactions = (
   const incomingIds = new Set(incomingTransactions.map((f) => f.investment_transaction_id));
   const removed: RemovedInvestmentTransaction[] = [];
   storedTransactions.forEach((e) => {
+    if (e.source === "manual") return; // Plaid sync must not remove user-entered rows
     const age = new Date().getTime() - new LocalDate(e.date).getTime();
     if (age > TWO_WEEKS) return;
     if (!incomingIds.has(e.investment_transaction_id)) {
@@ -232,6 +233,7 @@ export const syncPlaidTransactions = async (item_id: string) => {
 
       // Adjust counters for recent stored transactions that are still present (modified).
       storedInvestmentTransactions.forEach((e) => {
+        if (e.source === "manual") return; // manual rows aren't Plaid-managed
         const age = new Date().getTime() - new LocalDate(e.date).getTime();
         if (age > TWO_WEEKS) return;
         if (!removedIdSet.has(e.investment_transaction_id)) {


### PR DESCRIPTION
## Problem

`getPlaidRemovedInvestmentTransactions` (`src/server/lib/compute-tools/sync-plaid.ts`) flags a stored investment transaction as removed when it is absent from Plaid's incoming list and dated within `TWO_WEEKS`. It did **not** skip rows with `source === "manual"`.

Manual investment transactions can legitimately live on a **Plaid brokerage** account — the "Add Investment Transaction" UI (`AccountProperties/index.tsx:263`) is intentionally not gated to manual accounts so users can record RSU/ESPP / pre-Plaid-window buys on a connected brokerage (feature from PR #588 / issue #585). These rows carry `source="manual"` and never appear in Plaid's `/investments/transactions/get` response, so on the next sync any such txn dated within 14 days was treated as removed and soft-deleted — silent user-data loss.

## Fix

Skip `source === "manual"` rows in:
- the removal detector `getPlaidRemovedInvestmentTransactions` (fixes the data loss), and
- the recent-modified-counter loop (fixes a cosmetic mis-count of manual rows as Plaid-modified).

Plaid sync must not manage manually-entered rows. Net +2 source lines.

The parallel cash path carries no equivalent risk — manual cash transactions are MANUAL-provider-only (`get-new-transaction.ts:35` guard) and manual accounts are never Plaid-synced, so no cash removal-detector leak exists.

Closes #647.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx eslint` on both touched files — clean
- [x] `bun test` — 1095 pass / 0 fail (was 1094; +1 new)
- [x] **New unit test** `getPlaidRemovedInvestmentTransactions` › "does not flag manually-entered (source='manual') transactions as removed": a stored `source="manual"` txn dated today, absent from the incoming list, is NOT flagged removed. Fails without the guard (would be flagged, dated within `TWO_WEEKS`), passes with it.
- [x] `bun run build` — ✓ built
- [x] **Sandbox sanity** (`claoie.tplinkdns.com:20648`, branch `fix/manual-invest-txn-sync-removal`, logged in as admin): Accounts page renders correctly (donut headline, 14 account rows with balances + "from last month" deltas, 5-Credits outstanding line), Dashboard/Budgets/Accounts/Transactions nav intact, no runtime console errors (only benign sandbox service-worker registration noise). Screenshots `/tmp/pr-648-accounts.png` eye-checked.
- **E2E note:** the fixed path is a Plaid-sync server routine not reachable from the UI in the sandbox (no live Plaid re-sync that omits a stored row), so the guard behavior is proven by the new unit test rather than a Playwright click-chain. The user-facing surface being protected — the "Add Investment Transaction" flow on `AccountProperties` — is unchanged by this diff (server-only, `sync-plaid.ts` + its test).
