### PR TITLE
fix(accounts): stop double-counting cash in investment Invested/In Cash breakdown

### DIFF
--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -87,10 +87,11 @@ export const AccountProperties = ({ account }: Props) => {
 
   let currentLabel = "Current";
   let pendingLabel = "Pending";
-  const currentAmountString = numberToCommaString(current as number);
+  let currentAmountString = numberToCommaString(current as number);
   let pendingAmountString = numberToCommaString(
     current && available ? current - available : ((current || available) as number),
   );
+  let showPendingRow = true;
   if (type === AccountType.Credit) {
     currentLabel = "Spent";
     pendingLabel = "Available";
@@ -98,7 +99,15 @@ export const AccountProperties = ({ account }: Props) => {
   } else if (type === AccountType.Investment) {
     currentLabel = "Invested";
     pendingLabel = "In Cash";
+    // `available` is already included in `current`, so "Invested" (the non-cash
+    // portion) is current − available; rendering full `current` here while also
+    // listing `available` as "In Cash" would present the cash twice.
+    currentAmountString = numberToCommaString(
+      current && available ? current - available : (current as number),
+    );
     pendingAmountString = numberToCommaString(available as number);
+    // No cash figure to partition off when Plaid reports no `available`.
+    showPendingRow = available != null;
   }
 
   const onClickTransactions = () => {
@@ -166,12 +175,14 @@ export const AccountProperties = ({ account }: Props) => {
               {currentAmountString}
             </span>
           </KeyValue>
-          <KeyValue name={pendingLabel}>
-            <span>
-              {currencySymbol}&nbsp;
-              {pendingAmountString}
-            </span>
-          </KeyValue>
+          {showPendingRow && (
+            <KeyValue name={pendingLabel}>
+              <span>
+                {currencySymbol}&nbsp;
+                {pendingAmountString}
+              </span>
+            </KeyValue>
+          )}
         </Property>
       )}
       {!!graphData.lines && (


### PR DESCRIPTION
## What

The account-detail **Balance** breakdown for a Plaid-connected **investment** account double-counts the cash component.

- **Invested** rendered `balances.current`
- **In Cash** rendered `balances.available`

For investment accounts Plaid's `available` (cash / buying power) is **already included in** `current` — the same semantic `getAccountBalance` relies on (`src/client/lib/hooks/calculation/accounts.ts`, the fix from #149/#284). So the two rows overlapped: "Invested" silently contained the whole "In Cash" amount, and the rows summed to more than the account's headline balance. A 100%-cash investment account (e.g. a crypto-exchange balance) showed its **entire balance under both rows**.

Closes #649.

## Fix

In the investment branch of `AccountProperties`, "Invested" now renders the **non-cash portion** `current − available`, so `Invested + In Cash = current` — a true partition (matching how the depository branch already computes its second row). When Plaid reports no `available`, the "In Cash" row is now **hidden** instead of showing `NaN`.

Credit (`Spent` = `current` owed / `Available` = remaining line) and depository rows are untouched — those are genuinely disjoint quantities, not a subset relationship.

## Scope

One file, investment branch only:
- `currentAmountString` → `current − available` for investment (was full `current`).
- `showPendingRow` gate hides the "In Cash" row when `available` is null.

The *account total* elsewhere (Accounts list, Dashboard net worth) was already correct via `getAccountBalance`; only this detail-page breakdown was wrong.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run build` — clean
- [x] **UI E2E** — sandbox, 390×844 mobile viewport, admin login, Playwright, screenshots eye-checked. Drove **Accounts → click account row → detail** (real row-click affordance, no deep-link) for all Plaid investment accounts. Currency rendered qualitatively (scrambled prod-clone):
  - **Chase Brokerage (partial cash, `available` between 0 and `current`)** — Invested `$[redacted]`, In Cash `$[redacted]`; the two rows now **sum exactly to the account's headline "Jul 2026 balance"** (a true partition). Pre-fix, Invested showed the full balance so the two rows exceeded the total by the cash amount.
  - **Binance US Crypto Exchange (all-cash, `available == current`)** — Invested now `$0.00`, In Cash `$[redacted]` = the headline balance. Pre-fix this account rendered the **entire balance under BOTH rows** (the reported repro). Screenshot eye-checked: `/tmp/pr-650-invest-10.png`.
  - **E*TRADE Brokerage (all-cash)** — Invested `$0.00`, In Cash `$[redacted]` = headline balance.
  - **E*TRADE Stock Plan (no cash, `available` absent/0)** — In Cash `$0.00`, Invested = full balance = headline. Confirms the `available == null/0` fallback keeps Invested = current.
  - No console errors across all screens. Depository/credit account rows unchanged.
