### PR TITLE
refactor(client): extract <ChartTypeSelect> — shared chart-type dropdown (#326 phase 5i)

### DIFF
--- a/src/client/components/BalanceChartProperties.tsx
+++ b/src/client/components/BalanceChartProperties.tsx
@@ -1,5 +1,4 @@
 import { ChangeEventHandler, MouseEventHandler, ReactNode, useState } from "react";
-import { ChartType } from "common";
 import {
   BalanceChart,
   Chart,
@@ -7,13 +6,13 @@ import {
   useAppContext,
   useDebounce,
   useMutate,
-  getChartTypeName,
   DeleteButton,
   Properties,
   PropertyLabel,
   Property,
   Row,
   KeyValue,
+  ChartTypeSelect,
 } from "client";
 
 interface BalanceChartPropertiesProps {
@@ -23,14 +22,13 @@ interface BalanceChartPropertiesProps {
 
 export const BalanceChartProperties = ({ chart, children }: BalanceChartPropertiesProps) => {
   const { router } = useAppContext();
-  const { name, chart_id, type, configuration } = chart;
+  const { name, chart_id, configuration } = chart;
   const { account_ids, budget_ids } = configuration;
 
   const { data } = useAppContext();
   const { accounts, budgets } = data;
 
   const [nameInput, setNameInput] = useState(name);
-  const [selectedType, setSelectedType] = useState<ChartType>(type);
 
   const updateDebouncer = useDebounce();
   const mutate = useMutate(Chart);
@@ -43,12 +41,6 @@ export const BalanceChartProperties = ({ chart, children }: BalanceChartProperti
     const newName = e.target.value;
     setNameInput(newName);
     updateDebouncer(() => updateChart({ name: newName }).catch(() => setNameInput(name)), 300);
-  };
-
-  const onChangeType: ChangeEventHandler<HTMLSelectElement> = (e) => {
-    const newType = e.target.value as ChartType;
-    setSelectedType(newType);
-    updateChart({ type: newType });
   };
 
   const onClickAccounts: MouseEventHandler<HTMLButtonElement> = () => {
@@ -75,18 +67,7 @@ export const BalanceChartProperties = ({ chart, children }: BalanceChartProperti
         <KeyValue name="Chart&nbsp;Name">
           <input value={nameInput} onChange={onChangeName} aria-label="Chart name" />
         </KeyValue>
-        <KeyValue name="Chart&nbsp;Type">
-          <select value={selectedType} onChange={onChangeType}>
-            {Object.values(ChartType).map((v) => {
-              const chartTypeName = getChartTypeName(v);
-              return (
-                <option key={`chart_type_option_${v}`} value={v}>
-                  {chartTypeName}
-                </option>
-              );
-            })}
-          </select>
-        </KeyValue>
+        <ChartTypeSelect chart={chart} />
       </Property>
 
       <PropertyLabel>Selected&nbsp;Accounts&nbsp;&&nbsp;Budgets</PropertyLabel>

--- a/src/client/components/ChartTypeSelect.tsx
+++ b/src/client/components/ChartTypeSelect.tsx
@@ -1,0 +1,38 @@
+import { ChangeEventHandler, useState } from "react";
+import { ChartType } from "common";
+import {
+  Chart,
+  BalanceChart,
+  ProjectionChart,
+  FlowChart,
+  useMutate,
+  getChartTypeName,
+  KeyValue,
+} from "client";
+
+interface Props {
+  chart: BalanceChart | ProjectionChart | FlowChart;
+}
+
+export const ChartTypeSelect = ({ chart }: Props) => {
+  const [selectedType, setSelectedType] = useState<ChartType>(chart.type);
+  const mutate = useMutate(Chart);
+
+  const onChange: ChangeEventHandler<HTMLSelectElement> = (e) => {
+    const newType = e.target.value as ChartType;
+    setSelectedType(newType);
+    mutate.update(new Chart({ ...chart, type: newType }));
+  };
+
+  return (
+    <KeyValue name="Chart&nbsp;Type">
+      <select value={selectedType} onChange={onChange}>
+        {Object.values(ChartType).map((v) => (
+          <option key={`chart_type_option_${v}`} value={v}>
+            {getChartTypeName(v)}
+          </option>
+        ))}
+      </select>
+    </KeyValue>
+  );
+};

--- a/src/client/components/FlowChartProperties.tsx
+++ b/src/client/components/FlowChartProperties.tsx
@@ -1,5 +1,4 @@
 import { ChangeEventHandler, MouseEventHandler, ReactNode, useState } from "react";
-import { ChartType } from "common";
 import {
   FlowChart,
   Chart,
@@ -7,13 +6,13 @@ import {
   useAppContext,
   useDebounce,
   useMutate,
-  getChartTypeName,
   DeleteButton,
   Properties,
   PropertyLabel,
   Property,
   Row,
   KeyValue,
+  ChartTypeSelect,
 } from "client";
 
 interface FlowChartPropertiesProps {
@@ -23,14 +22,13 @@ interface FlowChartPropertiesProps {
 
 export const FlowChartProperties = ({ chart, children }: FlowChartPropertiesProps) => {
   const { router } = useAppContext();
-  const { name, chart_id, type, configuration } = chart;
+  const { name, chart_id, configuration } = chart;
   const { account_ids } = configuration;
 
   const { data } = useAppContext();
   const { accounts } = data;
 
   const [nameInput, setNameInput] = useState(name);
-  const [selectedType, setSelectedType] = useState<ChartType>(type);
 
   const updateDebouncer = useDebounce();
   const mutate = useMutate(Chart);
@@ -43,12 +41,6 @@ export const FlowChartProperties = ({ chart, children }: FlowChartPropertiesProp
     const newName = e.target.value;
     setNameInput(newName);
     updateDebouncer(() => updateChart({ name: newName }).catch(() => setNameInput(name)), 300);
-  };
-
-  const onChangeType: ChangeEventHandler<HTMLSelectElement> = (e) => {
-    const newType = e.target.value as ChartType;
-    setSelectedType(newType);
-    updateChart({ type: newType });
   };
 
   const onClickAccounts: MouseEventHandler<HTMLButtonElement> = () => {
@@ -71,18 +63,7 @@ export const FlowChartProperties = ({ chart, children }: FlowChartPropertiesProp
         <KeyValue name="Chart&nbsp;Name">
           <input value={nameInput} onChange={onChangeName} />
         </KeyValue>
-        <KeyValue name="Chart&nbsp;Type">
-          <select value={selectedType} onChange={onChangeType}>
-            {Object.values(ChartType).map((v) => {
-              const chartTypeName = getChartTypeName(v);
-              return (
-                <option key={`chart_type_option_${v}`} value={v}>
-                  {chartTypeName}
-                </option>
-              );
-            })}
-          </select>
-        </KeyValue>
+        <ChartTypeSelect chart={chart} />
       </Property>
 
       <PropertyLabel>Selected&nbsp;Accounts</PropertyLabel>

--- a/src/client/components/ProjectionChartProperties.tsx
+++ b/src/client/components/ProjectionChartProperties.tsx
@@ -1,4 +1,4 @@
-import { ChartType, getDateString, LocalDate, ViewDate } from "common";
+import { getDateString, LocalDate, ViewDate } from "common";
 import {
   Chart,
   ProjectionChart,
@@ -7,13 +7,13 @@ import {
   useAppContext,
   useDebounce,
   useMutate,
-  getChartTypeName,
   DeleteButton,
   Properties,
   PropertyLabel,
   Property,
   Row,
   KeyValue,
+  ChartTypeSelect,
   ToggleInput,
   ProjectionChartConfiguration,
   CapacityNumberInput,
@@ -35,12 +35,11 @@ interface ProjectionChartPropertiesProps {
 
 export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPropertiesProps) => {
   const { router } = useAppContext();
-  const { chart_id, name, type, configuration } = chart;
+  const { chart_id, name, configuration } = chart;
 
   const { data, calculations } = useAppContext();
   const { accounts } = data;
 
-  const [selectedType, setSelectedType] = useState<ChartType>(type);
   const [nameInput, setNameInput] = useState(name);
   const [configInput, setConfigInput] = useState(new ProjectionChartConfiguration(configuration));
 
@@ -72,12 +71,6 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
     const newName = e.target.value;
     setNameInput(newName);
     updateDebouncer(() => updateChart({ name: newName }).catch(() => setNameInput(name)), 300);
-  };
-
-  const onChangeType: ChangeEventHandler<HTMLSelectElement> = (e) => {
-    const newType = e.target.value as ChartType;
-    setSelectedType(newType);
-    updateChart({ type: newType });
   };
 
   const onClickAccounts: MouseEventHandler<HTMLButtonElement> = (_e) => {
@@ -156,18 +149,7 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
         <KeyValue name="Chart&nbsp;Name">
           <input value={nameInput} onChange={onChangeName} aria-label="Chart name" />
         </KeyValue>
-        <KeyValue name="Chart&nbsp;Type">
-          <select value={selectedType} onChange={onChangeType}>
-            {Object.values(ChartType).map((v) => {
-              const chartTypeName = getChartTypeName(v);
-              return (
-                <option key={`chart_type_option_${v}`} value={v}>
-                  {chartTypeName}
-                </option>
-              );
-            })}
-          </select>
-        </KeyValue>
+        <ChartTypeSelect chart={chart} />
       </Property>
 
       <PropertyLabel>Selected&nbsp;Accounts</PropertyLabel>

--- a/src/client/components/index.ts
+++ b/src/client/components/index.ts
@@ -36,6 +36,7 @@ export * from "./ConnectionProperties";
 export * from "./ApiKeyProperties";
 export * from "./NameInput";
 export * from "./CapacityInput";
+export * from "./ChartTypeSelect";
 export * from "./ToggleInput";
 export * from "./Spinner";
 export * from "./TransactionsPageTitle";


### PR DESCRIPTION
## What

Extracts `<ChartTypeSelect>` — the shared chart-type dropdown — as the next design-component coverage step for #326.

FlowChartProperties, BalanceChartProperties and ProjectionChartProperties each carried a **byte-identical** chart-type machine:

- a `const [selectedType, setSelectedType] = useState<ChartType>(type)`,
- a `const onChangeType` handler that set state + called `updateChart({ type })`, and
- a `<KeyValue name="Chart Type">` wrapping a `<select>` that mapped `Object.values(ChartType)` through `getChartTypeName`.

That machine is now one component — `<ChartTypeSelect chart={chart} />` — that owns the state, the change handler, and the markup. Each panel drops ~12 duplicated lines for a single element.

Pure refactor: same rendered DOM (`<KeyValue name="Chart Type"><select>…</select></KeyValue>`), same immediate (non-debounced) `mutate.update(new Chart(...))` behavior. No CSS added — the existing global `select` style + `.Properties .row select` context rules still apply unchanged.

Part of #326 (does not close it — the RadioInputs primitive decision is still pending).

## Test plan — disposition

**reviewoie:** approve — 0 HIGH, 0 MED, 1 LOW (informational). LOW proposed dropping the local `selectedType` state for `value={chart.type}`; left as-is because `useMutate.update` awaits the POST before `setData` (non-optimistic), so the local state is what gives the dropdown its immediate feedback — binding to `chart.type` would snap the dropdown back until the server responds. Replied on the PR.

**E2E** (Playwright, sandbox scrambled clone, ~390×844 mobile): login → Dashboard navigator → **Add Chart** (real affordance) → ChartDetailPage.
- Dropdown renders all 3 chart types, defaults to Balance, KeyValue label reads "Chart Type". ✅
- Select **Projection** → panel swaps to ProjectionChartProperties (Saving Configuration fields appear) and the dropdown shows Projection. ✅
- **Reload** → type persists as Projection. ✅
- Eye-checked balance + projection panel screenshots: KeyValue row layout byte-identical to the "Chart Name" row, dropdown aligned, no layout breakage. Only console noise = `sw.js` ServiceWorker registration over http-localhost (sandbox artifact; this PR doesn't touch the SW).

**CI:** build ✅ · test ✅.

- `tsc --noEmit` — clean
- `eslint src` — clean
