### PR TITLE
feat(performance): add TWR row to the Performance widget

### DIFF
--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -16,6 +16,7 @@ import type { ResolveSecuritySnapshotResponse } from "server/routes/accounts/pos
 import {
   extractCashFlows,
   computeMWR,
+  computeTWR,
   computeBenchmarkTWR,
   computeBenchmarkEndValue,
   valueAt,
@@ -117,18 +118,19 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
     // anything Polygon has backfilled via resolve-security-snapshot.
     // Txn fills the long historical tail predating Plaid's sync.
     const priceAt = buildPriceAt(securitySnapshots, investmentTransactions);
-    const vStart = ids.reduce(
-      (sum, id) =>
-        sum +
-        valueAt({ date: windowStart, windowStart, accountId: id, holdingSnapshots, investmentTransactions, priceAt }),
-      0,
-    );
-    const vEnd = ids.reduce(
-      (sum, id) =>
-        sum +
-        valueAt({ date: windowEnd, windowStart, accountId: id, holdingSnapshots, investmentTransactions, priceAt }),
-      0,
-    );
+    // Aggregate asset value across all in-scope accounts at an arbitrary
+    // date — the shared primitive behind the window boundaries (vStart/vEnd)
+    // and every TWR sub-period boundary. windowStart anchors the txn-derived
+    // qty walk consistently for all dates.
+    const valueAtAll = (date: string) =>
+      ids.reduce(
+        (sum, id) =>
+          sum +
+          valueAt({ date, windowStart, accountId: id, holdingSnapshots, investmentTransactions, priceAt }),
+        0,
+      );
+    const vStart = valueAtAll(windowStart);
+    const vEnd = valueAtAll(windowEnd);
 
     const flowsByDate = new Map<string, number>();
     for (const id of ids) {
@@ -142,6 +144,12 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
     const flows = allFlows.filter((f) => f.date > windowStart && f.date <= windowEnd);
 
     const mwr = computeMWR({ flows, vStart, vEnd, windowStart, windowEnd });
+
+    // Time-weighted return over the same window — timing-neutral by
+    // construction, so it isolates *selection* (did the holdings beat the
+    // index?) from *timing* (did contribution timing help?). Uses the same
+    // asset-side flows + valuations as the MWR (see computeTWR).
+    const twr = computeTWR({ flows, valueAt: valueAtAll, windowStart, windowEnd });
 
     // Benchmark TWR fallback chain: security_snapshots → static CSV.
     // (Polygon resolve fires async in a separate useEffect and merges
@@ -231,6 +239,7 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
       yearsInWindow,
       mwr,
       mwrGain,
+      twr,
       benchmark,
       benchmarkGain,
       gapPct,
@@ -304,6 +313,7 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
     yearsInWindow,
     mwr,
     mwrGain,
+    twr,
     benchmark,
     benchmarkGain,
     gapPct,
@@ -373,6 +383,18 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
             {displayMode === "pct"
               ? renderValues(mwr.cumulative, mwr.annualized, "—", formatPct)
               : renderValues(mwrGain, perYear(mwrGain), "—", formatSignedDollars)}
+          </span>
+        </div>
+
+        <div className="performanceRow">
+          <span className="performanceLabel">Your asset return (TWR)</span>
+          {/* TWR is a pure rate — the actual dollars earned ARE the MWR gain,
+              so there's no honest dollar counterpart. The row always renders %
+              and doesn't participate in the $ ↔ % toggle. */}
+          <span className="performanceValues">
+            {twr.status === "ok"
+              ? renderValues(twr.cumulative, twr.annualized, "—", formatPct)
+              : <span className="no-data">—</span>}
           </span>
         </div>
 

--- a/src/client/components/PerformanceBenchmark/index.tsx
+++ b/src/client/components/PerformanceBenchmark/index.tsx
@@ -121,14 +121,23 @@ export const PerformanceBenchmark = ({ accounts }: Props) => {
     // Aggregate asset value across all in-scope accounts at an arbitrary
     // date — the shared primitive behind the window boundaries (vStart/vEnd)
     // and every TWR sub-period boundary. windowStart anchors the txn-derived
-    // qty walk consistently for all dates.
-    const valueAtAll = (date: string) =>
-      ids.reduce(
+    // qty walk consistently for all dates. Each `valueAt` re-derives the
+    // per-account cash-security set + txn qty walk, so memoize per date: the
+    // window boundaries are queried by both vStart/vEnd and computeTWR, and a
+    // heavy-trader account can have many flow boundaries.
+    const valueCache = new Map<string, number>();
+    const valueAtAll = (date: string) => {
+      const cached = valueCache.get(date);
+      if (cached !== undefined) return cached;
+      const total = ids.reduce(
         (sum, id) =>
           sum +
           valueAt({ date, windowStart, accountId: id, holdingSnapshots, investmentTransactions, priceAt }),
         0,
       );
+      valueCache.set(date, total);
+      return total;
+    };
     const vStart = valueAtAll(windowStart);
     const vEnd = valueAtAll(windowEnd);
 

--- a/src/client/lib/hooks/calculation/benchmark.test.ts
+++ b/src/client/lib/hooks/calculation/benchmark.test.ts
@@ -6,6 +6,7 @@ import {
   extractCashFlows,
   extractCashFlowsBySecurity,
   computeMWR,
+  computeTWR,
   computeBenchmarkTWR,
   computeBenchmarkEndValue,
   valueAt,
@@ -218,6 +219,114 @@ describe("computeMWR", () => {
     });
     const years = (new Date("2026-12-31").getTime() - new Date("2026-01-01").getTime()) / (1000 * 60 * 60 * 24 * 365);
     expect(r.cumulative!).toBeCloseTo(Math.pow(1 + r.annualized!, years) - 1, 6);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+describe("computeTWR", () => {
+  // Helper: a valueAt closure backed by a date→value map.
+  const vAt = (m: Record<string, number>) => (date: string) => m[date] ?? 0;
+
+  test("no flows: TWR is the plain price ratio (10% over 1y)", () => {
+    const r = computeTWR({
+      flows: [],
+      valueAt: vAt({ "2026-01-01": 1000, "2027-01-01": 1100 }),
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    expect(r.status).toBe("ok");
+    expect(r.cumulative!).toBeCloseTo(0.1, 6);
+    expect(r.annualized!).toBeCloseTo(0.1, 2);
+  });
+
+  test("mid-window contribution does NOT distort TWR (isolates timing)", () => {
+    // 1000 → +10% → 1100, then +1000 bought (value 2100), → +10% → 2310.
+    // TWR = 1.1 × 1.1 − 1 = 21% regardless of the contribution timing.
+    const r = computeTWR({
+      flows: [{ date: "2026-07-01", amount: 1000 }],
+      valueAt: vAt({ "2026-01-01": 1000, "2026-07-01": 2100, "2027-01-01": 2310 }),
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    expect(r.status).toBe("ok");
+    expect(r.cumulative!).toBeCloseTo(0.21, 6);
+  });
+
+  test("TWR differs from MWR under DCA in a rising market (the #638 misread)", () => {
+    // A DCA user: 0 at open, +1000 at mid, market +10% each half → value
+    // sequence 0 / 1000 (just bought) / 1100. MWR annualizes the late dollar
+    // aggressively (~21%); TWR sees only the funded half's 10% move.
+    const args = {
+      flows: [{ date: "2026-07-01", amount: 1000 }],
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    };
+    const twr = computeTWR({ ...args, valueAt: vAt({ "2026-01-01": 0, "2026-07-01": 1000, "2027-01-01": 1100 }) });
+    const mwr = computeMWR({ ...args, vStart: 0, vEnd: 1100 });
+    expect(twr.status).toBe("ok");
+    expect(twr.cumulative!).toBeCloseTo(0.1, 6); // only the funded half's move
+    expect(mwr.annualized!).toBeGreaterThan(twr.cumulative!); // timing inflates MWR
+  });
+
+  test("sell mid-window: chains market return across the withdrawal", () => {
+    // 1000 → +10% → 1100, sell 550 (value 550 left), → +10% → 605.
+    // TWR = 1.1 × 1.1 − 1 = 21%. Sell = −550 flow.
+    const r = computeTWR({
+      flows: [{ date: "2026-07-01", amount: -550 }],
+      valueAt: vAt({ "2026-01-01": 1000, "2026-07-01": 550, "2027-01-01": 605 }),
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    expect(r.status).toBe("ok");
+    expect(r.cumulative!).toBeCloseTo(0.21, 6);
+  });
+
+  test("skips sub-periods opening on a zero base; measures only the funded span", () => {
+    // Unfunded first half (base 0 at open) then funded: only sub-period 2 counts.
+    const r = computeTWR({
+      flows: [{ date: "2026-07-01", amount: 1000 }],
+      valueAt: vAt({ "2026-01-01": 0, "2026-07-01": 1000, "2027-01-01": 1100 }),
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    expect(r.status).toBe("ok");
+    expect(r.cumulative!).toBeCloseTo(0.1, 6);
+  });
+
+  test("insufficient_data when no sub-period has a positive opening base", () => {
+    const r = computeTWR({
+      flows: [],
+      valueAt: vAt({ "2026-01-01": 0, "2027-01-01": 0 }),
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    expect(r.status).toBe("insufficient_data");
+    expect(r.cumulative).toBeNull();
+    expect(r.annualized).toBeNull();
+  });
+
+  test("a flow exactly on windowEnd is excluded from the closing value (earns no window time)", () => {
+    // 1000 → +10% → 1100, then a +5000 buy lands on the very last day.
+    // valueAt(end) = 6100 but the 5000 earned no time; TWR must stay 10%.
+    const r = computeTWR({
+      flows: [{ date: "2027-01-01", amount: 5000 }],
+      valueAt: vAt({ "2026-01-01": 1000, "2027-01-01": 6100 }),
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    expect(r.status).toBe("ok");
+    expect(r.cumulative!).toBeCloseTo(0.1, 6);
+  });
+
+  test("cumulative and annualized are consistent: (1+cum)^(1/years) − 1", () => {
+    const r = computeTWR({
+      flows: [{ date: "2026-07-01", amount: 500 }],
+      valueAt: vAt({ "2026-01-01": 1000, "2026-07-01": 1600, "2027-01-01": 1800 }),
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    const years = (new Date("2027-01-01").getTime() - new Date("2026-01-01").getTime()) / (1000 * 60 * 60 * 24 * 365);
+    expect(r.annualized!).toBeCloseTo(Math.pow(1 + r.cumulative!, 1 / years) - 1, 6);
   });
 });
 

--- a/src/client/lib/hooks/calculation/benchmark.test.ts
+++ b/src/client/lib/hooks/calculation/benchmark.test.ts
@@ -293,6 +293,43 @@ describe("computeTWR", () => {
     expect(r.cumulative!).toBeCloseTo(0.1, 6);
   });
 
+  test("chains ≥2 interior flows: three linked 10% sub-periods → 33.1%", () => {
+    // start 1000 → +10% → 1100, +1000 buy (2100) → +10% → 2310, +1000 buy
+    // (3310) → +10% → 3641. TWR = 1.1³ − 1 = 0.331, contributions ignored.
+    const r = computeTWR({
+      flows: [
+        { date: "2026-05-01", amount: 1000 },
+        { date: "2026-09-01", amount: 1000 },
+      ],
+      valueAt: vAt({
+        "2026-01-01": 1000,
+        "2026-05-01": 2100,
+        "2026-09-01": 3310,
+        "2027-01-01": 3641,
+      }),
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    expect(r.status).toBe("ok");
+    expect(r.cumulative!).toBeCloseTo(0.331, 6);
+  });
+
+  test("skips a sub-period whose closing value falls below the same-day buy (exec ≫ close anomaly)", () => {
+    // A buy priced far above the day's close makes endBeforeFlow negative for
+    // that sub-period — skipped rather than reported as a bogus loss; the
+    // funded remainder still measures its market move (10%).
+    const r = computeTWR({
+      flows: [{ date: "2026-07-01", amount: 2000 }],
+      valueAt: vAt({ "2026-01-01": 1000, "2026-07-01": 1500, "2027-01-01": 1650 }),
+      windowStart: "2026-01-01",
+      windowEnd: "2027-01-01",
+    });
+    // sub1: base 1000 > 0 but endBeforeFlow = 1500 − 2000 = −500 ≤ 0 → skip.
+    // sub2: base 1500, close 1650 → HPR 1.1. Only sub2 counts.
+    expect(r.status).toBe("ok");
+    expect(r.cumulative!).toBeCloseTo(0.1, 6);
+  });
+
   test("insufficient_data when no sub-period has a positive opening base", () => {
     const r = computeTWR({
       flows: [],

--- a/src/client/lib/hooks/calculation/benchmark.ts
+++ b/src/client/lib/hooks/calculation/benchmark.ts
@@ -209,6 +209,89 @@ export const computeMWR = (params: {
   return { status: "ok", annualized, cumulative };
 };
 
+export interface TwrResult {
+  status: "ok" | "insufficient_data";
+  /** Cumulative time-weighted return over the window: Π(1+HPRᵢ) − 1. */
+  cumulative: number | null;
+  /** Annualized equivalent: (1 + cumulative)^(1/years) − 1. */
+  annualized: number | null;
+}
+
+/**
+ * Time-weighted return of the asset portfolio over [windowStart, windowEnd].
+ *
+ * TWR strips out *when* and *how much* the user contributed — unlike
+ * `computeMWR` (dollar-weighted), which rewards or penalizes contribution
+ * timing. It chain-links the holding-period return of the existing position
+ * across the sub-periods bounded by each external cash flow:
+ *
+ *   HPRᵢ = (V(bᵢ) − CFᵢ) / V(bᵢ₋₁)          TWR = Π HPRᵢ − 1
+ *
+ * where `bᵢ` walks windowStart → each interior flow date → windowEnd, `V(b)`
+ * is the asset value at `b` from the passed `valueAt` closure, and `CFᵢ` is
+ * the flow landing on `bᵢ` (buy = +, sell = −). Because `valueAt` values
+ * shares the same day they're bought (same-date-inclusive, matching how the
+ * MWR's `vStart`/`vEnd` are taken), subtracting `CFᵢ` at the closing boundary
+ * isolates the period's *market* move from the new money — the flow then
+ * re-enters as the opening value of the next sub-period.
+ *
+ * **Boundary-value approximation.** `CFᵢ` is the flow's cash at its execution
+ * price while `V(bᵢ)` prices that day's shares at the close, so when execution
+ * ≠ close the per-period return carries that small basis error — the same
+ * modeled-price limitation the MWR already lives with (see `buildPriceAt`).
+ * Sub-periods opening on a zero/negative asset base (position not yet funded,
+ * or fully liquidated then re-funded) are skipped rather than treated as ±∞
+ * returns; the chain resumes at the next funded boundary. Returns
+ * `insufficient_data` when no sub-period has a positive opening base.
+ */
+export const computeTWR = (params: {
+  flows: CashFlow[];
+  valueAt: (date: string) => number;
+  windowStart: string;
+  windowEnd: string;
+}): TwrResult => {
+  const { flows, valueAt, windowStart, windowEnd } = params;
+
+  // Sum flows per date (defensive — extractCashFlows already dedups by date).
+  // A flow on windowStart belongs to the opening value; one on windowEnd is
+  // subtracted from the closing value (it earned no time in the window),
+  // mirroring the MWR's `f.date > windowStart && f.date <= windowEnd` filter.
+  const cfByDate = new Map<string, number>();
+  for (const f of flows) {
+    if (f.date <= windowStart || f.date > windowEnd) continue;
+    cfByDate.set(f.date, (cfByDate.get(f.date) ?? 0) + f.amount);
+  }
+
+  // Ordered boundaries: windowStart, each interior flow date, windowEnd. A
+  // flow exactly on windowEnd is not its own boundary — it folds into the
+  // final sub-period's closing subtraction.
+  const interior = Array.from(cfByDate.keys())
+    .filter((d) => d < windowEnd)
+    .sort((a, b) => (a < b ? -1 : 1));
+  const boundaries = [windowStart, ...interior, windowEnd];
+
+  let product = 1;
+  let counted = 0;
+  for (let i = 1; i < boundaries.length; i++) {
+    const base = valueAt(boundaries[i - 1]);
+    if (base <= 0) continue; // segment not funded yet / fully closed — skip
+    const cf = cfByDate.get(boundaries[i]) ?? 0; // 0 at windowEnd w/o a flow
+    const endBeforeFlow = valueAt(boundaries[i]) - cf;
+    if (endBeforeFlow <= 0) continue; // modeled anomaly (exec ≪ close) — skip
+    product *= endBeforeFlow / base;
+    counted += 1;
+  }
+
+  if (counted === 0) {
+    return { status: "insufficient_data", cumulative: null, annualized: null };
+  }
+
+  const cumulative = product - 1;
+  const years = yearsBetween(windowStart, windowEnd);
+  const annualized = Math.pow(1 + cumulative, 1 / years) - 1;
+  return { status: "ok", cumulative, annualized };
+};
+
 /**
  * Benchmark return for a passive security held over the same window.
  * For an ETF like VOO with no contributions, TWR = simple price ratio.


### PR DESCRIPTION
## What

Adds a **time-weighted return (TWR)** row to the Investment Performance widget, beside the existing MWR row. Closes #638 (supersedes the closed caption approach #635).

TWR is timing-neutral by construction, so reading it next to the index-benchmark row isolates **selection** (did the holdings beat the index?) from **timing** (did contribution timing help or hurt?). Today the widget only shows MWR (timing-sensitive) next to the benchmark's TWR-like return, so a DCA user in a rising market systematically sees a misleading negative Diff even with index-identical holdings — because later dollars had less time to compound. TWR removes that distortion from the comparison.

## How

- **`computeTWR`** (`benchmark.ts`, next to `computeMWR`): chain-links the holding-period return of the *existing* position across the sub-periods bounded by each external cash flow —

  `HPRᵢ = (V(bᵢ) − CFᵢ) / V(bᵢ₋₁)`,  `TWR = Π HPRᵢ − 1`

  where `bᵢ` walks windowStart → each interior flow date → windowEnd, `V(b)` is the asset value at `b` from the existing `valueAt` primitive, and `CFᵢ` is the flow on `bᵢ` (buy +, sell −). Because `valueAt` values shares the same day they're bought (same-date-inclusive, matching how MWR takes `vStart`/`vEnd`), subtracting `CFᵢ` at the closing boundary isolates the period's market move from the new money. Uses the **same asset-side flows + valuations as the MWR** — cash-excluded, phantom-holding-guarded — so the two rows are apples-to-apples.
  - Sub-periods opening on a zero/negative base (position not yet funded, or fully liquidated then re-funded) are skipped; `insufficient_data` when none is funded.
  - **Boundary-value approximation** (documented in the fn): `CFᵢ` is the flow's cash at execution price while `V(bᵢ)` prices at close, so exec≠close carries a small basis error — the same modeled-price limitation MWR already lives with.
- **Widget**: new `Your asset return (TWR)` row between MWR and benchmark. TWR is a pure rate (the dollars earned *are* the MWR gain), so it always renders `%` and stays out of the `$ ↔ %` toggle. Extracted a shared `valueAtAll(date)` closure that now backs `vStart`/`vEnd` and every TWR boundary.

## Open question for @hoiekim (not changed here)

The **Diff** row still compares MWR − benchmark. The clean "selection alone" comparison the issue describes is **TWR − benchmark**. I left Diff as-is to avoid silently redefining an existing row; with the TWR and benchmark rows now adjacent, the user can already read the selection gap directly. Want a follow-up that switches Diff to TWR-based (or adds a second "Selection" diff row)? Say the word and I'll do it in a separate PR.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` (whole tree) — clean
- [x] `bun test src` — 1104 pass / 0 fail (+11 `computeTWR` unit tests: no-flow price-ratio, timing-neutrality under a mid-window contribution, MWR-vs-TWR divergence under DCA, mid-window sell, ≥2-interior-flow linked chain, zero-base skip, `endBeforeFlow<=0` skip, `insufficient_data`, windowEnd-flow exclusion, cumulative↔annualized consistency)
- [x] `bun run build-client` — clean
- [x] **UI E2E** — sandbox, admin login, Accounts → investment-account detail (real row click) → **Investment Performance** widget, mobile 390×844, PNG eye-checked:
  - New **`Your asset return (TWR)`** row renders in the correct position — between `Your asset return (MWR)` and the index-benchmark row, aligned with the others (`/tmp/pr-653-twr-1Y.png`).
  - **Rate-only behavior confirmed**: toggling the widget to `$` flips MWR to a signed-dollar figure and the benchmark to a signed-dollar figure, while the **TWR row stays `%` (unchanged)** — asserted programmatically (`TWR unchanged: true`) and eye-checked (`/tmp/pr-653-twr-dollarmode.png`).
  - Window picker 1Y / 3Y / All all render the row; annualized-suppression footnote (`<6mo`) honored.
  - No new console errors (only the pre-existing sandbox-HTTP service-worker registration warning).
  - **Re-ran the full E2E after the reviewoie fix commit (a8a121c7) — identical, no regression.**
  - _Note: on the scrambled sandbox clone the asset-side snapshot history is short (all windows clamp to ~1 month) and the sampled account has no interior cash flows, so TWR == MWR there — which is **correct** (with no in-window flows the two returns are identical by construction). The **TWR ≠ MWR divergence** the feature exists for is proven rigorously by the unit tests (the DCA test asserts `twr.cumulative = 10%` while `mwr.annualized > 10%`, and the timing-neutrality test holds TWR flat across a mid-window contribution). The sandbox verified rendering + the rate-only toggle; the math divergence is unit-proven._
