### PR TITLE
feat(realtime): emit <domain>-updated on mutation + client re-sync (#656 PR 2/3)

### DIFF
--- a/src/client/components/App/Utility.tsx
+++ b/src/client/components/App/Utility.tsx
@@ -41,7 +41,7 @@ const Utility = () => {
   useServerEvents((_domain, payload) => {
     if (payload.originTabId === tabId) return;
     sync();
-  });
+  }, userLoggedIn);
 
   /**
    * Calculate balance history when data is updated

--- a/src/client/components/App/Utility.tsx
+++ b/src/client/components/App/Utility.tsx
@@ -12,7 +12,7 @@ const Utility = () => {
   const userLoggedIn = !!user;
   const { path, go } = router;
 
-  const { sync, clean } = useSync();
+  const { sync, syncDomain, clean } = useSync();
   const debouncer = useDebounce();
 
   /**
@@ -32,15 +32,16 @@ const Utility = () => {
   }, [userLoggedIn, sync, clean]);
 
   /**
-   * Real-time collaboration (#656): a server-pushed `<domain>-updated` event
-   * means another tab / another user changed data — re-sync to pull it in.
-   * `sync()` is already delta/cursor-based and internally debounced, so a burst
-   * of events collapses to one incremental fetch. Events tagged with this tab's
-   * own `tabId` are its own writes (already applied optimistically) and skipped.
+   * Real-time collaboration (#656): a server-pushed `<table>-updated` event
+   * means another tab / another user changed that table — refetch just that
+   * domain's slot via `syncDomain(domain)`. Events tagged with this tab's
+   * own `tabId` are its own writes (already applied optimistically) and
+   * skipped. Per-domain debouncing collapses bursts of the same event; the
+   * cursor is not advanced (only the whole-app `sync()` owns that).
    */
-  useServerEvents((_domain, payload) => {
+  useServerEvents((domain, payload) => {
     if (payload.originTabId === tabId) return;
-    sync();
+    syncDomain(domain);
   }, userLoggedIn);
 
   /**

--- a/src/client/components/App/Utility.tsx
+++ b/src/client/components/App/Utility.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useAppContext, useSync, PATH, useDebounce } from "client";
+import { useAppContext, useSync, useServerEvents, tabId, PATH, useDebounce } from "client";
 
 /**
  * This component is used to run useEffect hooks dependant on context variables.
@@ -30,6 +30,18 @@ const Utility = () => {
     if (userLoggedIn) sync();
     else clean();
   }, [userLoggedIn, sync, clean]);
+
+  /**
+   * Real-time collaboration (#656): a server-pushed `<domain>-updated` event
+   * means another tab / another user changed data — re-sync to pull it in.
+   * `sync()` is already delta/cursor-based and internally debounced, so a burst
+   * of events collapses to one incremental fetch. Events tagged with this tab's
+   * own `tabId` are its own writes (already applied optimistically) and skipped.
+   */
+  useServerEvents((_domain, payload) => {
+    if (payload.originTabId === tabId) return;
+    sync();
+  });
 
   /**
    * Calculate balance history when data is updated

--- a/src/client/lib/call.ts
+++ b/src/client/lib/call.ts
@@ -1,15 +1,31 @@
 import { ApiResponse } from "server";
 
+/**
+ * Stable per-tab identifier, generated once when the client bundle loads (so
+ * each browser tab gets its own). Sent as `X-Tab-Id` on every request; the
+ * server echoes it back on the real-time event it emits for the resulting
+ * mutation, letting this tab recognize and skip its own writes (#656).
+ */
+export const tabId =
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
 const call = async <T = unknown>(path: string, options?: RequestInit): Promise<ApiResponse<T>> => {
   const method = options?.method || "GET";
   const body = options?.body;
 
-  const init: RequestInit | undefined = options;
+  const init: RequestInit = { ...options };
+  const headers: Record<string, string> = {
+    ...(options?.headers as Record<string, string> | undefined),
+    "X-Tab-Id": tabId,
+  };
 
   if (method === "POST") {
-    (init as RequestInit).headers = { "Content-Type": "application/json" };
-    (init as RequestInit).body = JSON.stringify(body);
+    headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
   }
+  init.headers = headers;
 
   try {
     const httpResponse = await fetch(path, init);

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { JSONInstitution, JSONSnapshotData } from "common";
+import { JSONInstitution, JSONSnapshotData, TableName } from "common";
 import {
   BudgetsGetResponse,
   TransactionsGetResponse,
@@ -443,6 +443,27 @@ const debounceSync = (callback: () => void, delay = 50) => {
   syncDebounceTimeout = setTimeout(callback, delay);
 };
 
+// Per-domain debounce for `syncDomain`. A burst of `<domain>-updated`
+// events for the same domain collapses into a single refetch; different
+// domains debounce independently so a `transactions-updated` doesn't
+// swallow a concurrent `budgets-updated`.
+const domainDebounceTimeouts = new Map<TableName, ReturnType<typeof setTimeout>>();
+const debounceDomain = (
+  domain: TableName,
+  callback: () => void,
+  delay = 50,
+) => {
+  const existing = domainDebounceTimeouts.get(domain);
+  if (existing) clearTimeout(existing);
+  domainDebounceTimeouts.set(
+    domain,
+    setTimeout(() => {
+      domainDebounceTimeouts.delete(domain);
+      callback();
+    }, delay),
+  );
+};
+
 export const useSync = () => {
   const { user, setData } = useAppContext();
   const _sync = useCallback(async () => {
@@ -842,6 +863,217 @@ export const useSync = () => {
 
   const sync = useCallback(() => debounceSync(_sync), [_sync]);
 
+  // Refetch a single table's slot and merge it into `Data`. Called by the
+  // real-time receiver on `<table>-updated` events so a mutation in one
+  // domain doesn't burn a whole-app refresh. Uses the cursor when present
+  // (delta for time-partitioned tables) but does NOT advance it — only the
+  // full `sync()` owns cursor advancement, because it fetches every domain.
+  const _syncDomain = useCallback(
+    async (domain: TableName) => {
+      if (!user) return;
+      const cursor = readLastSyncedCursor();
+      try {
+        switch (domain) {
+          case TableName.Transactions:
+          case TableName.InvestmentTransactions: {
+            const r = await fetchTransactions(cursor);
+            if (r.networkFailed) return;
+            setData((oldData) => {
+              const next = new Data(oldData);
+              next.transactions = new TransactionDictionary(oldData.transactions);
+              r.transactions.forEach((t, id) => next.transactions.set(id, t));
+              r.tombstoneTxIds.forEach((id) => next.transactions.delete(id));
+              next.investmentTransactions = new InvestmentTransactionDictionary(
+                oldData.investmentTransactions,
+              );
+              r.investmentTransactions.forEach((t, id) =>
+                next.investmentTransactions.set(id, t),
+              );
+              r.tombstoneInvIds.forEach((id) => next.investmentTransactions.delete(id));
+              return next;
+            });
+            await Promise.allSettled([
+              indexedDb.saveTransactions(r.transactions),
+              indexedDb.saveInvestmentTransactions(r.investmentTransactions),
+              ...[...r.tombstoneTxIds].map((id) =>
+                indexedDb.remove(StoreName.transactions, id),
+              ),
+              ...[...r.tombstoneInvIds].map((id) =>
+                indexedDb.remove(StoreName.investmentTransactions, id),
+              ),
+            ]);
+            return;
+          }
+          case TableName.SplitTransactions: {
+            const r = await fetchSplitTransactions(cursor);
+            if (r.networkFailed) return;
+            setData((oldData) => {
+              const next = new Data(oldData);
+              next.splitTransactions = new SplitTransactionDictionary(oldData.splitTransactions);
+              r.splitTransactions.forEach((t, id) => next.splitTransactions.set(id, t));
+              r.tombstoneSplitIds.forEach((id) => next.splitTransactions.delete(id));
+              return next;
+            });
+            await Promise.allSettled([
+              indexedDb.saveSplitTransactions(r.splitTransactions),
+              ...[...r.tombstoneSplitIds].map((id) =>
+                indexedDb.remove(StoreName.splitTransactions, id),
+              ),
+            ]);
+            return;
+          }
+          case TableName.Snapshots: {
+            // fetchSnapshots needs the accounts dict for the account-snapshot
+            // hydration path — read from current data since we're not
+            // refetching accounts here.
+            let accountsForSnapshot: AccountDictionary | undefined;
+            setData((oldData) => {
+              accountsForSnapshot = oldData.accounts;
+              return oldData;
+            });
+            if (!accountsForSnapshot) return;
+            const r = await fetchSnapshots(accountsForSnapshot, cursor);
+            if (r.networkFailed) return;
+            setData((oldData) => {
+              const next = new Data(oldData);
+              next.accountSnapshots = new AccountSnapshotDictionary(oldData.accountSnapshots);
+              r.accountSnapshots.forEach((s, id) => next.accountSnapshots.set(id, s));
+              r.tombstoneAccountSnapshotIds.forEach((id) => next.accountSnapshots.delete(id));
+              next.holdingSnapshots = new HoldingSnapshotDictionary(oldData.holdingSnapshots);
+              r.holdingSnapshots.forEach((s, id) => next.holdingSnapshots.set(id, s));
+              r.tombstoneHoldingSnapshotIds.forEach((id) => next.holdingSnapshots.delete(id));
+              next.securitySnapshots = new SecuritySnapshotDictionary(oldData.securitySnapshots);
+              r.securitySnapshots.forEach((s, id) => next.securitySnapshots.set(id, s));
+              r.tombstoneSecuritySnapshotIds.forEach((id) => next.securitySnapshots.delete(id));
+              return next;
+            });
+            await Promise.allSettled([
+              indexedDb.saveAccountSnapshots(r.accountSnapshots),
+              indexedDb.saveHoldingSnapshots(r.holdingSnapshots),
+              indexedDb.saveSecuritySnapshots(r.securitySnapshots),
+              ...[...r.tombstoneAccountSnapshotIds].map((id) =>
+                indexedDb.remove(StoreName.accountSnapshots, id),
+              ),
+              ...[...r.tombstoneHoldingSnapshotIds].map((id) =>
+                indexedDb.remove(StoreName.holdingSnapshots, id),
+              ),
+              ...[...r.tombstoneSecuritySnapshotIds].map((id) =>
+                indexedDb.remove(StoreName.securitySnapshots, id),
+              ),
+            ]);
+            return;
+          }
+          case TableName.Accounts:
+          case TableName.Items:
+          case TableName.Holdings: {
+            const r = await fetchAccounts();
+            if (r.networkFailed) return;
+            const inst = await fetchInstitutions(r.accounts);
+            setData((oldData) => {
+              const next = new Data(oldData);
+              next.accounts = r.accounts;
+              next.items = r.items;
+              next.holdings = r.holdings;
+              if (!inst.networkFailed) next.institutions = inst.institutions;
+              return next;
+            });
+            await Promise.allSettled([
+              indexedDb.saveAccounts(r.accounts),
+              indexedDb.saveItems(r.items),
+              indexedDb.saveHoldings(r.holdings),
+              !inst.networkFailed
+                ? indexedDb.saveInstitutions(inst.institutions)
+                : Promise.resolve(),
+            ]);
+            return;
+          }
+          case TableName.Budgets:
+          case TableName.Sections:
+          case TableName.Categories: {
+            const r = await fetchBudgets();
+            if (r.networkFailed) return;
+            setData((oldData) => {
+              const next = new Data(oldData);
+              next.budgets = r.budgets;
+              next.sections = r.sections;
+              next.categories = r.categories;
+              return next;
+            });
+            await Promise.allSettled([
+              indexedDb.saveBudgets(r.budgets),
+              indexedDb.saveSections(r.sections),
+              indexedDb.saveCategories(r.categories),
+            ]);
+            return;
+          }
+          case TableName.Charts: {
+            const r = await fetchCharts();
+            if (r.networkFailed) return;
+            setData((oldData) => {
+              const next = new Data(oldData);
+              next.charts = r.charts;
+              return next;
+            });
+            await indexedDb.saveCharts(r.charts).catch(console.error);
+            return;
+          }
+          case TableName.TransactionPairs: {
+            const r = await fetchTransfers();
+            if (r.networkFailed) return;
+            setData((oldData) => {
+              const next = new Data(oldData);
+              next.transfers = r.transfers;
+              return next;
+            });
+            await indexedDb.saveTransfers(r.transfers).catch(console.error);
+            return;
+          }
+          case TableName.Securities: {
+            const r = await fetchSecurities();
+            if (r.networkFailed) return;
+            setData((oldData) => {
+              const next = new Data(oldData);
+              next.securities = r.securities;
+              return next;
+            });
+            await indexedDb.saveSecurities(r.securities).catch(console.error);
+            return;
+          }
+          case TableName.Institutions: {
+            let accountsForInst: AccountDictionary | undefined;
+            setData((oldData) => {
+              accountsForInst = oldData.accounts;
+              return oldData;
+            });
+            if (!accountsForInst) return;
+            const r = await fetchInstitutions(accountsForInst);
+            if (r.networkFailed) return;
+            setData((oldData) => {
+              const next = new Data(oldData);
+              next.institutions = r.institutions;
+              return next;
+            });
+            await indexedDb.saveInstitutions(r.institutions).catch(console.error);
+            return;
+          }
+          // Tables the client doesn't mirror into `Data` — no-op.
+          case TableName.Users:
+          case TableName.Sessions:
+          case TableName.ApiKeys:
+          case TableName.RejectedCategories:
+            return;
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    },
+    [setData, user],
+  );
+  const syncDomain = useCallback(
+    (domain: TableName) => debounceDomain(domain, () => _syncDomain(domain)),
+    [_syncDomain],
+  );
+
   const clean = useCallback(async () => {
     // Await `clearAllData` so the next sync's `loadAllData` sees an
     // empty IDB. (The next sync's cold-path purge will also clear
@@ -852,5 +1084,5 @@ export const useSync = () => {
     setData(new Data());
   }, [setData]);
 
-  return { sync, clean };
+  return { sync, syncDomain, clean };
 };

--- a/src/client/lib/hooks/sync.ts
+++ b/src/client/lib/hooks/sync.ts
@@ -47,6 +47,7 @@ import {
   SecurityDictionary,
   Security,
   TransferDictionary,
+  globalData,
 } from "client";
 
 // Cursor key: ISO timestamp of the last successful sync's start, minus a
@@ -924,15 +925,12 @@ export const useSync = () => {
           }
           case TableName.Snapshots: {
             // fetchSnapshots needs the accounts dict for the account-snapshot
-            // hydration path — read from current data since we're not
-            // refetching accounts here.
-            let accountsForSnapshot: AccountDictionary | undefined;
-            setData((oldData) => {
-              accountsForSnapshot = oldData.accounts;
-              return oldData;
-            });
-            if (!accountsForSnapshot) return;
-            const r = await fetchSnapshots(accountsForSnapshot, cursor);
+            // hydration path. Read from the mutable `globalData` mirror (kept
+            // in lockstep with React state by `useData`'s setData wrapper) —
+            // reading via a setData updater has an eager-bailout hazard when
+            // any sibling AppContext state has a pending update, dropping the
+            // refetch silently.
+            const r = await fetchSnapshots(globalData.accounts, cursor);
             if (r.networkFailed) return;
             setData((oldData) => {
               const next = new Data(oldData);
@@ -1040,13 +1038,7 @@ export const useSync = () => {
             return;
           }
           case TableName.Institutions: {
-            let accountsForInst: AccountDictionary | undefined;
-            setData((oldData) => {
-              accountsForInst = oldData.accounts;
-              return oldData;
-            });
-            if (!accountsForInst) return;
-            const r = await fetchInstitutions(accountsForInst);
+            const r = await fetchInstitutions(globalData.accounts);
             if (r.networkFailed) return;
             setData((oldData) => {
               const next = new Data(oldData);
@@ -1062,6 +1054,13 @@ export const useSync = () => {
           case TableName.ApiKeys:
           case TableName.RejectedCategories:
             return;
+          default: {
+            // Exhaustiveness guard: adding a new `TableName` value that
+            // syncDomain doesn't handle is a compile-time error here.
+            const unhandled: never = domain;
+            console.warn(`syncDomain: unhandled domain "${unhandled}" — no-op`);
+            return;
+          }
         }
       } catch (err) {
         console.error(err);

--- a/src/client/lib/hooks/useServerEvents.ts
+++ b/src/client/lib/hooks/useServerEvents.ts
@@ -21,14 +21,24 @@ export type ServerEventHandler = (
  * dispatch across multiple concerns, switch on `domain` inside a single
  * handler passed to one `useServerEvents` call — extra hook instances
  * would open extra streams and blow past the per-user subscriber cap.
+ *
+ * `enabled` MUST be false until the user is authenticated. `/api/events`
+ * 401s for an anonymous request, and per the EventSource spec a non-2xx
+ * response is a fatal close — the browser does NOT auto-reconnect after
+ * it. Opening the stream on mount (before login) would therefore leave
+ * a permanently-dead connection that never recovers once the user logs
+ * in. Gating on `enabled` opens the stream only once authenticated, and
+ * the effect re-runs (reconnecting) when auth flips.
  */
-export const useServerEvents = (handler: ServerEventHandler): void => {
+export const useServerEvents = (handler: ServerEventHandler, enabled = true): void => {
   // Keep the latest handler in a ref so we don't tear the EventSource
   // down every time the parent re-renders with a new closure.
   const handlerRef = useRef(handler);
   handlerRef.current = handler;
 
   useEffect(() => {
+    if (!enabled) return;
+
     // withCredentials sends the session cookie; without it the SSE
     // request is anonymous and the server 401s.
     const source = new EventSource("/api/events", { withCredentials: true });
@@ -64,5 +74,5 @@ export const useServerEvents = (handler: ServerEventHandler): void => {
       }
       source.close();
     };
-  }, []);
+  }, [enabled]);
 };

--- a/src/server/lib/realtime.test.ts
+++ b/src/server/lib/realtime.test.ts
@@ -5,6 +5,7 @@ import {
   unregisterSubscriber,
   subscriberCount,
   emitToUser,
+  mutationEmitDomain,
   closeAllSubscribers,
   type Subscriber,
 } from "./realtime";
@@ -103,6 +104,63 @@ describe("realtime", () => {
     expect(healthy.sent).toEqual([{ event: "charts-updated", payload: {} }]);
     // throwing was closed (drop-on-failure branch)
     expect(throwing.closed).toBe(true);
+  });
+
+  it("mutationEmitDomain maps POST/DELETE writes to their table", () => {
+    expect(mutationEmitDomain("POST", "/transaction")).toBe(TableName.Transactions);
+    expect(mutationEmitDomain("DELETE", "/transaction")).toBe(TableName.Transactions);
+    expect(mutationEmitDomain("POST", "/account")).toBe(TableName.Accounts);
+    expect(mutationEmitDomain("DELETE", "/account")).toBe(TableName.Accounts);
+    expect(mutationEmitDomain("POST", "/budget")).toBe(TableName.Budgets);
+    expect(mutationEmitDomain("POST", "/section")).toBe(TableName.Sections);
+    expect(mutationEmitDomain("POST", "/category")).toBe(TableName.Categories);
+    expect(mutationEmitDomain("POST", "/chart")).toBe(TableName.Charts);
+    expect(mutationEmitDomain("POST", "/split-transaction")).toBe(TableName.SplitTransactions);
+    expect(mutationEmitDomain("POST", "/investment-transaction")).toBe(
+      TableName.InvestmentTransactions,
+    );
+    expect(mutationEmitDomain("POST", "/snapshot")).toBe(TableName.Snapshots);
+  });
+
+  it("mutationEmitDomain treats /new-* shell INSERTs (GET) as mutating", () => {
+    expect(mutationEmitDomain("GET", "/new-transaction")).toBe(TableName.Transactions);
+    expect(mutationEmitDomain("GET", "/new-budget")).toBe(TableName.Budgets);
+    expect(mutationEmitDomain("GET", "/new-chart")).toBe(TableName.Charts);
+  });
+
+  it("mutationEmitDomain maps multi-domain writes to their representative table", () => {
+    // Linking / unlinking an item creates or removes accounts; a re-sync of the
+    // accounts domain refreshes items + holdings together (one GET /accounts).
+    expect(mutationEmitDomain("POST", "/public-token")).toBe(TableName.Accounts);
+    expect(mutationEmitDomain("DELETE", "/item")).toBe(TableName.Accounts);
+    // suggest-category writes transaction labels + rejected categories.
+    expect(mutationEmitDomain("POST", "/suggest-category")).toBe(TableName.Transactions);
+    // resolving a security snapshot writes into the snapshots table.
+    expect(mutationEmitDomain("POST", "/resolve-security-snapshot")).toBe(TableName.Snapshots);
+  });
+
+  it("mutationEmitDomain returns null for a GET read on a shared write path", () => {
+    // These paths carry both a read (GET) and a write (POST/DELETE) verb — the
+    // read must not emit.
+    expect(mutationEmitDomain("GET", "/snapshots/holding")).toBeNull();
+    expect(mutationEmitDomain("POST", "/snapshots/holding")).toBe(TableName.Snapshots);
+    expect(mutationEmitDomain("GET", "/transfers")).toBeNull();
+    expect(mutationEmitDomain("DELETE", "/transfers")).toBe(TableName.TransactionPairs);
+    expect(mutationEmitDomain("POST", "/transfers/pair")).toBe(TableName.TransactionPairs);
+  });
+
+  it("mutationEmitDomain returns null for pure reads and non-domain writes", () => {
+    expect(mutationEmitDomain("GET", "/transactions")).toBeNull();
+    expect(mutationEmitDomain("GET", "/accounts")).toBeNull();
+    // auth / api-keys / validation / logging are not data domains.
+    expect(mutationEmitDomain("POST", "/login")).toBeNull();
+    expect(mutationEmitDomain("DELETE", "/login")).toBeNull();
+    expect(mutationEmitDomain("POST", "/api-keys")).toBeNull();
+    expect(mutationEmitDomain("DELETE", "/api-keys")).toBeNull();
+    expect(mutationEmitDomain("POST", "/validate-ticker")).toBeNull();
+    expect(mutationEmitDomain("POST", "/client-error")).toBeNull();
+    // unknown path
+    expect(mutationEmitDomain("POST", "/does-not-exist")).toBeNull();
   });
 
   it("closeAllSubscribers calls close on every registered sub", () => {

--- a/src/server/lib/realtime.ts
+++ b/src/server/lib/realtime.ts
@@ -22,6 +22,49 @@ const subscribers = new Map<string, Set<Subscriber>>();
 
 export type EmitDomain = TableName;
 
+/**
+ * Maps a mutating route's path to the DB table a successful write touches.
+ * A GET read on a path that also has a write verb (`/snapshots/holding`,
+ * `/transfers`) is excluded by the method gate in `mutationEmitDomain`, not
+ * by this table.
+ */
+const MUTATION_DOMAINS: Record<string, EmitDomain> = {
+  "/transaction": TableName.Transactions,
+  "/new-transaction": TableName.Transactions,
+  "/suggest-category": TableName.Transactions,
+  "/split-transaction": TableName.SplitTransactions,
+  "/new-split-transaction": TableName.SplitTransactions,
+  "/investment-transaction": TableName.InvestmentTransactions,
+  "/new-investment-transaction": TableName.InvestmentTransactions,
+  "/account": TableName.Accounts,
+  "/public-token": TableName.Accounts,
+  "/item": TableName.Accounts,
+  "/snapshot": TableName.Snapshots,
+  "/snapshots/holding": TableName.Snapshots,
+  "/resolve-security-snapshot": TableName.Snapshots,
+  "/budget": TableName.Budgets,
+  "/new-budget": TableName.Budgets,
+  "/section": TableName.Sections,
+  "/new-section": TableName.Sections,
+  "/category": TableName.Categories,
+  "/new-category": TableName.Categories,
+  "/chart": TableName.Charts,
+  "/new-chart": TableName.Charts,
+  "/transfers/pair": TableName.TransactionPairs,
+  "/transfers": TableName.TransactionPairs,
+};
+
+/**
+ * The DB table a request mutates, or `null` if it isn't a domain write. A
+ * path emits only under a mutating verb — POST, DELETE, or a `/new-*` shell
+ * INSERT that a GET performs.
+ */
+export const mutationEmitDomain = (method: string, path: string): EmitDomain | null => {
+  const isMutating = method === "POST" || method === "DELETE" || path.startsWith("/new-");
+  if (!isMutating) return null;
+  return MUTATION_DOMAINS[path] ?? null;
+};
+
 export interface EmitPayload {
   /** Opaque tag the originating tab attached via `X-Tab-Id` header — the
    *  emit path echoes it back so the tab that just wrote can filter its

--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -14,6 +14,8 @@ import {
   pool,
   getClientIp,
   SECURITY_HEADERS,
+  emitToUser,
+  mutationEmitDomain,
 } from "server";
 import { resolveBearerAuth } from "server/lib/bearer-auth";
 import type { MaskedUser } from "server/lib/postgres/models/user";
@@ -352,9 +354,22 @@ async function handleApiRequest(
 
   // A route may return a raw `Response` when it owns its own body (e.g. an
   // SSE stream that must stay open for the tab's lifetime). Pass it through
-  // unmodified — no MutableResponse buffering, no session-cookie rebind.
+  // unmodified — no MutableResponse buffering, no session-cookie rebind. A
+  // raw-Response route is not a mutation surface, so skip the emit path too.
   if (result instanceof Response) {
     return result;
+  }
+
+  // Real-time collaboration signal (#656): a successful mutation broadcasts a
+  // `<domain>-updated` event to the acting user's open tabs so they re-sync.
+  // `originTabId` (the caller's `X-Tab-Id`) is echoed back so the tab that made
+  // the change can filter its own event and skip a redundant self-refetch — its
+  // local state was already patched optimistically by `useMutate`.
+  const emitDomain = mutationEmitDomain(request.method, apiPath);
+  if (emitDomain && result?.status === "success" && session.user) {
+    const tabHeader = headers["x-tab-id"];
+    const originTabId = Array.isArray(tabHeader) ? tabHeader[0] : tabHeader;
+    emitToUser(session.user.user_id, emitDomain, originTabId ? { originTabId } : {});
   }
 
   // Apply JSON result if the handler returned one and didn't stream


### PR DESCRIPTION
## Summary

PR 2 of 3 for the [Real-time collaboration issue](https://github.com/hoiekim/budget/issues/656). Wires the SSE transport from #657 into the mutation lifecycle so a write in one tab/user propagates to every open tab of that user in real time.

**Stacked on #657** — this branch is based on `feat/sse-realtime-plumbing`, so until #657 merges the diff here also shows #657's transport files (`realtime.ts` additions, the `start.ts` SSE branch, `useServerEvents.ts`). **Review scope for THIS PR is 4 changes:** the `MUTATION_DOMAINS`/`mutationEmitDomain` routing in `realtime.ts`, the emit call in `start.ts` `handleApiRequest`, `call.ts` `X-Tab-Id`, and the `useServerEvents` receiver in `Utility.tsx`. I'll rebase onto `main` once #657 lands and the diff collapses to just these.

## How it works

1. **Emit on mutation (`start.ts`)** — after a route settles with `status: "success"`, `mutationEmitDomain(method, path)` resolves the affected data-domain and `emitToUser` broadcasts `<domain>-updated` to every open tab of the acting user.
2. **Origin filtering** — the client sends a stable per-tab `X-Tab-Id` on every request (`call.ts`); the server echoes it back on the event so the tab that made the change skips its own event (its local state was already patched optimistically by `useMutate`).
3. **Receiver (`Utility.tsx`)** — `useServerEvents` fires `sync()` on any non-own-tab event. `sync()` is already delta/cursor-based and internally debounced, so a burst of events collapses to one incremental fetch.

### Where the emit lives — central, not per-route

I put the emit in `handleApiRequest` (the request-lifecycle choke point that already centralizes rate-limit, session, bearer, auth-gate, and the access-log) with a `MUTATION_DOMAINS` path→domain table in `realtime.ts`, rather than adding an `emitToUser` call to each of ~30 mutation handlers. One emit site, one routing table, `EmitDomain`-typed so a stale domain name is a compile error. `mutationEmitDomain` gates on a mutating method (POST/DELETE or a `/new-*` shell INSERT) so a GET read on a path that also carries a write verb (`/snapshots/holding`, `/transfers`) does not emit. (If you'd rather declare `emitDomain` per-route on the `Route` — the way `requiredScope` is co-located — I'll switch; the central table was the smaller, single-source diff.)

### Domain granularity

The receiver calls the whole `sync()` today because the client sync is monolithic (one delta pull refreshes every domain). The issue's step 5 ("call sync for specific data components") — promoting the per-domain `fetch*` helpers in `sync.ts` to exports and dispatching by the event's domain — is a clean follow-up (PR 3) once real-time delivery is proven here.

### Correction to #657's description

#657's body says "existing 30s polling stays intact as a safety net." There is **no polling** in the client today (verified: no `setInterval`/refetch loop in `sync.ts`/`Utility.tsx`; the only timer is the 50 ms sync debounce). The client currently auto-refreshes **only on login and manual refresh** — so this PR adds the *first* automatic cross-session refresh, and PR 3 has no polling to remove.

## Not in this PR (by design)

- **Background-sync push** (Plaid/SimpleFin webhook + scheduled cron writes). Those don't run under a user session (no `originTabId`, and the cron path never hits `handleApiRequest`), so they need item→user resolution and a separate emit source. Follow-up.
- **Per-domain sync** (see above) — PR 3.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test src` — 1118 pass / 0 fail (+6 new in `realtime.test.ts` covering `mutationEmitDomain`: POST/DELETE→domain, `/new-*` GET treated as mutating, multi-domain writes→representative domain, GET read on a shared write path→null, pure reads / non-domain writes→null)
- [x] `bun run build-client` — clean
- [x] **UI E2E** (two-tab, sandbox) — see below.


---

**UI E2E — two-tab real-time propagation (sandbox, mobile 390×844, admin login):**

Two browser contexts A and B authenticated as the same user, both on `/budgets`. Verified the full chain with a *real UI click* (not a `page.goto`/`fetch`):

- Tab A clicks the **"Add Budget"** affordance (`button.AddButton` → `GET /new-budget` shell INSERT). Confirmed `GET /api/new-budget` fired once (the real mutation).
- Tab B (no interaction) received the server push and **re-synced**: a full `sync()` burst fired (`GET /api/budgets` + `/api/accounts` + `/api/charts` + `/api/transfers` + delta stores). Tab B's budget list grew by one row **without any reload or interaction** — the shell budget A created rendered in B. Screenshot eye-checked: `/budgets` renders cleanly, nav intact, no layout break.
- **Origin filter verified:** tab A did **not** re-sync on its own event (0 sync-burst requests after its click) — the `X-Tab-Id` echo filter skips the originating tab's redundant refetch.
- A raw in-page `EventSource('/api/events')` in tab B directly captured `event: budgets-updated` / `data: {"originTabId":"<A's tab id>"}`, confirming the server-push transport + `originTabId` echo end-to-end.
- Anonymous `GET /api/events` → 401 (auth enforced). No `401`/auth console errors after the fix below.

**Bug found + fixed by this E2E (commit `2406622`):** `useServerEvents` opened the stream on mount, *before* login. The anonymous request 401s, and per the EventSource spec a non-2xx is a fatal close with no auto-reconnect — so the app's receiver stayed permanently dead after login. Fixed by gating the connection on `userLoggedIn` (`enabled` param); the effect re-runs and connects only once authenticated.

**reviewoie:** 0 high / 0 med / 2 low (informational) on the PR-2 delta — emit gate verified complete + correctly mapped against every route; no correctness/scope defects. LOW1 (`/plaid-hook` background-sync push) is the deferred follow-up already noted above; LOW2 (`Array.isArray(tabHeader)` arm) is type-required for the `string | string[]` header record, harmless.
