### PR TITLE
feat(realtime): plaid-hook emits <table>-updated to item owner (#656 PR 3/3)

### DIFF
--- a/src/server/lib/compute-tools/sync-plaid.ts
+++ b/src/server/lib/compute-tools/sync-plaid.ts
@@ -263,6 +263,7 @@ export const syncPlaidTransactions = async (item_id: string) => {
   await Promise.all([syncTransactions, syncInvestmentTransactions]);
 
   return {
+    user_id: user.user_id,
     added: addedCount,
     modified: modifiedCount,
     removed: removedCount,

--- a/src/server/routes/webhooks/post-plaid-hook.test.ts
+++ b/src/server/routes/webhooks/post-plaid-hook.test.ts
@@ -32,6 +32,7 @@ const mockGetUserItem = mock(
 const mockUpsertItems = mock(
   async (_user: unknown, _items: unknown[]) => [] as unknown[],
 );
+const mockEmitToUser = mock((_userId: string, _domain: string, _payload?: unknown) => {});
 const mockSendAlarm = mock(async () => {});
 const mockLogger = {
   info: mock(() => {}),
@@ -50,6 +51,7 @@ mock.module("server", () => ({
   updateItemStatus: mockUpdateItemStatus,
   getUserItem: mockGetUserItem,
   upsertItems: mockUpsertItems,
+  emitToUser: mockEmitToUser,
 }));
 
 mock.module("server/lib/alarm", () => ({
@@ -94,6 +96,7 @@ beforeEach(() => {
   }));
   mockUpsertItems.mockReset();
   mockUpsertItems.mockImplementation(async () => []);
+  mockEmitToUser.mockReset();
   mockSendAlarm.mockReset();
   mockSendAlarm.mockImplementation(async () => {});
   mockLogger.info.mockReset();
@@ -208,6 +211,27 @@ describe("post-plaid-hook — TRANSACTIONS", () => {
     expect(result).toMatchObject({ status: "success" });
   });
 
+  test("SYNC_UPDATES_AVAILABLE emits transactions + investment_transactions to owner on non-empty change", async () => {
+    mockSyncPlaidTransactions.mockImplementation(async () => ({ added: 3, modified: 0, removed: 0 }));
+    await run({
+      webhook_type: "TRANSACTIONS",
+      webhook_code: "SYNC_UPDATES_AVAILABLE",
+      item_id: "item-7",
+    });
+    expect(mockEmitToUser).toHaveBeenCalledWith("u-1", "transactions");
+    expect(mockEmitToUser).toHaveBeenCalledWith("u-1", "investment_transactions");
+  });
+
+  test("SYNC_UPDATES_AVAILABLE does NOT emit when nothing changed", async () => {
+    mockSyncPlaidTransactions.mockImplementation(async () => ({ added: 0, modified: 0, removed: 0 }));
+    await run({
+      webhook_type: "TRANSACTIONS",
+      webhook_code: "SYNC_UPDATES_AVAILABLE",
+      item_id: "item-7",
+    });
+    expect(mockEmitToUser).not.toHaveBeenCalled();
+  });
+
   test("SYNC_UPDATES_AVAILABLE with null sync result → failed", async () => {
     mockSyncPlaidTransactions.mockImplementation(async () => null);
     const { result } = await run({
@@ -216,6 +240,7 @@ describe("post-plaid-hook — TRANSACTIONS", () => {
       item_id: "item-7",
     });
     expect(result).toMatchObject({ status: "failed" });
+    expect(mockEmitToUser).not.toHaveBeenCalled();
   });
 
   for (const code of [
@@ -232,6 +257,7 @@ describe("post-plaid-hook — TRANSACTIONS", () => {
       });
       expect(result).toMatchObject({ status: "success" });
       expect(mockSyncPlaidTransactions).not.toHaveBeenCalled();
+      expect(mockEmitToUser).not.toHaveBeenCalled();
     });
   }
 
@@ -257,7 +283,7 @@ describe("post-plaid-hook — ITEM", () => {
     expect(mockUpdateItemStatus).not.toHaveBeenCalled();
   });
 
-  test("PENDING_EXPIRATION → marks item BAD and alarms", async () => {
+  test("PENDING_EXPIRATION → marks item BAD, alarms, and emits accounts to owner", async () => {
     const { result } = await run({
       webhook_type: "ITEM",
       webhook_code: "PENDING_EXPIRATION",
@@ -265,6 +291,7 @@ describe("post-plaid-hook — ITEM", () => {
     });
     expect(mockUpdateItemStatus).toHaveBeenCalledWith("item-9", ItemStatus.BAD);
     expect(mockSendAlarm).toHaveBeenCalled();
+    expect(mockEmitToUser).toHaveBeenCalledWith("u-1", "accounts");
     expect(result).toMatchObject({ status: "success" });
   });
 
@@ -304,7 +331,7 @@ describe("post-plaid-hook — ITEM", () => {
   });
 
   for (const code of ["USER_ACCOUNT_REVOKED", "ITEM_UPDATED"]) {
-    test(`${code} → refreshes item products`, async () => {
+    test(`${code} → refreshes item products and emits accounts to owner`, async () => {
       const { result } = await run({
         webhook_type: "ITEM",
         webhook_code: code,
@@ -313,6 +340,7 @@ describe("post-plaid-hook — ITEM", () => {
       expect(mockGetUserItem).toHaveBeenCalledWith("item-5");
       expect(mockGetItem).toHaveBeenCalledWith("access-tok");
       expect(mockUpsertItems).toHaveBeenCalled();
+      expect(mockEmitToUser).toHaveBeenCalledWith("u-1", "accounts");
       expect(result).toMatchObject({ status: "success" });
     });
   }

--- a/src/server/routes/webhooks/post-plaid-hook.test.ts
+++ b/src/server/routes/webhooks/post-plaid-hook.test.ts
@@ -17,7 +17,7 @@ const mockGetItem = mock(async (_accessToken: string) => ({
   products: [] as string[],
 }));
 const mockSyncPlaidTransactions = mock(
-  async (_itemId: string) => ({ added: 0, modified: 0, removed: 0 }) as unknown,
+  async (_itemId: string) => ({ user_id: "u-1", added: 0, modified: 0, removed: 0 }) as unknown,
 );
 const mockUpdateItemStatus = mock(
   async (_itemId: string, _status: ItemStatus) => true as unknown,
@@ -83,6 +83,7 @@ beforeEach(() => {
   }));
   mockSyncPlaidTransactions.mockReset();
   mockSyncPlaidTransactions.mockImplementation(async () => ({
+    user_id: "u-1",
     added: 0,
     modified: 0,
     removed: 0,
@@ -211,19 +212,22 @@ describe("post-plaid-hook — TRANSACTIONS", () => {
     expect(result).toMatchObject({ status: "success" });
   });
 
-  test("SYNC_UPDATES_AVAILABLE emits transactions + investment_transactions to owner on non-empty change", async () => {
-    mockSyncPlaidTransactions.mockImplementation(async () => ({ added: 3, modified: 0, removed: 0 }));
+  test("SYNC_UPDATES_AVAILABLE emits ONLY transactions on non-empty change", async () => {
+    mockSyncPlaidTransactions.mockImplementation(async () => ({ user_id: "u-1", added: 3, modified: 0, removed: 0 }));
     await run({
       webhook_type: "TRANSACTIONS",
       webhook_code: "SYNC_UPDATES_AVAILABLE",
       item_id: "item-7",
     });
+    // Emit ONLY `transactions` — client's syncDomain case body handles both
+    // series in one /api/transactions fetch, so emitting investment_transactions
+    // would double-fire the same fetch.
+    expect(mockEmitToUser).toHaveBeenCalledTimes(1);
     expect(mockEmitToUser).toHaveBeenCalledWith("u-1", "transactions");
-    expect(mockEmitToUser).toHaveBeenCalledWith("u-1", "investment_transactions");
   });
 
   test("SYNC_UPDATES_AVAILABLE does NOT emit when nothing changed", async () => {
-    mockSyncPlaidTransactions.mockImplementation(async () => ({ added: 0, modified: 0, removed: 0 }));
+    mockSyncPlaidTransactions.mockImplementation(async () => ({ user_id: "u-1", added: 0, modified: 0, removed: 0 }));
     await run({
       webhook_type: "TRANSACTIONS",
       webhook_code: "SYNC_UPDATES_AVAILABLE",
@@ -295,7 +299,7 @@ describe("post-plaid-hook — ITEM", () => {
     expect(result).toMatchObject({ status: "success" });
   });
 
-  test("ERROR + ITEM_LOGIN_REQUIRED → marks item BAD and alarms", async () => {
+  test("ERROR + ITEM_LOGIN_REQUIRED → marks item BAD, alarms, and emits accounts to owner", async () => {
     const { result } = await run({
       webhook_type: "ITEM",
       webhook_code: "ERROR",
@@ -304,6 +308,7 @@ describe("post-plaid-hook — ITEM", () => {
     });
     expect(mockUpdateItemStatus).toHaveBeenCalledWith("item-9", ItemStatus.BAD);
     expect(mockSendAlarm).toHaveBeenCalled();
+    expect(mockEmitToUser).toHaveBeenCalledWith("u-1", "accounts");
     expect(result).toMatchObject({ status: "success" });
   });
 
@@ -368,13 +373,16 @@ describe("post-plaid-hook — ITEM", () => {
 });
 
 describe("post-plaid-hook — HOLDINGS", () => {
-  test("DEFAULT_UPDATE → syncs and returns success", async () => {
+  test("DEFAULT_UPDATE → syncs, emits transactions on non-empty change, returns success", async () => {
+    mockSyncPlaidTransactions.mockImplementation(async () => ({ user_id: "u-1", added: 1, modified: 0, removed: 0 }));
     const { result } = await run({
       webhook_type: "HOLDINGS",
       webhook_code: "DEFAULT_UPDATE",
       item_id: "item-h",
     });
     expect(mockSyncPlaidTransactions).toHaveBeenCalledWith("item-h");
+    expect(mockEmitToUser).toHaveBeenCalledTimes(1);
+    expect(mockEmitToUser).toHaveBeenCalledWith("u-1", "transactions");
     expect(result).toMatchObject({ status: "success" });
   });
 
@@ -392,13 +400,16 @@ describe("post-plaid-hook — HOLDINGS", () => {
 
 describe("post-plaid-hook — INVESTMENTS_TRANSACTIONS", () => {
   for (const code of ["DEFAULT_UPDATE", "HISTORICAL_UPDATE"]) {
-    test(`${code} → syncs and returns success`, async () => {
+    test(`${code} → syncs, emits transactions on non-empty change, returns success`, async () => {
+      mockSyncPlaidTransactions.mockImplementation(async () => ({ user_id: "u-1", added: 2, modified: 0, removed: 0 }));
       const { result } = await run({
         webhook_type: "INVESTMENTS_TRANSACTIONS",
         webhook_code: code,
         item_id: "item-iv",
       });
       expect(mockSyncPlaidTransactions).toHaveBeenCalledWith("item-iv");
+      expect(mockEmitToUser).toHaveBeenCalledTimes(1);
+      expect(mockEmitToUser).toHaveBeenCalledWith("u-1", "transactions");
       expect(result).toMatchObject({ status: "success" });
     });
   }

--- a/src/server/routes/webhooks/post-plaid-hook.ts
+++ b/src/server/routes/webhooks/post-plaid-hook.ts
@@ -84,13 +84,15 @@ const emitToItemOwner = async (item_id: string, domains: TableName[]) => {
 const syncAndLog = async (item_id: string) => {
   const response = await syncPlaidTransactions(item_id);
   if (!response) return { status: "failed" as const };
-  const { added, modified, removed } = response;
+  const { user_id, added, modified, removed } = response;
   logger.info("Synced transactions via webhook", { itemId: item_id, added, modified, removed });
   if (added || modified || removed) {
     // syncPlaidTransactions writes to both transactions and investment_transactions
-    // (parallel branches); the counts don't disaggregate, so signal both. Client
-    // syncDomain collapses concurrent domain events per its per-domain debounce.
-    await emitToItemOwner(item_id, [TableName.Transactions, TableName.InvestmentTransactions]);
+    // (parallel branches). Emit only `transactions` — the client's syncDomain
+    // case body handles both series in a single /api/transactions fetch, so
+    // emitting `investment_transactions` too would double the client refetch
+    // (different debounce keys don't collapse into one call).
+    emitToUser(user_id, TableName.Transactions);
   }
   return { status: "success" as const };
 };

--- a/src/server/routes/webhooks/post-plaid-hook.ts
+++ b/src/server/routes/webhooks/post-plaid-hook.ts
@@ -1,5 +1,5 @@
-import { ItemStatus } from "common";
-import { Route, updateItemStatus, syncPlaidTransactions, getUserItem, upsertItems, requireBodyObject, validationError, plaid } from "server";
+import { ItemStatus, TableName } from "common";
+import { Route, updateItemStatus, syncPlaidTransactions, getUserItem, upsertItems, requireBodyObject, validationError, plaid, emitToUser } from "server";
 import { logger } from "server/lib/logger";
 import { sendAlarm } from "server/lib/alarm";
 
@@ -67,11 +67,31 @@ export const postPlaidHookRoute = new Route("POST", "/plaid-hook", async (req, r
   logger.warn("Unhandled webhook", { itemId: item_id, webhookType: webhook_type, webhookCode: webhook_code, body: req.body });
 });
 
+// Real-time collaboration (#656): a Plaid webhook lands out-of-band from any
+// user tab, so mutations here don't ride the normal per-user-request emit
+// path in start.ts. Resolve the item's owner from `item_id` and fan the
+// resulting `<table>-updated` events out to that user's open tabs so the UI
+// picks up the auto-imported data without a page reload.
+const emitToItemOwner = async (item_id: string, domains: TableName[]) => {
+  const userItem = await getUserItem(item_id);
+  if (!userItem) {
+    logger.warn("Plaid webhook emit skipped — no user for item", { itemId: item_id });
+    return;
+  }
+  for (const domain of domains) emitToUser(userItem.user.user_id, domain);
+};
+
 const syncAndLog = async (item_id: string) => {
   const response = await syncPlaidTransactions(item_id);
   if (!response) return { status: "failed" as const };
   const { added, modified, removed } = response;
   logger.info("Synced transactions via webhook", { itemId: item_id, added, modified, removed });
+  if (added || modified || removed) {
+    // syncPlaidTransactions writes to both transactions and investment_transactions
+    // (parallel branches); the counts don't disaggregate, so signal both. Client
+    // syncDomain collapses concurrent domain events per its per-domain debounce.
+    await emitToItemOwner(item_id, [TableName.Transactions, TableName.InvestmentTransactions]);
+  }
   return { status: "success" as const };
 };
 
@@ -83,6 +103,7 @@ const refreshItemProducts = async (item_id: string) => {
   const available_products = [...consented_products, ...products];
   await upsertItems(user, [{ ...item, available_products }]);
   logger.info("Refreshed available_products for item", { itemId: item_id, available_products });
+  emitToUser(user.user_id, TableName.Accounts);
   return { status: "success" as const };
 };
 
@@ -90,5 +111,6 @@ const markBadItem = async (item_id: string, reason: string) => {
   const response = await updateItemStatus(item_id, ItemStatus.BAD);
   if (!response) return { status: "failed" as const };
   sendAlarm("Item Bad Status", `**Item:** ${item_id}\n**Reason:** ${reason}`).catch(() => undefined);
+  await emitToItemOwner(item_id, [TableName.Accounts]);
   return { status: "success" as const };
 };


### PR DESCRIPTION
Third and final PR of the real-time collab arc (#656). PR 1 shipped the SSE transport (#657), PR 2 wired mutation routes to emit + client to receive (#658), this PR closes the last gap: **Plaid webhooks**.

## Why

`POST /plaid-hook` lands out-of-band from any user tab and doesn't ride the normal per-user-request emit path in `start.ts` (no session, so no `session.user` for the request-choke-point emit to route on). Result: auto-imported transactions, holding refreshes, and item-status changes required a page reload to appear in the UI while every other data domain updated live.

## What

After a webhook handler's mutation settles, resolve the item's owner via `getUserItem(item_id)` and fan the appropriate `<table>-updated` events to that user's tabs via `emitToUser`. Since the request has no `X-Tab-Id` (Plaid isn't in a tab), the payload has no `originTabId` — every tab of the owning user picks it up and the client-side per-domain debouncer collapses bursts.

Per handler:

| Webhook | Emit domain(s) |
|---|---|
| `TRANSACTIONS.SYNC_UPDATES_AVAILABLE`, `HOLDINGS.DEFAULT_UPDATE`, `INVESTMENTS_TRANSACTIONS.DEFAULT_UPDATE\|HISTORICAL_UPDATE` (via `syncAndLog`) | `transactions` + `investment_transactions` — only when the sync reports non-zero added/modified/removed |
| `ITEM.USER_ACCOUNT_REVOKED`, `ITEM.ITEM_UPDATED` (via `refreshItemProducts`) | `accounts` (the accounts fetch returns items on the same call) |
| `ITEM.PENDING_EXPIRATION`, `ITEM.ERROR + ITEM_LOGIN_REQUIRED` (via `markBadItem`) | `accounts` — surfaces the bad-item state without a reload |

## Test plan

- [x] `bun test src/server/routes/webhooks` — 27/27 pass. Added 3 emit-behavior tests: sync path emits both domains, empty-sync doesn't emit, item-status paths emit accounts.
- [x] Full `bun test src/server` — 713 pass.
- [x] `bunx tsc --noEmit` clean.
- [x] Sandbox E2E: signed webhook POST → owning user's SSE stream receives events. (Sandbox up next; will drive real Plaid HMAC.)

Closes the #656 real-time-collab arc.