### PR TITLE
refactor(snapshots): read through Table.query instead of raw buildSelectWithFilters bypass

### DIFF
--- a/src/server/lib/compute-tools/backfill-snapshots.test.ts
+++ b/src/server/lib/compute-tools/backfill-snapshots.test.ts
@@ -99,12 +99,29 @@ const makeSecurityRow = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+// `getSecuritySnapshots` now reads through `snapshotsTable.query`, which
+// hydrates each row into a `SnapshotModel` — its typeChecker requires every
+// column present (null is fine, undefined is not), so this returns the full
+// row shape.
 const makeSnapshotRow = (overrides: Record<string, unknown> = {}) => ({
   snapshot_id: "snap-1",
+  user_id: null,
   snapshot_date: "2026-04-15",
   snapshot_type: "security",
+  account_id: null,
+  balances_available: null,
+  balances_current: null,
+  balances_limit: null,
+  balances_iso_currency_code: null,
   security_id: "sec-1",
   close_price: 90,
+  holding_account_id: null,
+  holding_security_id: null,
+  institution_price: null,
+  institution_value: null,
+  cost_basis: null,
+  quantity: null,
+  updated: null,
   is_deleted: false,
   ...overrides,
 });

--- a/src/server/lib/postgres/repositories/snapshots.ts
+++ b/src/server/lib/postgres/repositories/snapshots.ts
@@ -1,5 +1,4 @@
 import { JSONSnapshotData } from "common";
-import { pool } from "../client";
 import {
   MaskedUser,
   SnapshotModel,
@@ -17,9 +16,7 @@ import {
   HOLDING_SECURITY_ID,
   USER_ID,
 } from "../models";
-import { SNAPSHOTS } from "common/constants";
-
-import { UpsertResult, successResult, errorResult, buildSelectWithFilters } from "../database";
+import { UpsertResult, successResult, errorResult } from "../database";
 import { searchSecuritiesById } from "./securities";
 import { logger } from "../../logger";
 
@@ -57,18 +54,15 @@ export interface HoldingSnapshot {
   quantity?: number;
 }
 
-const rowToSnapshot = (row: Record<string, unknown>): JSONSnapshotData =>
-  new SnapshotModel(row).toJSON();
-
 // Security snapshots are price data — stored with `user_id = NULL` because
 // they're shared across all users. The user-scoped query below would
 // otherwise exclude them by the `user_id = $1` filter, leaving the frontend
 // unable to resolve `security_id → ticker_symbol` (Closes #323).
 //
-// Two queries instead of one: the user-scoped table-helper path doesn't
-// support an OR predicate, and a raw SQL rewrite of the whole search would
-// duplicate the date-range / inFilters logic that `buildSelectWithFilters`
-// already encodes. Two helper calls + concat is the smaller change.
+// Two queries instead of one: `snapshotsTable.query` filters by a single
+// `user_id`, so it can't express the `user_id = $1 OR user_id IS NULL` union
+// that surfacing shared security rows alongside the user's own requires.
+// Two scoped `.query` calls + concat is the smaller change.
 export const searchSnapshots = async (
   user: MaskedUser | null,
   options: SearchSnapshotsOptions = {},
@@ -85,20 +79,21 @@ export const searchSnapshots = async (
       ? { column: UPDATED, start: options.startDate, end: options.endDate }
       : undefined;
 
-  const userScoped = buildSelectWithFilters(SNAPSHOTS, "*", {
-    user_id: user?.user_id,
-    filters: {
+  const userSnapshots = await snapshotsTable.query(
+    {
       [SNAPSHOT_TYPE]: options.snapshot_type,
       [ACCOUNT_ID]: options.account_id,
       [SECURITY_ID]: options.security_id,
     },
-    inFilters: options.account_ids?.length ? { [ACCOUNT_ID]: options.account_ids } : undefined,
-    dateRange,
-    orderBy: `${SNAPSHOT_DATE} DESC`,
-    limit: options.limit,
-    excludeDeleted: !options.includeDeleted,
-  });
-  const userResult = await pool.query<Record<string, unknown>>(userScoped.sql, userScoped.values);
+    {
+      user_id: user?.user_id,
+      inFilters: options.account_ids?.length ? { [ACCOUNT_ID]: options.account_ids } : undefined,
+      dateRange,
+      orderBy: `${SNAPSHOT_DATE} DESC`,
+      limit: options.limit,
+      excludeDeleted: !options.includeDeleted,
+    },
+  );
 
   // Holding snapshots store the account in `holding_account_id` and leave
   // `account_id` NULL — so the `account_id`-filtered query above never
@@ -116,11 +111,10 @@ export const searchSnapshots = async (
   const wantsHoldingByAccount =
     (!options.snapshot_type || options.snapshot_type === "holding") &&
     (options.account_id || options.account_ids?.length);
-  const holdingByAccountRows: Record<string, unknown>[] = [];
+  const holdingByAccountSnapshots: SnapshotModel[] = [];
   if (wantsHoldingByAccount) {
-    const holdingScoped = buildSelectWithFilters(SNAPSHOTS, "*", {
-      user_id: user?.user_id,
-      filters: {
+    const holdingSnapshots = await snapshotsTable.query(
+      {
         [SNAPSHOT_TYPE]: "holding",
         [HOLDING_ACCOUNT_ID]: options.account_id,
         // Holding rows store the security in `holding_security_id`; the
@@ -129,19 +123,18 @@ export const searchSnapshots = async (
         // passes both `account_id` and `security_id`).
         [HOLDING_SECURITY_ID]: options.security_id,
       },
-      inFilters: options.account_ids?.length
-        ? { [HOLDING_ACCOUNT_ID]: options.account_ids }
-        : undefined,
-      dateRange,
-      orderBy: `${SNAPSHOT_DATE} DESC`,
-      limit: options.limit,
-      excludeDeleted: !options.includeDeleted,
-    });
-    const holdingResult = await pool.query<Record<string, unknown>>(
-      holdingScoped.sql,
-      holdingScoped.values,
+      {
+        user_id: user?.user_id,
+        inFilters: options.account_ids?.length
+          ? { [HOLDING_ACCOUNT_ID]: options.account_ids }
+          : undefined,
+        dateRange,
+        orderBy: `${SNAPSHOT_DATE} DESC`,
+        limit: options.limit,
+        excludeDeleted: !options.includeDeleted,
+      },
     );
-    holdingByAccountRows.push(...holdingResult.rows);
+    holdingByAccountSnapshots.push(...holdingSnapshots);
   }
 
   // Security snapshots only make sense when the caller isn't narrowing to a
@@ -152,22 +145,20 @@ export const searchSnapshots = async (
     !options.account_id &&
     !options.account_ids?.length;
   if (!wantsSecurity) {
-    return [...userResult.rows, ...holdingByAccountRows].map(rowToSnapshot);
+    return [...userSnapshots, ...holdingByAccountSnapshots].map((s) => s.toJSON());
   }
 
-  const globalSecurity = buildSelectWithFilters(SNAPSHOTS, "*", {
-    filters: {
+  const securitySnapshots = await snapshotsTable.query(
+    {
       [SNAPSHOT_TYPE]: "security",
       [SECURITY_ID]: options.security_id,
     },
-    dateRange,
-    orderBy: `${SNAPSHOT_DATE} DESC`,
-    limit: options.limit,
-    excludeDeleted: !options.includeDeleted,
-  });
-  const securityResult = await pool.query<Record<string, unknown>>(
-    globalSecurity.sql,
-    globalSecurity.values,
+    {
+      dateRange,
+      orderBy: `${SNAPSHOT_DATE} DESC`,
+      limit: options.limit,
+      excludeDeleted: !options.includeDeleted,
+    },
   );
 
   // Enrich each security snapshot with ticker_symbol / name / type from the
@@ -176,13 +167,13 @@ export const searchSnapshots = async (
   // still couldn't resolve `security_id → ticker`. Same enrichment pattern
   // as `getHoldingSnapshotsRoute`.
   const uniqueSecurityIds = [
-    ...new Set(securityResult.rows.map((r) => r.security_id as string).filter(Boolean)),
+    ...new Set(securitySnapshots.map((s) => s.security_id as string).filter(Boolean)),
   ];
   const securities = uniqueSecurityIds.length ? await searchSecuritiesById(uniqueSecurityIds) : [];
   const securityMap = new Map(securities.map((s) => [s.security_id, s]));
 
-  const enrichedSecuritySnapshots = securityResult.rows.map((row) => {
-    const snap = rowToSnapshot(row);
+  const enrichedSecuritySnapshots = securitySnapshots.map((model) => {
+    const snap = model.toJSON();
     if (!isSecuritySnapshot(snap)) return snap;
     const sec = securityMap.get(snap.security.security_id);
     if (sec) {
@@ -195,8 +186,8 @@ export const searchSnapshots = async (
   });
 
   return [
-    ...userResult.rows.map(rowToSnapshot),
-    ...holdingByAccountRows.map(rowToSnapshot),
+    ...userSnapshots.map((s) => s.toJSON()),
+    ...holdingByAccountSnapshots.map((s) => s.toJSON()),
     ...enrichedSecuritySnapshots,
   ];
 };
@@ -204,21 +195,22 @@ export const searchSnapshots = async (
 export const getSecuritySnapshots = async (
   options: { security_id?: string; startDate?: string; endDate?: string } = {},
 ): Promise<SecuritySnapshot[]> => {
-  const { sql, values } = buildSelectWithFilters(SNAPSHOTS, "*", {
-    filters: { [SNAPSHOT_TYPE]: "security", [SECURITY_ID]: options.security_id },
-    dateRange:
-      options.startDate || options.endDate
-        ? { column: SNAPSHOT_DATE, start: options.startDate, end: options.endDate }
-        : undefined,
-    orderBy: SNAPSHOT_DATE,
-  });
-  const result = await pool.query<Record<string, unknown>>(sql, values);
+  const snapshots = await snapshotsTable.query(
+    { [SNAPSHOT_TYPE]: "security", [SECURITY_ID]: options.security_id },
+    {
+      dateRange:
+        options.startDate || options.endDate
+          ? { column: SNAPSHOT_DATE, start: options.startDate, end: options.endDate }
+          : undefined,
+      orderBy: SNAPSHOT_DATE,
+    },
+  );
 
-  return result.rows.map((row) => ({
-    snapshot_id: row.snapshot_id as string,
-    snapshot_date: String(row.snapshot_date),
-    security_id: row.security_id as string,
-    close_price: row.close_price != null ? Number(row.close_price) : undefined,
+  return snapshots.map((s) => ({
+    snapshot_id: s.snapshot_id,
+    snapshot_date: String(s.snapshot_date),
+    security_id: s.security_id as string,
+    close_price: s.close_price != null ? Number(s.close_price) : undefined,
   }));
 };
 
@@ -230,26 +222,24 @@ export const getHoldingSnapshots = async (
   if (options.account_id) filters.holding_account_id = options.account_id;
   if (options.security_id) filters.holding_security_id = options.security_id;
 
-  const { sql, values } = buildSelectWithFilters(SNAPSHOTS, "*", {
+  const snapshots = await snapshotsTable.query(filters, {
     user_id: user.user_id,
-    filters,
     dateRange:
       options.startDate || options.endDate
         ? { column: SNAPSHOT_DATE, start: options.startDate, end: options.endDate }
         : undefined,
     orderBy: SNAPSHOT_DATE,
   });
-  const result = await pool.query<Record<string, unknown>>(sql, values);
 
-  return result.rows.map((row) => ({
-    snapshot_id: row.snapshot_id as string,
-    snapshot_date: String(row.snapshot_date),
-    holding_account_id: row.holding_account_id as string,
-    holding_security_id: row.holding_security_id as string,
-    institution_price: row.institution_price != null ? Number(row.institution_price) : undefined,
-    institution_value: row.institution_value != null ? Number(row.institution_value) : undefined,
-    cost_basis: row.cost_basis != null ? Number(row.cost_basis) : undefined,
-    quantity: row.quantity != null ? Number(row.quantity) : undefined,
+  return snapshots.map((s) => ({
+    snapshot_id: s.snapshot_id,
+    snapshot_date: String(s.snapshot_date),
+    holding_account_id: s.holding_account_id as string,
+    holding_security_id: s.holding_security_id as string,
+    institution_price: s.institution_price != null ? Number(s.institution_price) : undefined,
+    institution_value: s.institution_value != null ? Number(s.institution_value) : undefined,
+    cost_basis: s.cost_basis != null ? Number(s.cost_basis) : undefined,
+    quantity: s.quantity != null ? Number(s.quantity) : undefined,
   }));
 };
 

--- a/src/server/routes/accounts/delete-holding-snapshot.test.ts
+++ b/src/server/routes/accounts/delete-holding-snapshot.test.ts
@@ -70,15 +70,29 @@ const fakeRes = () =>
  * `getHoldingSnapshots` does on the snapshots SELECT. Only the columns
  * the ownership-check actually consumes need to be present.
  */
+// Reads now flow through `snapshotsTable.query`, which hydrates each row into
+// a `SnapshotModel` — its typeChecker requires every column present (null is
+// fine, undefined is not), so this returns the full row shape.
 const snapshotRow = (overrides: Record<string, unknown> = {}) => ({
   snapshot_id: "snap-1",
+  user_id: null,
   snapshot_date: "2026-05-14",
+  snapshot_type: "holding",
+  account_id: null,
+  balances_available: null,
+  balances_current: null,
+  balances_limit: null,
+  balances_iso_currency_code: null,
+  security_id: null,
+  close_price: null,
   holding_account_id: "acc-1",
   holding_security_id: "sec-1",
-  institution_price: "12.50",
-  institution_value: "125.00",
-  cost_basis: "100.00",
-  quantity: "10",
+  institution_price: 12.5,
+  institution_value: 125,
+  cost_basis: 100,
+  quantity: 10,
+  updated: null,
+  is_deleted: false,
   ...overrides,
 });
 

--- a/src/server/routes/accounts/delete-holding-snapshot.test.ts
+++ b/src/server/routes/accounts/delete-holding-snapshot.test.ts
@@ -66,13 +66,11 @@ const fakeRes = () =>
   }) as unknown as Parameters<typeof deleteHoldingSnapshotRoute.execute>[1];
 
 /**
- * A canned holding-snapshot row matching the projection the route's
- * `getHoldingSnapshots` does on the snapshots SELECT. Only the columns
- * the ownership-check actually consumes need to be present.
+ * A canned holding-snapshot row for the route's `getHoldingSnapshots`
+ * ownership-check. Reads flow through `snapshotsTable.query`, which hydrates
+ * each row into a `SnapshotModel` — its typeChecker requires every column
+ * present (null is fine, undefined is not), so this returns the full row shape.
  */
-// Reads now flow through `snapshotsTable.query`, which hydrates each row into
-// a `SnapshotModel` — its typeChecker requires every column present (null is
-// fine, undefined is not), so this returns the full row shape.
 const snapshotRow = (overrides: Record<string, unknown> = {}) => ({
   snapshot_id: "snap-1",
   user_id: null,

--- a/src/server/routes/accounts/get-holding-snapshots.test.ts
+++ b/src/server/routes/accounts/get-holding-snapshots.test.ts
@@ -67,15 +67,29 @@ const fakeRes = () =>
     end() {},
   }) as unknown as Parameters<typeof getHoldingSnapshotsRoute.execute>[1];
 
+// Reads now flow through `snapshotsTable.query`, which hydrates each row into
+// a `SnapshotModel` — its typeChecker requires every column present (null is
+// fine, undefined is not), so this returns the full row shape.
 const snapshotRow = (overrides: Record<string, unknown> = {}) => ({
   snapshot_id: "snap-1",
+  user_id: null,
   snapshot_date: "2026-05-14",
+  snapshot_type: "holding",
+  account_id: null,
+  balances_available: null,
+  balances_current: null,
+  balances_limit: null,
+  balances_iso_currency_code: null,
+  security_id: null,
+  close_price: null,
   holding_account_id: "acc-1",
   holding_security_id: "sec-1",
-  institution_price: "12.50",
-  institution_value: "125.00",
-  cost_basis: "100.00",
-  quantity: "10",
+  institution_price: 12.5,
+  institution_value: 125,
+  cost_basis: 100,
+  quantity: 10,
+  updated: null,
+  is_deleted: false,
   ...overrides,
 });
 

--- a/src/server/routes/accounts/post-holding-snapshot.success.test.ts
+++ b/src/server/routes/accounts/post-holding-snapshot.success.test.ts
@@ -117,15 +117,30 @@ const existingSecurityRow = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+// `getHoldingSnapshots` (the ownership gate) now reads through
+// `snapshotsTable.query`, which hydrates each row into a `SnapshotModel` — its
+// typeChecker requires every column present (null is fine, undefined is not),
+// so this returns the full row shape.
 const holdingSnapshotRow = (overrides: Record<string, unknown> = {}) => ({
   snapshot_id: "snap-1",
+  user_id: null,
   snapshot_date: "2024-03-15",
+  snapshot_type: "holding",
+  account_id: null,
+  balances_available: null,
+  balances_current: null,
+  balances_limit: null,
+  balances_iso_currency_code: null,
+  security_id: null,
+  close_price: null,
   holding_account_id: "acct-1",
   holding_security_id: "sec-1",
   quantity: 10,
   cost_basis: 1000,
   institution_price: 110,
   institution_value: 1100,
+  updated: null,
+  is_deleted: false,
   ...overrides,
 });
 

--- a/src/server/routes/accounts/post-resolve-security-snapshot.test.ts
+++ b/src/server/routes/accounts/post-resolve-security-snapshot.test.ts
@@ -137,12 +137,30 @@ const securityRow = (overrides: Partial<JSONSecurity> = {}) => ({
   ...overrides,
 });
 
+// `getSecuritySnapshots` now reads through `snapshotsTable.query`, which
+// hydrates each row into a `SnapshotModel` — its typeChecker requires every
+// column present (null is fine, undefined is not), so this returns the full
+// row shape.
 const snapshotRow = (overrides: Record<string, unknown> = {}) => ({
   snapshot_id: "snap-existing",
+  user_id: null,
   snapshot_date: "2026-05-10",
   snapshot_type: "security",
+  account_id: null,
+  balances_available: null,
+  balances_current: null,
+  balances_limit: null,
+  balances_iso_currency_code: null,
   security_id: "sec-1",
   close_price: 100,
+  holding_account_id: null,
+  holding_security_id: null,
+  institution_price: null,
+  institution_value: null,
+  cost_basis: null,
+  quantity: null,
+  updated: null,
+  is_deleted: false,
   ...overrides,
 });
 


### PR DESCRIPTION
## What

`snapshots.ts` was the **lone repository** hand-rolling `buildSelectWithFilters(...)` + `pool.query(...)` + manual row re-hydration for reads, while every other repo funnels reads through the canonical `Table.query` Model method (`transactions.ts`, `accounts.ts`, …). This migrates the five read call sites onto `snapshotsTable.query`.

Closes #580. [Principle 2 — one canonical way] / the extend-Table-methods-over-bypass pattern.

## Why it's behavior-preserving

`Table.query(filters, options)` already **delegates to the exact same `buildSelectWithFilters`** and accepts every option these call sites pass — `user_id`, `filters`, `inFilters`, `dateRange`, `orderBy`, `limit`, `excludeDeleted`. So the emitted SQL is byte-identical; the bypass bought nothing.

- **`excludeDeleted` default matches.** The builder defaults `excludeDeleted = true`; `Table.query` defaults it to `this.supportsSoftDelete` (= `true` for snapshots). The two `get*` sites that previously omitted the flag keep excluding soft-deleted rows.
- **Returned shapes preserved.** `getSecuritySnapshots` / `getHoldingSnapshots` still project to their custom `SecuritySnapshot` / `HoldingSnapshot` shapes; `searchSnapshots` still returns `JSONSnapshotData[]` via `model.toJSON()`.
- **`searchSnapshots`' two-query split stays.** A single `user_id` filter can't express the `user_id = $1 OR user_id IS NULL` union that surfacing shared (user_id NULL) security-price rows requires — so it stays three scoped `.query` calls + concat, same as before. The `rowToSnapshot` shim is retired in favor of `model.toJSON()`.

## Reads now hydrate `SnapshotModel`

`Table.query` constructs+validates a `SnapshotModel` per row — which `searchSnapshots` already did in production via `rowToSnapshot`, so this is not new behavior on real data. Production is safe because `client.ts` parses `NUMERIC`/`INT8` → `number` (via `parseFloat`) and `SELECT *` returns every column, so the model always validates.

The route / compute-tool **test mocks** were feeding partial rows with string numerics (an artifact of the old manual-`Number()` projection). They now return the **full row shape with numeric types** — matching what production pg yields — exactly as the existing `securityRow` factory already documents.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` (whole tree) — clean
- [x] `bun test src` — 1128 pass / 0 fail / 2 skip (route + compute-tool snapshot suites retargeted to full-row mocks)
- [x] **UI E2E** — sandbox, mobile 390×844, admin login, PNGs eye-checked:
  - `/accounts` — 19 account rows render with balances + per-row balance graphs (23 canvases); `/api/snapshots` (searchSnapshots) fires 200. No console errors.
  - `/account-detail` for an **investment (Stock Plan)** account, real `.AccountRow` click:
    - **Balance graph** (Use Snapshots ON) draws the historical line — fed by the account-narrowed `/api/snapshots?…` (searchSnapshots holding branch). 200.
    - **Holdings Composition** table populates: priced security row with **ticker + name resolved** (proves the security-snapshot enrichment path in `searchSnapshots`), an `Unknown` row, and a `Total` row.
    - **Performance widget** computes: `Your asset return (MWR)`, `<index> benchmark`, and `Diff` rows all render — the snapshot-anchored MWR/benchmark math is intact.
    - 0 non-SW console errors.
  - Values are unchanged from `upstream/main` by construction: `Table.query` delegates to the identical `buildSelectWithFilters` with the same options, so the emitted SQL is byte-for-byte the same as the removed bypass. `getSecuritySnapshots` feeds server-side compute tools (backfill / resolve-security) not directly reachable through the UI on a scrambled clone — its shape is pinned by the retargeted unit suites.
