### PR TITLE
fix(labels): re-sync <select> state when underlying label prop changes

### DIFF
--- a/src/client/components/InvestmentTransactionProperties/index.tsx
+++ b/src/client/components/InvestmentTransactionProperties/index.tsx
@@ -61,11 +61,6 @@ export const InvestmentTransactionProperties = ({ investmentTransaction }: Props
     categoryOptions,
   } = useBudgetCategorySelect(label, account, `investment_transaction_${investment_transaction_id}`);
 
-  useEffect(() => {
-    setSelectedBudgetIdLabel(label.budget_id || account?.label.budget_id || "");
-    setSelectedCategoryIdLabel(label.category_id || "");
-  }, [label, account, setSelectedBudgetIdLabel, setSelectedCategoryIdLabel]);
-
   const onChangeBudgetSelect: ChangeEventHandler<HTMLSelectElement> = async (e) => {
     const { value } = e.target;
     if (value === selectedBudgetIdLabel) return;

--- a/src/client/components/TransactionProperties/SplitTransactionRow.tsx
+++ b/src/client/components/TransactionProperties/SplitTransactionRow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, ChangeEventHandler } from "react";
+import { ChangeEventHandler } from "react";
 import { currencyCodeToSymbol } from "common";
 import {
   TransactionLabel,
@@ -38,11 +38,6 @@ const SplitTransactionRow = ({ splitTransaction }: Props) => {
     budgetOptions,
     categoryOptions,
   } = useBudgetCategorySelect(label, account, `split_transaction_${split_transaction_id}`);
-
-  useEffect(() => {
-    if (label.budget_id) return;
-    setSelectedBudgetIdLabel(account?.label.budget_id || "");
-  }, [label.budget_id, account?.label.budget_id, setSelectedBudgetIdLabel]);
 
   const onChangeBudgetSelect: ChangeEventHandler<HTMLSelectElement> = async (e) => {
     const { value } = e.target;

--- a/src/client/components/TransactionProperties/index.tsx
+++ b/src/client/components/TransactionProperties/index.tsx
@@ -77,11 +77,6 @@ export const TransactionProperties = ({ transaction }: Props) => {
     categoryOptions,
   } = useBudgetCategorySelect(label, account, `transaction_${transaction_id}`);
 
-  useEffect(() => {
-    setSelectedBudgetIdLabel(label.budget_id || account?.label.budget_id || "");
-    setSelectedCategoryIdLabel(label.category_id || "");
-  }, [label, account, setSelectedBudgetIdLabel, setSelectedCategoryIdLabel]);
-
   const onChangeBudgetSelect: ChangeEventHandler<HTMLSelectElement> = async (e) => {
     const { value } = e.target;
     if (value === selectedBudgetIdLabel) return;

--- a/src/client/components/TransactionsTable/TransactionRow.tsx
+++ b/src/client/components/TransactionsTable/TransactionRow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, ChangeEventHandler, MouseEventHandler } from "react";
+import { ChangeEventHandler, MouseEventHandler } from "react";
 import {
   useAppContext,
   useBudgetCategorySelect,
@@ -57,11 +57,6 @@ const TransactionRow = ({ transaction }: Props) => {
     : isSuggested
       ? "suggested"
       : "";
-
-  useEffect(() => {
-    if (label.budget_id) return;
-    setSelectedBudgetIdLabel(account?.label.budget_id || "");
-  }, [label.budget_id, account?.label.budget_id, setSelectedBudgetIdLabel]);
 
   const isSplitTransaction = transaction instanceof SplitTransaction;
 

--- a/src/client/lib/hooks/useBudgetCategorySelect.tsx
+++ b/src/client/lib/hooks/useBudgetCategorySelect.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Account, Category, TransactionLabel, useAppContext } from "client";
 
 export interface BudgetCategorySelect {
@@ -44,6 +44,31 @@ export const useBudgetCategorySelect = (
   const [selectedCategoryIdLabel, setSelectedCategoryIdLabel] = useState(() => {
     return label.category_id || "";
   });
+
+  // Keep local <select> state in lockstep with the underlying label the hook
+  // was called with. Without these effects the initial `useState` lazy
+  // initializers snapshot the label at mount and never re-read — an
+  // external update to the transaction (another tab via the #656 SSE
+  // fanout, a background sync-plaid write, a suggestion-engine pass)
+  // updates the underlying `data.transactions[id].label` but the
+  // component's rendered <select> keeps displaying the stale mount-time
+  // value until a page refresh remounts the row.
+  //
+  // React's `useState` does not "watch" its initial-value argument — the
+  // lazy initializer is invoked exactly once per mount. Effects are the
+  // documented shape for prop-driven derived state (React docs:
+  // "You Might Not Need an Effect" > "Adjusting some state when a prop
+  // changes"). If the user has typed a not-yet-submitted change into the
+  // <select>, an external prop change WILL clobber it — the on-change
+  // handlers submit synchronously so the pending window is a few ms; the
+  // trade-off matches `TransactionProperties.tsx`'s existing memo-sync
+  // shape (`useEffect(() => setMemoValue(label.memo ?? ""), [tx_id, label.memo])`).
+  useEffect(() => {
+    setSelectedBudgetIdLabel(label.budget_id || account?.label.budget_id || "");
+  }, [label.budget_id, account?.label.budget_id]);
+  useEffect(() => {
+    setSelectedCategoryIdLabel(label.category_id || "");
+  }, [label.category_id]);
 
   const budgetOptions = useMemo(() => {
     const components: JSX.Element[] = [];


### PR DESCRIPTION
Follows up your two-tab test in `#Budget label sync bug` — the SSE fanout from #656/#657/#658/#659 reaches tab 2's IDB and `data.transactions[id].label` in ~250 ms, but tab 2's rendered category / budget \`<select>\` keeps displaying the mount-time value until a full page refresh.

## Root cause

`useBudgetCategorySelect`:

```tsx
const [selectedBudgetIdLabel, setSelectedBudgetIdLabel] = useState(
  () => label.budget_id || account?.label.budget_id || "",
);
const [selectedCategoryIdLabel, setSelectedCategoryIdLabel] = useState(
  () => label.category_id || "",
);
```

React's `useState` lazy initializer runs **exactly once per mount**. It doesn't watch its argument, so subsequent prop changes to `label.*` never re-hydrate the local state. The controlled `<select>` ends up shadowing the data layer indefinitely.

The `TransactionRow` had a partial escape (`useEffect` set `selectedBudgetIdLabel` to the account default only when `label.budget_id` was falsy), and `TransactionProperties` had a full sync effect at its own layer — but no consumer had a category sync, so the row-level category dropdown stayed stale under any external label update (SSE fanout, background sync-plaid pending→posted reconciliation, suggestion-engine pass).

## Fix

Sync-on-prop-change effects INSIDE the hook so every consumer gets it for free — the pattern React docs recommend for prop-derived state ("You Might Not Need an Effect" § "Adjusting some state when a prop changes"). Matches the memo-sync shape `TransactionProperties.tsx` already uses for `memoValue` (`useEffect(() => setMemoValue(label.memo ?? ""), [tx_id, label.memo])`).

```tsx
useEffect(() => {
  setSelectedBudgetIdLabel(label.budget_id || account?.label.budget_id || "");
}, [label.budget_id, account?.label.budget_id]);
useEffect(() => {
  setSelectedCategoryIdLabel(label.category_id || "");
}, [label.category_id]);
```

Trade-off: if the user has typed a not-yet-submitted change into the `<select>`, an external prop change clobbers it. Acceptable — the on-change handlers submit synchronously so the pending window is a few ms.

Affects every consumer of the hook:
- `TransactionRow` (transactions table)
- `TransactionProperties` (transaction detail panel)
- `InvestmentTransactionRow` / `InvestmentTransactionProperties`
- `SplitTransactionRow` inside the split editor

## Verification

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/client` → 353/0 across 18 files
- [x] Two-tab E2E against `localhost:20999` sandbox on this branch — tab 2's IDB reflects the tab 1 category-post label mutation in ~250 ms (unchanged from pre-fix; the SSE pipeline was already fine)
- [ ] **Real two-tab UI test** (your repro from this thread) is the authoritative sign-off — my Playwright E2E kept picking transactions that landed outside tab 2's TransactionsPage default filter, so the specific row's `<select>` wasn't in the DOM to observe

## Sandbox

Sandbox 999 (this branch) is up at the usual URL if you want to hit the row-dropdown repro end-to-end.