### PR TITLE
refactor(client): extract <ButtonRow> — action-row primitive (#326 phase 5j)

### DIFF
--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -28,6 +28,7 @@ import {
   Properties,
   Property,
   PropertyLabel,
+  ButtonRow,
   Row,
   ToggleInput,
 } from "client/components";
@@ -256,31 +257,23 @@ export const AccountProperties = ({ account }: Props) => {
           <PropertyLabel>Add</PropertyLabel>
           <Property>
             {isManualAccount && type !== AccountType.Investment && (
-              <Row className="button">
-                <button onClick={onClickAddTransaction}>Add&nbsp;Transaction</button>
-              </Row>
+              <ButtonRow onClick={onClickAddTransaction}>Add&nbsp;Transaction</ButtonRow>
             )}
             {type === AccountType.Investment && (
-              <Row className="button">
-                <button onClick={onClickAddInvestmentTransaction}>
-                  Add&nbsp;Investment&nbsp;Transaction
-                </button>
-              </Row>
+              <ButtonRow onClick={onClickAddInvestmentTransaction}>
+                Add&nbsp;Investment&nbsp;Transaction
+              </ButtonRow>
             )}
           </Property>
         </>
       )}
       <PropertyLabel>Navigate</PropertyLabel>
       <Property>
-        <Row className="button">
-          <button onClick={onClickConnectionDetail}>See&nbsp;Connection&nbsp;Details</button>
-        </Row>
+        <ButtonRow onClick={onClickConnectionDetail}>See&nbsp;Connection&nbsp;Details</ButtonRow>
         {screenType === ScreenType.Narrow && (
-          <Row className="button">
-            <button className="propertyName" onClick={onClickTransactions}>
-              See&nbsp;Transactions
-            </button>
-          </Row>
+          <ButtonRow className="propertyName" onClick={onClickTransactions}>
+            See&nbsp;Transactions
+          </ButtonRow>
         )}
       </Property>
       {isManualAccount && (

--- a/src/client/components/AccountProperties/index.tsx
+++ b/src/client/components/AccountProperties/index.tsx
@@ -271,9 +271,7 @@ export const AccountProperties = ({ account }: Props) => {
       <Property>
         <ButtonRow onClick={onClickConnectionDetail}>See&nbsp;Connection&nbsp;Details</ButtonRow>
         {screenType === ScreenType.Narrow && (
-          <ButtonRow className="propertyName" onClick={onClickTransactions}>
-            See&nbsp;Transactions
-          </ButtonRow>
+          <ButtonRow onClick={onClickTransactions}>See&nbsp;Transactions</ButtonRow>
         )}
       </Property>
       {isManualAccount && (

--- a/src/client/components/ApiKeyProperties/index.tsx
+++ b/src/client/components/ApiKeyProperties/index.tsx
@@ -8,6 +8,7 @@ import {
   Properties,
   Property,
   PropertyLabel,
+  ButtonRow,
   Row,
   useAppContext,
 } from "client";
@@ -122,16 +123,12 @@ export const ApiKeyProperties = () => {
         </Property>
         <PropertyLabel>&nbsp;</PropertyLabel>
         <Property>
-          <Row className="button">
-            <button type="button" className="colored" onClick={onCopy}>
-              Copy&nbsp;to&nbsp;clipboard
-            </button>
-          </Row>
-          <Row className="button">
-            <button type="button" onClick={onSavedConfirm}>
-              I&rsquo;ve&nbsp;saved&nbsp;it
-            </button>
-          </Row>
+          <ButtonRow type="button" className="colored" onClick={onCopy}>
+            Copy&nbsp;to&nbsp;clipboard
+          </ButtonRow>
+          <ButtonRow type="button" onClick={onSavedConfirm}>
+            I&rsquo;ve&nbsp;saved&nbsp;it
+          </ButtonRow>
         </Property>
       </Properties>
     );
@@ -170,21 +167,17 @@ export const ApiKeyProperties = () => {
         </Property>
         <PropertyLabel>&nbsp;</PropertyLabel>
         <Property>
-          <Row className="button">
-            <button
-              type="button"
-              className="colored"
-              onClick={onCreate}
-              disabled={creating || !name.trim()}
-            >
-              {creating ? "Creating…" : "Create Key"}
-            </button>
-          </Row>
-          <Row className="button">
-            <button type="button" onClick={goBack}>
-              Cancel
-            </button>
-          </Row>
+          <ButtonRow
+            type="button"
+            className="colored"
+            onClick={onCreate}
+            disabled={creating || !name.trim()}
+          >
+            {creating ? "Creating…" : "Create Key"}
+          </ButtonRow>
+          <ButtonRow type="button" onClick={goBack}>
+            Cancel
+          </ButtonRow>
         </Property>
       </Properties>
     );
@@ -216,11 +209,9 @@ export const ApiKeyProperties = () => {
         </Property>
         <PropertyLabel>&nbsp;</PropertyLabel>
         <Property>
-          <Row className="button">
-            <button type="button" onClick={goBack}>
-              Back
-            </button>
-          </Row>
+          <ButtonRow type="button" onClick={goBack}>
+            Back
+          </ButtonRow>
         </Property>
       </Properties>
     );
@@ -262,11 +253,9 @@ export const ApiKeyProperties = () => {
             Revoke
           </DeleteButton>
         </Row>
-        <Row className="button">
-          <button type="button" onClick={goBack}>
-            Back
-          </button>
-        </Row>
+        <ButtonRow type="button" onClick={goBack}>
+          Back
+        </ButtonRow>
       </Property>
     </Properties>
   );

--- a/src/client/components/ApiKeyProperties/index.tsx
+++ b/src/client/components/ApiKeyProperties/index.tsx
@@ -123,7 +123,7 @@ export const ApiKeyProperties = () => {
         </Property>
         <PropertyLabel>&nbsp;</PropertyLabel>
         <Property>
-          <ButtonRow type="button" className="colored" onClick={onCopy}>
+          <ButtonRow type="button" buttonClassName="colored" onClick={onCopy}>
             Copy&nbsp;to&nbsp;clipboard
           </ButtonRow>
           <ButtonRow type="button" onClick={onSavedConfirm}>
@@ -169,7 +169,7 @@ export const ApiKeyProperties = () => {
         <Property>
           <ButtonRow
             type="button"
-            className="colored"
+            buttonClassName="colored"
             onClick={onCreate}
             disabled={creating || !name.trim()}
           >

--- a/src/client/components/BalanceChartProperties.tsx
+++ b/src/client/components/BalanceChartProperties.tsx
@@ -12,6 +12,7 @@ import {
   Properties,
   PropertyLabel,
   Property,
+  ButtonRow,
   Row,
   KeyValue,
 } from "client";
@@ -91,11 +92,9 @@ export const BalanceChartProperties = ({ chart, children }: BalanceChartProperti
 
       <PropertyLabel>Selected&nbsp;Accounts&nbsp;&&nbsp;Budgets</PropertyLabel>
       <Property>
-        <Row className="button">
-          <button onClick={onClickAccounts}>
-            {selectedAccountsCount + selectedBudgetsCount}&nbsp;selected
-          </button>
-        </Row>
+        <ButtonRow onClick={onClickAccounts}>
+          {selectedAccountsCount + selectedBudgetsCount}&nbsp;selected
+        </ButtonRow>
       </Property>
 
       {children}

--- a/src/client/components/BudgetProperties/CapacitiesInput/index.tsx
+++ b/src/client/components/BudgetProperties/CapacitiesInput/index.tsx
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction, ChangeEventHandler, useRef, useEffect } from 
 import { LocalDate, ViewDate, currencyCodeToSymbol, getDateString } from "common";
 import { Budget, Capacity, CapacityData, sortCapacities, useAppContext } from "client";
 import { BudgetFamily } from "client/lib/models/BudgetFamily";
-import { CapacityInput, Row } from "client/components";
+import { CapacityInput, ButtonRow, Row } from "client/components";
 import BudgetDonut from "./BudgetDonut";
 import "./index.css";
 
@@ -156,9 +156,7 @@ const CapacitiesInput = ({
 
   return (
     <div className="CapacitiesInput">
-      <Row className="button">
-        <button onClick={onClickAdd}>Add&nbsp;New&nbsp;Period</button>
-      </Row>
+      <ButtonRow onClick={onClickAdd}>Add&nbsp;New&nbsp;Period</ButtonRow>
       {rows}
     </div>
   );

--- a/src/client/components/Configuration/ApiKeysSection.tsx
+++ b/src/client/components/Configuration/ApiKeysSection.tsx
@@ -6,6 +6,7 @@ import {
   useAppContext,
   PropertyLabel,
   Property,
+  ButtonRow,
   Row,
 } from "client";
 
@@ -66,20 +67,16 @@ export const ApiKeysSection = () => {
           </Row>
         )}
         {keys.map((k) => (
-          <Row className="button" key={k.key_id}>
-            <button className="connection" onClick={() => goToKey(k.key_id)}>
-              <div>
-                <span>{k.name}</span>
-                <span className="small">&nbsp;&nbsp;{k.key_prefix}…</span>
-              </div>
-            </button>
-          </Row>
+          <ButtonRow key={k.key_id} className="connection" onClick={() => goToKey(k.key_id)}>
+            <div>
+              <span>{k.name}</span>
+              <span className="small">&nbsp;&nbsp;{k.key_prefix}…</span>
+            </div>
+          </ButtonRow>
         ))}
-        <Row className="button">
-          <button type="button" onClick={goToNewKey}>
-            Add
-          </button>
-        </Row>
+        <ButtonRow type="button" onClick={goToNewKey}>
+          Add
+        </ButtonRow>
       </Property>
     </>
   );

--- a/src/client/components/Configuration/ApiKeysSection.tsx
+++ b/src/client/components/Configuration/ApiKeysSection.tsx
@@ -67,7 +67,7 @@ export const ApiKeysSection = () => {
           </Row>
         )}
         {keys.map((k) => (
-          <ButtonRow key={k.key_id} className="connection" onClick={() => goToKey(k.key_id)}>
+          <ButtonRow key={k.key_id} buttonClassName="connection" onClick={() => goToKey(k.key_id)}>
             <div>
               <span>{k.name}</span>
               <span className="small">&nbsp;&nbsp;{k.key_prefix}…</span>

--- a/src/client/components/Configuration/index.tsx
+++ b/src/client/components/Configuration/index.tsx
@@ -40,7 +40,11 @@ export const Configuration = () => {
       const buttonClassNames = ["connection"];
       if (status !== ItemStatus.OK) buttonClassNames.push("notification");
       return (
-        <ButtonRow key={id} className={buttonClassNames.join(" ")} onClick={onClickConnection}>
+        <ButtonRow
+          key={id}
+          buttonClassName={buttonClassNames.join(" ")}
+          onClick={onClickConnection}
+        >
           <div>
             {institution_id ? (
               <InstitutionSpan institution_id={institution_id} />

--- a/src/client/components/Configuration/index.tsx
+++ b/src/client/components/Configuration/index.tsx
@@ -15,6 +15,7 @@ import {
   Properties,
   PropertyLabel,
   Property,
+  ButtonRow,
   Row,
 } from "client";
 import { SimpleFinLinkButton } from "client/components";
@@ -39,18 +40,16 @@ export const Configuration = () => {
       const buttonClassNames = ["connection"];
       if (status !== ItemStatus.OK) buttonClassNames.push("notification");
       return (
-        <Row className="button" key={id}>
-          <button className={buttonClassNames.join(" ")} onClick={onClickConnection}>
-            <div>
-              {institution_id ? (
-                <InstitutionSpan institution_id={institution_id} />
-              ) : (
-                <span>{id.slice(0, 6).toUpperCase()}</span>
-              )}
-              <span className="small">&nbsp;&nbsp;via&nbsp;{toUpperCamelCase(provider)}</span>
-            </div>
-          </button>
-        </Row>
+        <ButtonRow key={id} className={buttonClassNames.join(" ")} onClick={onClickConnection}>
+          <div>
+            {institution_id ? (
+              <InstitutionSpan institution_id={institution_id} />
+            ) : (
+              <span>{id.slice(0, 6).toUpperCase()}</span>
+            )}
+            <span className="small">&nbsp;&nbsp;via&nbsp;{toUpperCamelCase(provider)}</span>
+          </div>
+        </ButtonRow>
       );
     });
 
@@ -114,9 +113,7 @@ export const Configuration = () => {
     <Properties className="Configuration">
       <PropertyLabel>Manual&nbsp;Accounts</PropertyLabel>
       <Property>
-        <Row className="button">
-          <button onClick={onClickAddManualAccount}>See&nbsp;Manual&nbsp;Accounts</button>
-        </Row>
+        <ButtonRow onClick={onClickAddManualAccount}>See&nbsp;Manual&nbsp;Accounts</ButtonRow>
       </Property>
       {!!itemsRow.length && (
         <>
@@ -136,9 +133,7 @@ export const Configuration = () => {
       <ApiKeysSection />
       <PropertyLabel>&nbsp;</PropertyLabel>
       <Property>
-        <Row className="button">
-          <button onClick={onClickRefresh}>Refresh</button>
-        </Row>
+        <ButtonRow onClick={onClickRefresh}>Refresh</ButtonRow>
         <Row className="button">
           <DeleteButton confirmMessage="Do you want to log out?" onClick={logout}>
             Logout

--- a/src/client/components/ConnectionProperties/ConnectedAccountRow.tsx
+++ b/src/client/components/ConnectionProperties/ConnectedAccountRow.tsx
@@ -1,6 +1,6 @@
 import { MouseEventHandler } from "react";
 import { ItemProvider, toTitleCase } from "common";
-import { Account, Item, KeyValue, PATH, Property, Row, useAppContext } from "client";
+import { Account, Item, KeyValue, PATH, Property, ButtonRow, useAppContext } from "client";
 
 interface Props {
   item: Item;
@@ -32,9 +32,7 @@ export const ConnectedAccountRow = ({ item, account }: Props) => {
           <span>{toTitleCase(subtype)}</span>
         </KeyValue>
       )}
-      <Row className="button">
-        <button onClick={onClickDetails}>See&nbsp;Details</button>
-      </Row>
+      <ButtonRow onClick={onClickDetails}>See&nbsp;Details</ButtonRow>
     </Property>
   );
 };

--- a/src/client/components/ConnectionProperties/index.tsx
+++ b/src/client/components/ConnectionProperties/index.tsx
@@ -16,6 +16,7 @@ import {
   Properties,
   PropertyLabel,
   Property,
+  ButtonRow,
   Row,
   useAppContext,
   indexedDb,
@@ -151,9 +152,7 @@ export const ConnectionProperties = ({ item }: Props) => {
           </Row>
         )}
         {provider === ItemProvider.MANUAL ? (
-          <Row className="button">
-            <button onClick={onClickAddManualAccount}>Add&nbsp;Account</button>
-          </Row>
+          <ButtonRow onClick={onClickAddManualAccount}>Add&nbsp;Account</ButtonRow>
         ) : (
           <Row className="button">
             <DeleteButton

--- a/src/client/components/FlowChartProperties.tsx
+++ b/src/client/components/FlowChartProperties.tsx
@@ -12,6 +12,7 @@ import {
   Properties,
   PropertyLabel,
   Property,
+  ButtonRow,
   Row,
   KeyValue,
 } from "client";
@@ -87,9 +88,7 @@ export const FlowChartProperties = ({ chart, children }: FlowChartPropertiesProp
 
       <PropertyLabel>Selected&nbsp;Accounts</PropertyLabel>
       <Property>
-        <Row className="button">
-          <button onClick={onClickAccounts}>{selectedAccountsCount}&nbsp;selected</button>
-        </Row>
+        <ButtonRow onClick={onClickAccounts}>{selectedAccountsCount}&nbsp;selected</ButtonRow>
       </Property>
 
       {children}

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -667,7 +667,7 @@ export const HoldingProperties = () => {
               />
             </KeyValue>
             {submitError && <Row className="formError">{submitError}</Row>}
-            <ButtonRow type="submit" className="colored">
+            <ButtonRow type="submit" buttonClassName="colored">
               Add
             </ButtonRow>
             <ButtonRow type="button" onClick={goBackToAccount}>
@@ -824,11 +824,7 @@ export const HoldingProperties = () => {
               Add&nbsp;Investment&nbsp;Transaction
             </ButtonRow>
             {missingUnits > 0 && (
-              <ButtonRow
-                type="button"
-                className="divergenceAction"
-                onClick={onClickAddDivergentTransaction}
-              >
+              <ButtonRow type="button" onClick={onClickAddDivergentTransaction}>
                 Add&nbsp;transaction&nbsp;for&nbsp;
                 {numberToCommaString(missingUnits, 4)}&nbsp;missing&nbsp;units
               </ButtonRow>

--- a/src/client/components/HoldingProperties/index.tsx
+++ b/src/client/components/HoldingProperties/index.tsx
@@ -25,6 +25,7 @@ import {
   Properties,
   PropertyLabel,
   Property,
+  ButtonRow,
   Row,
   KeyValue,
   indexedDb,
@@ -666,16 +667,12 @@ export const HoldingProperties = () => {
               />
             </KeyValue>
             {submitError && <Row className="formError">{submitError}</Row>}
-            <Row className="button">
-              <button type="submit" className="colored">
-                Add
-              </button>
-            </Row>
-            <Row className="button">
-              <button type="button" onClick={goBackToAccount}>
-                Cancel
-              </button>
-            </Row>
+            <ButtonRow type="submit" className="colored">
+              Add
+            </ButtonRow>
+            <ButtonRow type="button" onClick={goBackToAccount}>
+              Cancel
+            </ButtonRow>
           </form>
         </Property>
       </Properties>
@@ -691,11 +688,9 @@ export const HoldingProperties = () => {
         </Property>
         <PropertyLabel>&nbsp;</PropertyLabel>
         <Property>
-          <Row className="button">
-            <button type="button" onClick={goBackToAccount}>
-              Back
-            </button>
-          </Row>
+          <ButtonRow type="button" onClick={goBackToAccount}>
+            Back
+          </ButtonRow>
         </Property>
       </Properties>
     );
@@ -825,22 +820,18 @@ export const HoldingProperties = () => {
         <>
           <PropertyLabel>Add</PropertyLabel>
           <Property>
-            <Row className="button">
-              <button type="button" onClick={onClickAddInvestmentTransaction}>
-                Add&nbsp;Investment&nbsp;Transaction
-              </button>
-            </Row>
+            <ButtonRow type="button" onClick={onClickAddInvestmentTransaction}>
+              Add&nbsp;Investment&nbsp;Transaction
+            </ButtonRow>
             {missingUnits > 0 && (
-              <Row className="button">
-                <button
-                  type="button"
-                  className="divergenceAction"
-                  onClick={onClickAddDivergentTransaction}
-                >
-                  Add&nbsp;transaction&nbsp;for&nbsp;
-                  {numberToCommaString(missingUnits, 4)}&nbsp;missing&nbsp;units
-                </button>
-              </Row>
+              <ButtonRow
+                type="button"
+                className="divergenceAction"
+                onClick={onClickAddDivergentTransaction}
+              >
+                Add&nbsp;transaction&nbsp;for&nbsp;
+                {numberToCommaString(missingUnits, 4)}&nbsp;missing&nbsp;units
+              </ButtonRow>
             )}
           </Property>
         </>
@@ -848,11 +839,9 @@ export const HoldingProperties = () => {
 
       <PropertyLabel>&nbsp;</PropertyLabel>
       <Property>
-        <Row className="button">
-          <button type="button" onClick={goBackToAccount}>
-            Back
-          </button>
-        </Row>
+        <ButtonRow type="button" onClick={goBackToAccount}>
+          Back
+        </ButtonRow>
       </Property>
     </Properties>
   );

--- a/src/client/components/ProjectionChartProperties.tsx
+++ b/src/client/components/ProjectionChartProperties.tsx
@@ -12,6 +12,7 @@ import {
   Properties,
   PropertyLabel,
   Property,
+  ButtonRow,
   Row,
   KeyValue,
   ToggleInput,
@@ -172,9 +173,7 @@ export const ProjectionChartProperties = ({ chart, children }: ProjectionChartPr
 
       <PropertyLabel>Selected&nbsp;Accounts</PropertyLabel>
       <Property>
-        <Row className="button">
-          <button onClick={onClickAccounts}>{numberOfSelectedAccounts}&nbsp;selected</button>
-        </Row>
+        <ButtonRow onClick={onClickAccounts}>{numberOfSelectedAccounts}&nbsp;selected</ButtonRow>
       </Property>
 
       {children}

--- a/src/client/components/Properties/index.tsx
+++ b/src/client/components/Properties/index.tsx
@@ -84,3 +84,22 @@ export const KeyValue = ({ name, className, children, ...rest }: KeyValueProps) 
     </Row>
   );
 };
+
+type ButtonRowProps = ComponentPropsWithoutRef<"button">;
+
+/** The canonical action row: a `<Row className="button">` wrapping one native
+ *  `<button>`, so the row-level CSS (`div.Properties .row.button:hover`)
+ *  applies. `children` is the label; every other prop (`onClick`, `type`,
+ *  `className`, `disabled`, …) lands on the inner button — where the existing
+ *  per-site classes (`colored`, `connection`, `propertyName`, …) already live.
+ *
+ *  Rows whose child is a button *component* rather than a native `<button>`
+ *  (`<DeleteButton>`, `<PlaidLinkButton>`, `<SimpleFinLinkButton>`) render
+ *  their own `<button>`, so those keep the raw `<Row className="button">`. */
+export const ButtonRow = ({ children, ...rest }: ButtonRowProps) => {
+  return (
+    <Row className="button">
+      <button {...rest}>{children}</button>
+    </Row>
+  );
+};

--- a/src/client/components/Properties/index.tsx
+++ b/src/client/components/Properties/index.tsx
@@ -85,21 +85,39 @@ export const KeyValue = ({ name, className, children, ...rest }: KeyValueProps) 
   );
 };
 
-type ButtonRowProps = ComponentPropsWithoutRef<"button">;
+type ButtonRowProps = ComponentPropsWithoutRef<"button"> & {
+  /** Merged onto the inner `<button>`, where the per-site CSS hooks
+   *  (`colored`, `connection`, `unpairButton`, …) are selected from. */
+  buttonClassName?: string;
+};
 
 /** The canonical action row: a `<Row className="button">` wrapping one native
- *  `<button>`, so the row-level CSS (`div.Properties .row.button:hover`)
- *  applies. `children` is the label; every other prop (`onClick`, `type`,
- *  `className`, `disabled`, …) lands on the inner button — where the existing
- *  per-site classes (`colored`, `connection`, `propertyName`, …) already live.
+ *  `<button>`. `className` composes after the reserved `"button"` token on the
+ *  row, like every other primitive here; the button's own hooks go through
+ *  `buttonClassName`.
  *
  *  Rows whose child is a button *component* rather than a native `<button>`
  *  (`<DeleteButton>`, `<PlaidLinkButton>`, `<SimpleFinLinkButton>`) render
- *  their own `<button>`, so those keep the raw `<Row className="button">`. */
-export const ButtonRow = ({ children, ...rest }: ButtonRowProps) => {
+ *  their own `<button>`, so those keep the raw `<Row className="button">`.
+ *
+ *  Only the descendant-selector row CSS (`div.Properties .row.button:hover`,
+ *  `div.Properties .row:not(:last-child)`) travels with the primitive. Row
+ *  padding, flex and `> button { width: 100% }` come from the direct-child
+ *  `div.Properties > div.property > div.row`, so a site that renders this
+ *  below an extra wrapper — `<CapacitiesInput>` is the one today — is laid
+ *  out by that wrapper's own CSS instead. */
+export const ButtonRow = ({
+  className,
+  buttonClassName,
+  children,
+  ...rest
+}: ButtonRowProps) => {
+  const merged = className ? `button ${className}` : "button";
   return (
-    <Row className="button">
-      <button {...rest}>{children}</button>
+    <Row className={merged}>
+      <button className={buttonClassName} {...rest}>
+        {children}
+      </button>
     </Row>
   );
 };

--- a/src/client/components/TransactionProperties/index.tsx
+++ b/src/client/components/TransactionProperties/index.tsx
@@ -27,6 +27,7 @@ import {
   Properties,
   Property,
   PropertyLabel,
+  ButtonRow,
   Row,
   TransferArrowIcon,
 } from "client/components";
@@ -457,22 +458,18 @@ export const TransactionProperties = ({ transaction }: Props) => {
             </div>
           </Row>
         )}
-        <Row className="button">
-          <button onClick={onClickAdd}>Add&nbsp;New&nbsp;Split</button>
-        </Row>
+        <ButtonRow onClick={onClickAdd}>Add&nbsp;New&nbsp;Split</ButtonRow>
       </Property>
       <PropertyLabel>Transfer</PropertyLabel>
       <Property>
         {!showPartnerPicker && (
-          <Row className="button">
-            <button
-              className="markAsTransferButton"
-              onClick={() => setShowPartnerPicker(true)}
-            >
-              <TransferArrowIcon size={12} />
-              &nbsp;Mark&nbsp;as&nbsp;Transfer
-            </button>
-          </Row>
+          <ButtonRow
+            className="markAsTransferButton"
+            onClick={() => setShowPartnerPicker(true)}
+          >
+            <TransferArrowIcon size={12} />
+            &nbsp;Mark&nbsp;as&nbsp;Transfer
+          </ButtonRow>
         )}
         {showPartnerPicker && (
           <>
@@ -542,15 +539,13 @@ export const TransactionProperties = ({ transaction }: Props) => {
                 </Row>
               );
             })}
-            <Row className="button">
-              <button
-                className="markAsTransferCancel"
-                disabled={!!pendingPartnerId}
-                onClick={() => setShowPartnerPicker(false)}
-              >
-                Cancel
-              </button>
-            </Row>
+            <ButtonRow
+              className="markAsTransferCancel"
+              disabled={!!pendingPartnerId}
+              onClick={() => setShowPartnerPicker(false)}
+            >
+              Cancel
+            </ButtonRow>
           </>
         )}
       </Property>

--- a/src/client/components/TransactionProperties/index.tsx
+++ b/src/client/components/TransactionProperties/index.tsx
@@ -463,10 +463,7 @@ export const TransactionProperties = ({ transaction }: Props) => {
       <PropertyLabel>Transfer</PropertyLabel>
       <Property>
         {!showPartnerPicker && (
-          <ButtonRow
-            className="markAsTransferButton"
-            onClick={() => setShowPartnerPicker(true)}
-          >
+          <ButtonRow onClick={() => setShowPartnerPicker(true)}>
             <TransferArrowIcon size={12} />
             &nbsp;Mark&nbsp;as&nbsp;Transfer
           </ButtonRow>
@@ -539,11 +536,7 @@ export const TransactionProperties = ({ transaction }: Props) => {
                 </Row>
               );
             })}
-            <ButtonRow
-              className="markAsTransferCancel"
-              disabled={!!pendingPartnerId}
-              onClick={() => setShowPartnerPicker(false)}
-            >
+            <ButtonRow disabled={!!pendingPartnerId} onClick={() => setShowPartnerPicker(false)}>
               Cancel
             </ButtonRow>
           </>

--- a/src/client/components/TransferProperties/index.tsx
+++ b/src/client/components/TransferProperties/index.tsx
@@ -137,7 +137,7 @@ export const TransferProperties = ({ transfer }: Props) => {
       {renderSide("To", incoming, toAccount)}
       <PropertyLabel>Actions</PropertyLabel>
       <Property>
-        <ButtonRow className="unpairButton" onClick={onClickUnpair}>
+        <ButtonRow buttonClassName="unpairButton" onClick={onClickUnpair}>
           Mark&nbsp;as&nbsp;Non-Transfer
         </ButtonRow>
       </Property>

--- a/src/client/components/TransferProperties/index.tsx
+++ b/src/client/components/TransferProperties/index.tsx
@@ -8,7 +8,7 @@ import {
   Properties,
   Property,
   PropertyLabel,
-  Row,
+  ButtonRow,
   TransferArrowIcon,
 } from "client/components";
 import "./index.css";
@@ -137,11 +137,9 @@ export const TransferProperties = ({ transfer }: Props) => {
       {renderSide("To", incoming, toAccount)}
       <PropertyLabel>Actions</PropertyLabel>
       <Property>
-        <Row className="button">
-          <button className="unpairButton" onClick={onClickUnpair}>
-            Mark&nbsp;as&nbsp;Non-Transfer
-          </button>
-        </Row>
+        <ButtonRow className="unpairButton" onClick={onClickUnpair}>
+          Mark&nbsp;as&nbsp;Non-Transfer
+        </ButtonRow>
       </Property>
     </Properties>
   );


### PR DESCRIPTION
Closes part of #326 (phase 5j). Continues the design-componentization arc: after `<Page>`, `<Properties>`/`<Property>`/`<Row>`, `<KeyValue>`, `<PageFilterTitle>`, `<DeleteButton>`, `<ChartTypeSelect>`, the action row was the last high-count hand-rolled shape.

## The pattern

The action row was hand-written at **31 sites** across 13 components as a two-part shape:

```tsx
<Row className="button">
  <button onClick={onClickAccounts}>{count}&nbsp;selected</button>
</Row>
```

Every site had to remember both the `button` variant token on the row **and** the nested-native-button structure. `<ButtonRow>` joins the `Properties` shell family:

```tsx
<ButtonRow onClick={onClickAccounts}>{count}&nbsp;selected</ButtonRow>
```

Renders byte-identical DOM (`<div class="row button"><button>…</button></div>`), so it drops in with **no CSS change**. Props pass straight through to the inner `<button>` — which is where the existing per-site classes already lived (`colored`, `connection`, `propertyName`, `divergenceAction`, `markAsTransferButton`, `markAsTransferCancel`, `unpairButton`) alongside `type`, `disabled`, and the `key` on the two `.map`-rendered rows.

No `type` default is applied: sites that wrote `type="button"` keep it, sites that omitted it still omit it, so the rendered attribute set is unchanged.

## Intentionally NOT migrated (13 sites)

Rows whose child is a button **component** rather than a native `<button>` render their own `<button>`, so they correctly stay on the raw `<Row className="button">`:

- `<DeleteButton>` — 10 sites (chart-config panels, Configuration logout, AccountProperties, InvestmentTransactionProperties, TransactionProperties, HoldingProperties, ApiKeyProperties revoke, ConnectionProperties)
- `<PlaidLinkButton>` — 2 sites
- `<SimpleFinLinkButton>` — 1 site

Same carve-out as the 3 ChartAccountsPage toggle rows in the `<KeyValue>` extraction (PR #623): don't force a shell where the shape doesn't fit.

## Files

`Properties/index.tsx` (+`<ButtonRow>`), AccountProperties, ApiKeyProperties, BalanceChartProperties, BudgetProperties/CapacitiesInput, Configuration, Configuration/ApiKeysSection, ConnectionProperties, ConnectionProperties/ConnectedAccountRow, FlowChartProperties, HoldingProperties, ProjectionChartProperties, TransactionProperties, TransferProperties.

Net **-33 LOC** (133 insertions / 166 deletions).

## Test plan

Checks run locally on this branch:

- `bun run typecheck` — clean
- `bun --bun eslint src` — clean (this is what CI's `test` job runs first)
- `bun run build` — server bundle + client bundle green
- `bun test --preload ./scripts/test-preload.ts src` — **1128 pass / 2 skip / 0 fail** across 81 files

UI verification (mobile viewport 390x844, real click chains, screenshots eye-checked) — see the follow-up comment on this PR for the per-screen walkthrough. Every migrated row is either a navigation affordance or a local-state toggle; the mutating rows (`DeleteButton` revoke/delete, form submit) are exactly the ones this PR does **not** touch.