### PR TITLE
security(alarm): per-key alarm cooldown so /client-error cannot suppress every alarm

### DIFF
--- a/src/server/lib/alarm.test.ts
+++ b/src/server/lib/alarm.test.ts
@@ -5,21 +5,35 @@ import { restoreLeaves } from "test-helpers";
 const mockFetch = mock(() => Promise.resolve({ ok: true } as Response));
 global.fetch = mockFetch as typeof fetch;
 
-// Dynamically import so we can reset module state between tests
 let alarm: typeof import("./alarm");
+
+// The cooldown and the rate window are both wall-clock, so drive Date.now from
+// the test to cover expiry without sleeping.
+const realDateNow = Date.now;
+let now = 1_700_000_000_000;
+const advance = (ms: number): void => {
+  now += ms;
+};
+
+afterAll(() => {
+  Date.now = realDateNow;
+  restoreLeaves();
+});
 
 beforeEach(async () => {
   mockFetch.mockClear();
-  // Re-import to reset module-level state
+  mockFetch.mockImplementation(() => Promise.resolve({ ok: true } as Response));
+  now = 1_700_000_000_000;
+  Date.now = () => now;
   alarm = await import("./alarm");
-
-afterAll(restoreLeaves);
   alarm.resetAlarmState();
 });
 
 afterEach(() => {
   delete process.env.DISCORD_ALARM_WEBHOOK;
 });
+
+const WEBHOOK = "https://discord.com/api/webhooks/test";
 
 describe("sendAlarm", () => {
   it("does nothing when DISCORD_ALARM_WEBHOOK is not set", async () => {
@@ -29,43 +43,46 @@ describe("sendAlarm", () => {
   });
 
   it("sends a POST to the webhook URL", async () => {
-    process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
+    process.env.DISCORD_ALARM_WEBHOOK = WEBHOOK;
     await alarm.sendAlarm("Test Error", "Something went wrong");
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("https://discord.com/api/webhooks/test");
+    expect(url).toBe(WEBHOOK);
     expect(options.method).toBe("POST");
   });
 
   it("respects cooldown — a second alarm on the same key within 60s is suppressed", async () => {
-    process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
+    process.env.DISCORD_ALARM_WEBHOOK = WEBHOOK;
     await alarm.sendAlarm("Error 1", "detail 1");
+    advance(59_000);
     await alarm.sendAlarm("Error 1", "detail 2");
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
+  it("sends again on the same key once the cooldown has elapsed", async () => {
+    process.env.DISCORD_ALARM_WEBHOOK = WEBHOOK;
+    await alarm.sendAlarm("Error 1", "detail 1");
+    advance(60_001);
+    await alarm.sendAlarm("Error 1", "detail 2");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
   it("cools down per key — a different title is not suppressed", async () => {
-    // Previously one global timestamp gated every source, so the first alarm of
-    // any minute silenced all others. Distinct titles are distinct buckets now.
-    process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
+    process.env.DISCORD_ALARM_WEBHOOK = WEBHOOK;
     await alarm.sendAlarm("Scheduled Sync Failed", "detail 1");
     await alarm.sendAlarm("Item Bad Status", "detail 2");
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("cools down per explicit key, independently of the title", async () => {
-    process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
+    process.env.DISCORD_ALARM_WEBHOOK = WEBHOOK;
     await alarm.sendAlarm("Client JS Error", "a", "client-error");
     await alarm.sendAlarm("Client JS Error", "b", "client-error");
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it("a client-error flood does NOT suppress unrelated server alarms", async () => {
-    // The regression that matters: /api/client-error is unauthenticated, so
-    // with a shared bucket one request per minute blinded every server-side
-    // alarm — route 5xx, uncaughtException/unhandledRejection, scheduled-sync
-    // and Plaid Item failures.
-    process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
+    process.env.DISCORD_ALARM_WEBHOOK = WEBHOOK;
     for (let i = 0; i < 25; i += 1) {
       await alarm.sendAlarm("Client JS Error", `report ${i}`, "client-error");
     }
@@ -74,5 +91,71 @@ describe("sendAlarm", () => {
     await alarm.sendAlarm("Scheduled Sync Failed", "sync blew up");
     await alarm.sendAlarm("Item Bad Status", "item broke");
     expect(mockFetch).toHaveBeenCalledTimes(3); // both real alarms got through
+  });
+
+  it("caps total sends per window when many distinct keys fire at once", async () => {
+    process.env.DISCORD_ALARM_WEBHOOK = WEBHOOK;
+    // Route.execute keys on the registered path, so a total outage makes every
+    // route its own eligible bucket — the per-key cooldown alone does not bound
+    // outbound webhook traffic.
+    for (let i = 0; i < 40; i += 1) {
+      await alarm.sendAlarm(`Route Error: GET /r${i}`, "boom");
+    }
+    expect(mockFetch).toHaveBeenCalledTimes(10);
+  });
+
+  it("does not spend a cooldown on a key the global ceiling refused", async () => {
+    process.env.DISCORD_ALARM_WEBHOOK = WEBHOOK;
+    for (let i = 0; i < 10; i += 1) {
+      await alarm.sendAlarm(`Route Error: GET /r${i}`, "boom");
+    }
+    await alarm.sendAlarm("Scheduled Sync Failed", "dropped by ceiling");
+    expect(mockFetch).toHaveBeenCalledTimes(10);
+
+    // The window clears the 10 sends; the refused key must be eligible again
+    // immediately rather than serving a 60s cooldown it never earned.
+    advance(60_001);
+    await alarm.sendAlarm("Scheduled Sync Failed", "now it gets through");
+    expect(mockFetch).toHaveBeenCalledTimes(11);
+  });
+
+  it("frees ceiling slots as the window slides", async () => {
+    process.env.DISCORD_ALARM_WEBHOOK = WEBHOOK;
+    for (let i = 0; i < 10; i += 1) {
+      await alarm.sendAlarm(`Route Error: GET /a${i}`, "boom");
+    }
+    await alarm.sendAlarm("Route Error: GET /blocked", "boom");
+    expect(mockFetch).toHaveBeenCalledTimes(10);
+
+    advance(60_001);
+    await alarm.sendAlarm("Route Error: GET /blocked", "boom");
+    expect(mockFetch).toHaveBeenCalledTimes(11);
+  });
+
+  it("does not throw when the webhook returns a non-2xx", async () => {
+    process.env.DISCORD_ALARM_WEBHOOK = WEBHOOK;
+    mockFetch.mockImplementation(
+      () => Promise.resolve({ ok: false, status: 429 } as Response)
+    );
+    await alarm.sendAlarm("Rate Limited", "detail");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when fetch rejects", async () => {
+    process.env.DISCORD_ALARM_WEBHOOK = WEBHOOK;
+    mockFetch.mockImplementation(() => Promise.reject(new Error("network down")));
+    await alarm.sendAlarm("Network Error", "detail");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("prunes cooldown entries once they can no longer suppress", async () => {
+    process.env.DISCORD_ALARM_WEBHOOK = WEBHOOK;
+    for (let i = 0; i < 5; i += 1) {
+      await alarm.sendAlarm(`Route Error: GET /p${i}`, "boom");
+    }
+    expect(alarm.getCooldownKeyCount()).toBe(5);
+    advance(60_001);
+    await alarm.sendAlarm("Route Error: GET /p0", "boom");
+    expect(alarm.getCooldownKeyCount()).toBe(1);
   });
 });

--- a/src/server/lib/alarm.test.ts
+++ b/src/server/lib/alarm.test.ts
@@ -109,12 +109,17 @@ describe("sendAlarm", () => {
     for (let i = 0; i < 10; i += 1) {
       await alarm.sendAlarm(`Route Error: GET /r${i}`, "boom");
     }
+    // Offset the refusal from the 10 sends so the window and a wrongly-spent
+    // cooldown expire at different instants. Refusing at the same instant lets
+    // one advance() clear both, and the assertion below passes either way.
+    advance(5_000);
     await alarm.sendAlarm("Scheduled Sync Failed", "dropped by ceiling");
     expect(mockFetch).toHaveBeenCalledTimes(10);
 
-    // The window clears the 10 sends; the refused key must be eligible again
-    // immediately rather than serving a 60s cooldown it never earned.
-    advance(60_001);
+    // Now past the window (the 10 sends are pruned) but still inside the 60s
+    // that a cooldown spent at the refusal would have started, so the refused
+    // key gets through only if the ceiling branch left its cooldown untouched.
+    advance(55_001);
     await alarm.sendAlarm("Scheduled Sync Failed", "now it gets through");
     expect(mockFetch).toHaveBeenCalledTimes(11);
   });

--- a/src/server/lib/alarm.test.ts
+++ b/src/server/lib/alarm.test.ts
@@ -37,10 +37,42 @@ describe("sendAlarm", () => {
     expect(options.method).toBe("POST");
   });
 
-  it("respects cooldown — second alarm within 60s is suppressed", async () => {
+  it("respects cooldown — a second alarm on the same key within 60s is suppressed", async () => {
     process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
     await alarm.sendAlarm("Error 1", "detail 1");
-    await alarm.sendAlarm("Error 2", "detail 2");
+    await alarm.sendAlarm("Error 1", "detail 2");
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("cools down per key — a different title is not suppressed", async () => {
+    // Previously one global timestamp gated every source, so the first alarm of
+    // any minute silenced all others. Distinct titles are distinct buckets now.
+    process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
+    await alarm.sendAlarm("Scheduled Sync Failed", "detail 1");
+    await alarm.sendAlarm("Item Bad Status", "detail 2");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("cools down per explicit key, independently of the title", async () => {
+    process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
+    await alarm.sendAlarm("Client JS Error", "a", "client-error");
+    await alarm.sendAlarm("Client JS Error", "b", "client-error");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("a client-error flood does NOT suppress unrelated server alarms", async () => {
+    // The regression that matters: /api/client-error is unauthenticated, so
+    // with a shared bucket one request per minute blinded every server-side
+    // alarm — route 5xx, uncaughtException/unhandledRejection, scheduled-sync
+    // and Plaid Item failures.
+    process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
+    for (let i = 0; i < 25; i += 1) {
+      await alarm.sendAlarm("Client JS Error", `report ${i}`, "client-error");
+    }
+    expect(mockFetch).toHaveBeenCalledTimes(1); // the flood itself is capped
+
+    await alarm.sendAlarm("Scheduled Sync Failed", "sync blew up");
+    await alarm.sendAlarm("Item Bad Status", "item broke");
+    expect(mockFetch).toHaveBeenCalledTimes(3); // both real alarms got through
   });
 });

--- a/src/server/lib/alarm.ts
+++ b/src/server/lib/alarm.ts
@@ -1,29 +1,43 @@
 /**
  * Discord alarm module for server error notifications.
  *
- * Sends a POST to the DISCORD_ALARM_WEBHOOK URL when errors occur.
- * A 1-minute cooldown per alarm key prevents noise bursts without letting one
- * chatty source (e.g. the unauthenticated /api/client-error beacon) starve
- * other sources.
+ * Sends a POST to the DISCORD_ALARM_WEBHOOK URL when errors occur, under two
+ * independent limits: a per-key cooldown so one chatty source cannot starve the
+ * others, and a global per-window ceiling so a broad outage (every route 5xxing
+ * into its own bucket) cannot burst past Discord's webhook rate limit.
  */
 
 import { logger } from "server/lib/logger";
 
 const COOLDOWN_MS = 60_000; // 1 minute
 
+/**
+ * Ceiling on webhook POSTs per COOLDOWN_MS across all keys. `Route.execute`
+ * buckets per registered route path, so a total outage has as many eligible
+ * keys as there are routes — Discord rate-limits well below that.
+ */
+const MAX_SENDS_PER_WINDOW = 10;
+
 const lastAlarmAt = new Map<string, number>();
+const sendTimestamps: number[] = [];
+
+/** Drop cooldown entries and send timestamps that can no longer suppress anything. */
+const pruneExpired = (now: number): void => {
+  const cutoff = now - COOLDOWN_MS;
+  for (const [key, at] of lastAlarmAt) {
+    if (at <= cutoff) lastAlarmAt.delete(key);
+  }
+  while (sendTimestamps.length && sendTimestamps[0]! <= cutoff) sendTimestamps.shift();
+};
 
 /**
- * Send a Discord webhook alarm message. Respects a per-key cooldown so traffic
- * on one key cannot suppress alarms from other sources.
+ * Send a Discord webhook alarm message.
  *
  * @param title Embed title (also the default cooldown key)
  * @param detail Embed description
  * @param key Cooldown bucket. Defaults to `title`. Pass an explicit value for
- *   sources that may fire frequently — notably `/api/client-error`, which is
- *   unauthenticated, so with a single shared bucket one request per minute was
- *   enough to silently suppress every server-side alarm (route 5xx,
- *   uncaughtException, unhandledRejection, scheduled-sync and Plaid failures).
+ *   sources whose title is fixed but whose volume is caller-driven, so their
+ *   traffic is charged to one bucket instead of the reporting source's.
  */
 export const sendAlarm = async (
   title: string,
@@ -34,9 +48,22 @@ export const sendAlarm = async (
   if (!webhookUrl) return;
 
   const now = Date.now();
+  pruneExpired(now);
+
   const last = lastAlarmAt.get(key) ?? 0;
   if (now - last < COOLDOWN_MS) return;
+
+  if (sendTimestamps.length >= MAX_SENDS_PER_WINDOW) {
+    logger.warn("Discord alarm dropped — global rate ceiling reached", {
+      key,
+      title,
+      windowSends: sendTimestamps.length,
+    });
+    return;
+  }
+
   lastAlarmAt.set(key, now);
+  sendTimestamps.push(now);
 
   const body = JSON.stringify({
     embeds: [
@@ -50,18 +77,32 @@ export const sendAlarm = async (
   });
 
   try {
-    await fetch(webhookUrl, {
+    const response = await fetch(webhookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body,
     });
+    // A non-2xx means this alarm was never delivered. The cooldown stays
+    // committed (retrying into a rate limit makes it worse), so without this
+    // branch the drop is silent.
+    if (!response.ok) {
+      logger.error("Discord alarm rejected by webhook", {
+        key,
+        title,
+        status: response.status,
+      });
+    }
   } catch (err) {
     // Don't throw — alarm failure should never crash the server
-    logger.error("Failed to send Discord alarm", {}, err);
+    logger.error("Failed to send Discord alarm", { key, title }, err);
   }
 };
 
 /** Reset cooldown state (for testing). */
 export const resetAlarmState = (): void => {
   lastAlarmAt.clear();
+  sendTimestamps.length = 0;
 };
+
+/** Live cooldown bucket count (for testing the prune keeps this O(active keys)). */
+export const getCooldownKeyCount = (): number => lastAlarmAt.size;

--- a/src/server/lib/alarm.ts
+++ b/src/server/lib/alarm.ts
@@ -2,23 +2,41 @@
  * Discord alarm module for server error notifications.
  *
  * Sends a POST to the DISCORD_ALARM_WEBHOOK URL when errors occur.
- * A 1-minute cooldown prevents noise bursts.
+ * A 1-minute cooldown per alarm key prevents noise bursts without letting one
+ * chatty source (e.g. the unauthenticated /api/client-error beacon) starve
+ * other sources.
  */
 
 import { logger } from "server/lib/logger";
 
 const COOLDOWN_MS = 60_000; // 1 minute
 
-let lastAlarmAt = 0;
+const lastAlarmAt = new Map<string, number>();
 
-/** Send a Discord webhook alarm message. Respects cooldown. */
-export const sendAlarm = async (title: string, detail: string): Promise<void> => {
+/**
+ * Send a Discord webhook alarm message. Respects a per-key cooldown so traffic
+ * on one key cannot suppress alarms from other sources.
+ *
+ * @param title Embed title (also the default cooldown key)
+ * @param detail Embed description
+ * @param key Cooldown bucket. Defaults to `title`. Pass an explicit value for
+ *   sources that may fire frequently — notably `/api/client-error`, which is
+ *   unauthenticated, so with a single shared bucket one request per minute was
+ *   enough to silently suppress every server-side alarm (route 5xx,
+ *   uncaughtException, unhandledRejection, scheduled-sync and Plaid failures).
+ */
+export const sendAlarm = async (
+  title: string,
+  detail: string,
+  key: string = title
+): Promise<void> => {
   const webhookUrl = process.env.DISCORD_ALARM_WEBHOOK;
   if (!webhookUrl) return;
 
   const now = Date.now();
-  if (now - lastAlarmAt < COOLDOWN_MS) return;
-  lastAlarmAt = now;
+  const last = lastAlarmAt.get(key) ?? 0;
+  if (now - last < COOLDOWN_MS) return;
+  lastAlarmAt.set(key, now);
 
   const body = JSON.stringify({
     embeds: [
@@ -45,5 +63,5 @@ export const sendAlarm = async (title: string, detail: string): Promise<void> =>
 
 /** Reset cooldown state (for testing). */
 export const resetAlarmState = (): void => {
-  lastAlarmAt = 0;
+  lastAlarmAt.clear();
 };

--- a/src/server/routes/client-error.test.ts
+++ b/src/server/routes/client-error.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+import { restoreLeaves } from "test-helpers";
+
+// `mock.module` is process-global in Bun and `restoreLeaves` only restores the
+// `pg` / `bcrypt` leaves, so capture the real modules up front and restore them
+// in `afterAll` (the post-plaid-hook.test.ts pattern) to keep these stubs out of
+// sibling route tests sharing the process.
+const realAlarm = { ...(await import("server/lib/alarm")) };
+const realLogger = { ...(await import("server/lib/logger")) };
+
+const mockSendAlarm = mock(async (_title: string, _detail: string, _key?: string) => {});
+const mockLogger = {
+  info: mock(() => {}),
+  warn: mock(() => {}),
+  error: mock(() => {}),
+};
+
+mock.module("server/lib/alarm", () => ({ ...realAlarm, sendAlarm: mockSendAlarm }));
+mock.module("server/lib/logger", () => ({ ...realLogger, logger: mockLogger }));
+
+const { postClientErrorRoute } = await import("./client-error");
+
+afterAll(() => {
+  mock.module("server/lib/alarm", () => realAlarm);
+  mock.module("server/lib/logger", () => realLogger);
+  restoreLeaves();
+});
+
+beforeEach(() => {
+  mockSendAlarm.mockReset();
+  mockSendAlarm.mockImplementation(async () => {});
+  mockLogger.info.mockReset();
+  mockLogger.warn.mockReset();
+  mockLogger.error.mockReset();
+});
+
+const makeReq = (body: unknown): Parameters<typeof postClientErrorRoute.execute>[0] =>
+  ({
+    method: "POST",
+    path: "/client-error",
+    url: "http://x/api/client-error",
+    headers: {},
+    query: {},
+    body,
+    ip: "127.0.0.1",
+  }) as unknown as Parameters<typeof postClientErrorRoute.execute>[0];
+
+const makeRes = (): Parameters<typeof postClientErrorRoute.execute>[1] =>
+  ({ status: mock(() => {}), write: mock(() => {}) }) as unknown as Parameters<
+    typeof postClientErrorRoute.execute
+  >[1];
+
+describe("POST /client-error", () => {
+  test("charges the alarm to its own cooldown bucket, not the title's", async () => {
+    // The invariant that closes #663: without the explicit third argument the
+    // key falls back to the title and client reports again share a bucket with
+    // every server-side alarm.
+    await postClientErrorRoute.execute(
+      makeReq({ message: "boom", stack: "at foo", url: "http://x/page" }),
+      makeRes()
+    );
+
+    expect(mockSendAlarm).toHaveBeenCalledTimes(1);
+    const [title, detail, key] = mockSendAlarm.mock.calls[0] as [string, string, string];
+    expect(key).toBe("client-error");
+    expect(key).not.toBe(title);
+    expect(detail).toContain("boom");
+  });
+
+  test("reports a placeholder message when the body carries no usable fields", async () => {
+    await postClientErrorRoute.execute(makeReq({}), makeRes());
+
+    const [, detail] = mockSendAlarm.mock.calls[0] as [string, string, string];
+    expect(detail).toContain("(no message)");
+  });
+
+  test("ignores non-string fields instead of interpolating them", async () => {
+    await postClientErrorRoute.execute(
+      makeReq({ message: { toString: () => "evil" }, stack: 42, url: null }),
+      makeRes()
+    );
+
+    const [, detail, key] = mockSendAlarm.mock.calls[0] as [string, string, string];
+    expect(detail).toContain("(no message)");
+    expect(detail).not.toContain("42");
+    expect(key).toBe("client-error");
+  });
+
+  test("truncates a long stack so one report cannot fill the embed", async () => {
+    await postClientErrorRoute.execute(
+      makeReq({ message: "boom", stack: "x".repeat(5000) }),
+      makeRes()
+    );
+
+    const [, detail] = mockSendAlarm.mock.calls[0] as [string, string, string];
+    expect(detail).not.toContain("x".repeat(1001));
+  });
+
+  test("returns success", async () => {
+    const result = await postClientErrorRoute.execute(
+      makeReq({ message: "boom" }),
+      makeRes()
+    );
+    expect(result).toEqual({ status: "success" });
+  });
+});

--- a/src/server/routes/client-error.ts
+++ b/src/server/routes/client-error.ts
@@ -31,7 +31,9 @@ export const postClientErrorRoute = new Route("POST", "/client-error", async (re
     .filter(Boolean)
     .join("\n");
 
-  await sendAlarm("Client JS Error", detail);
+  // Dedicated cooldown bucket: this endpoint is unauthenticated, so sharing a
+  // bucket let any caller suppress unrelated server-side alarms indefinitely.
+  await sendAlarm("Client JS Error", detail, "client-error");
 
   return { status: "success" as const };
 });

--- a/src/server/routes/client-error.ts
+++ b/src/server/routes/client-error.ts
@@ -11,8 +11,10 @@ export type ClientErrorPostBody = {
 /**
  * POST /client-error
  *
- * Accepts frontend error reports sent via navigator.sendBeacon.
- * Forwards to Discord alarm. No auth required (beacon fires after page unload).
+ * Accepts frontend error reports sent via navigator.sendBeacon and forwards
+ * them to the Discord alarm. Session-gated like every other route (it is absent
+ * from `PUBLIC_PATH_METHODS` in start.ts), so errors thrown before login are
+ * rejected with 401 and never reported.
  */
 export const postClientErrorRoute = new Route("POST", "/client-error", async (req) => {
   const body = req.body as ClientErrorPostBody;
@@ -31,8 +33,8 @@ export const postClientErrorRoute = new Route("POST", "/client-error", async (re
     .filter(Boolean)
     .join("\n");
 
-  // Dedicated cooldown bucket: this endpoint is unauthenticated, so sharing a
-  // bucket let any caller suppress unrelated server-side alarms indefinitely.
+  // Dedicated cooldown bucket so client report volume, which any session can
+  // drive, is charged here instead of to the server-side alarm sources.
   await sendAlarm("Client JS Error", detail, "client-error");
 
   return { status: "success" as const };


### PR DESCRIPTION
Part 1 of #663.

## The bug

`sendAlarm` gated every source on a single global timestamp:

```ts
let lastAlarmAt = 0;
if (now - lastAlarmAt < COOLDOWN_MS) return;   // one bucket for ALL sources
lastAlarmAt = now;
```

One send per minute across the whole process, so the first alarm of any minute silenced every other source for the rest of it. The distinct titles starve each other on `main` today:

- `lib/route.ts:91` — route 5xx handler
- `start.ts:471` / `:479` — `uncaughtException` / `unhandledRejection`
- `lib/compute-tools/schedule.ts:36,49,81,112` — scheduled Plaid / SimpleFin sync failures
- `routes/webhooks/post-plaid-hook.ts:115`, `lib/plaid/transactions.ts:72,177`, `lib/plaid/accounts.ts:37,109` — Item Bad Status

`/client-error` is the worst offender because its volume is client-driven: a browser stuck in a retry loop posts every few seconds and keeps `lastAlarmAt` permanently fresh, so Hoie stops hearing about broken syncs.

### Correction to the original framing of this PR

The first version of this description (and comments in `alarm.ts`, `client-error.ts` and `alarm.test.ts`) claimed `POST /api/client-error` is **unauthenticated**, making this an anonymous-internet denial-of-alerting. **That is wrong.** `PUBLIC_PATH_METHODS` (`start.ts:185-189`) contains only `/login`, `POST /plaid-hook` and `GET /health`; `start.ts:337` returns 401 for anything else without `session.user`. Verified empirically — anonymous `POST /api/client-error` returns `401 {"status":"failed","message":"Not authenticated."}`.

So the exploit needs a valid session. The bug is real and worth fixing, but it is a noisy-neighbour / self-inflicted-retry-loop problem, not a remote unauthenticated one. Commit 2bf3edd corrects the claim in all four places it had been committed to source. Two consequences worth recording:

- **Part 2 of #663 is mis-scoped.** A per-IP rate limit on an already session-gated route buys much less than the issue assumes. The shape that actually closes the residual hole is below.
- **There is a real functional gap this false docstring was hiding:** a client error thrown *before* login beacons into a 401 and is silently dropped. Not addressed here (it needs a decision about whether the route should be public); flagged for follow-up.

## The fix

Cooldown is per key, in a `Map`:

```ts
const last = lastAlarmAt.get(key) ?? 0;
if (now - last < COOLDOWN_MS) return;
```

`key` defaults to `title`, so every existing call site is untouched and the distinct titles stop starving each other. `/client-error` passes its own `"client-error"` bucket. Same shape inbox already uses in `lib/alarm.ts`.

Three things came out of review (2bf3edd):

**Global ceiling.** Per-key cooldown alone left *no* bound on outbound webhook traffic. `Route.execute` keys on `Route.path`, which is the registered literal, so there is one bucket per registered route — 55 of them. Postgres goes down, every trafficked route 5xxes, and each fires its own webhook POST inside one minute. On `main` that was 1 message. Added `MAX_SENDS_PER_WINDOW = 10` per 60s across all keys; refusals are logged rather than silent, and a key refused by the ceiling does **not** have its cooldown spent, so it stays eligible once the window slides.

**Non-2xx was swallowed.** The old code did `await fetch(...)` with no `res.ok` check, so a Discord 429 was discarded with no log while the cooldown was already committed — alarms lost during exactly the broad outage this protects. Now logged with the status. The cooldown stays committed deliberately: retrying into a rate limit makes it worse.

**Map growth.** Expired entries are pruned on each call, so `lastAlarmAt` is O(active keys) rather than O(keys ever seen). Bounded today by the route count, but this is the precondition for ever keying on an error fingerprint (below).

## Residual hole, and the shape that closes it

The cooldown is process-global per key, so one `/client-error` report per minute from any single session still suppresses every *other* user's distinct client error for that minute — which is the endpoint's whole purpose. Per-key cooldown fixes the cross-source starvation (client reports can no longer blind server-side alarms); it does not fix client-vs-client. The fix is a per-error-fingerprint bucket (`client-error:<hash(message)>`), and that is precisely when keys become caller-influenced and the bounded prune above becomes load-bearing rather than precautionary. Better scoped against #663 part 2 than folded in here.

## Test plan

- `bun run typecheck` — clean
- `bun --bun eslint src` — clean (what CI's `test` job runs first)
- `bun test --preload ./scripts/test-preload.ts src` — **1143 pass / 2 skip / 0 fail** across 82 files
- `alarm.test.ts` + the new `routes/client-error.test.ts`: 18 pass / 0 fail

`alarm.test.ts` previously asserted the bug — two *different* titles expecting one send pinned the cross-source suppression as intended behaviour. Now: same-key suppression, cooldown expiry, per-title and per-explicit-key independence, the 25-report flood not suppressing two unrelated alarms, the global ceiling capping a 40-distinct-key burst at 10, a ceiling-refused key not serving a cooldown it never earned, slot release as the window slides, non-2xx and rejected-fetch both non-throwing, and the prune keeping the map at O(active keys). `Date.now` is driven from the test so window expiry is covered without sleeping.

`routes/client-error.test.ts` is new. The invariant that actually closes this issue — the route passing `"client-error"` as the third argument — had no test at all, so a future edit dropping that argument would reopen the hole with every `alarm.test.ts` case still green. It also covers the body-parsing edges (non-string `message`/`stack`/`url` rejected rather than interpolated, stack truncation, placeholder message).

Also hoisted `afterAll(restoreLeaves)`, which was nested inside the `beforeEach` callback and so re-registered once per test.

No UI surface — this is server-side alerting only. Verifying it live would mean POSTing to a real Discord webhook, which I have not done.
