### PR TITLE
fix(accounts): POST /api/account inserts new manual accounts instead of no-oping (#668)

### DIFF
--- a/src/server/lib/postgres/database.ts
+++ b/src/server/lib/postgres/database.ts
@@ -45,6 +45,8 @@ export type AdditionalWhere = { column: string; value: ParamValue | typeof IS_NO
 export interface UpdateOptions {
   additionalWhere?: AdditionalWhere | AdditionalWhere[];
   returning?: string[];
+  /** Restrict the UPDATE to live rows, the way `prepareQuery` already does. */
+  excludeDeleted?: boolean;
 }
 
 export interface UpsertOptions {
@@ -183,6 +185,10 @@ export function buildUpdate(
         paramIndex++;
       }
     }
+  }
+
+  if (options.excludeDeleted) {
+    sql += ` AND ${SOFT_DELETE_CONDITION}`;
   }
 
   if (options.returning && options.returning.length > 0) {

--- a/src/server/lib/postgres/database.ts
+++ b/src/server/lib/postgres/database.ts
@@ -436,3 +436,21 @@ export function noChangeResult(id: string): UpsertResult {
     status: 304,
   };
 }
+
+export function conflictResult(id: string): UpsertResult {
+  return {
+    update: { _id: id },
+    status: 409,
+  };
+}
+
+/** Postgres `unique_violation`. */
+const UNIQUE_VIOLATION = "23505";
+
+export function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: unknown }).code === UNIQUE_VIOLATION
+  );
+}

--- a/src/server/lib/postgres/models/base.ts
+++ b/src/server/lib/postgres/models/base.ts
@@ -170,6 +170,10 @@ export abstract class Table<
    * whose label_category_confidence is still NULL"). Values follow
    * `prepareQuery` semantics: `null` → IS NULL, `IS_NOT_NULL` → IS NOT NULL,
    * anything else → `column = $N`.
+   *
+   * `excludeDeleted` opts into the live-row predicate `query` applies by
+   * default. Opt-in rather than default here because an update is also how a
+   * soft-deleted row would be restored.
    */
   async update(
     primaryKeyValue: ParamValue,
@@ -178,6 +182,7 @@ export abstract class Table<
     userId?: string,
     client?: QueryExecutor,
     extraWhere?: AdditionalWhere[],
+    excludeDeleted?: boolean,
   ): Promise<Record<string, unknown> | null> {
     this._assertSimplePrimaryKey("update");
     const additionalWhere: AdditionalWhere[] = [];
@@ -186,6 +191,7 @@ export abstract class Table<
     const query = buildUpdate(this.name, this.primaryKey, primaryKeyValue, data, {
       returning: returning ?? [this.primaryKey],
       additionalWhere: additionalWhere.length > 0 ? additionalWhere : undefined,
+      excludeDeleted: excludeDeleted && this.supportsSoftDelete,
     });
     if (!query) return null;
     const executor = client ?? pool;

--- a/src/server/lib/postgres/repositories/accounts.test.ts
+++ b/src/server/lib/postgres/repositories/accounts.test.ts
@@ -24,6 +24,7 @@ const {
   getAccount,
   searchAccounts,
   searchAccountsById,
+  createAccount,
   upsertAccounts,
   deleteAccounts,
 } = await import("./accounts");
@@ -244,6 +245,54 @@ describe("upsertAccounts", () => {
     const result = await upsertAccounts(testUser, accounts);
     expect(result).toHaveLength(3);
     expect(result.every((r: { status: number }) => r.status === 200)).toBe(true);
+  });
+});
+
+describe("createAccount", () => {
+  const newAccount = {
+    account_id: "acc-new",
+    item_id: "item-1",
+    institution_id: "Unknown",
+    name: "Unknown",
+    type: AccountType.Other,
+  } as Parameters<typeof createAccount>[1];
+
+  test("issues an INSERT, never an UPSERT — ON CONFLICT has no user_id guard", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ account_id: "acc-new" }], rowCount: 1 });
+    await createAccount(testUser, newAccount);
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toMatch(/^\s*INSERT\s+INTO\s+accounts\b/i);
+    expect(sql).not.toMatch(/ON\s+CONFLICT/i);
+  });
+
+  test("binds the requesting user's id and the account's own id", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ account_id: "acc-new" }], rowCount: 1 });
+    await createAccount({ user_id: "usr-99", username: "other" }, newAccount);
+    const values = mockQuery.mock.calls[0][1] as unknown[];
+    expect(values).toContain("usr-99");
+    expect(values).toContain("acc-new");
+    expect(values).toContain("item-1");
+  });
+
+  test("returns a success result when a row comes back", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ account_id: "acc-new" }], rowCount: 1 });
+    const result = await createAccount(testUser, newAccount);
+    expect(result.status).toBe(200);
+    expect(result.update._id).toBe("acc-new");
+  });
+
+  test("returns an error result when the insert returns no row", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const result = await createAccount(testUser, newAccount);
+    expect(result.status).toBe(500);
+    expect(result.update._id).toBe("acc-new");
+  });
+
+  test("returns an error result on a unique violation", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("duplicate key value violates unique constraint"));
+    const result = await createAccount(testUser, newAccount);
+    expect(result.status).toBe(500);
+    expect(result.update._id).toBe("acc-new");
   });
 });
 

--- a/src/server/lib/postgres/repositories/accounts.test.ts
+++ b/src/server/lib/postgres/repositories/accounts.test.ts
@@ -288,8 +288,21 @@ describe("createAccount", () => {
     expect(result.update._id).toBe("acc-new");
   });
 
-  test("returns an error result on a unique violation", async () => {
-    mockQuery.mockRejectedValueOnce(new Error("duplicate key value violates unique constraint"));
+  test("returns a conflict result — not a fault — on a 23505 unique violation", async () => {
+    mockQuery.mockRejectedValueOnce(
+      Object.assign(new Error("duplicate key value violates unique constraint"), {
+        code: "23505",
+      }),
+    );
+    const result = await createAccount(testUser, newAccount);
+    expect(result.status).toBe(409);
+    expect(result.update._id).toBe("acc-new");
+  });
+
+  test("returns an error result when the insert throws for any other reason", async () => {
+    mockQuery.mockRejectedValueOnce(Object.assign(new Error("invalid input syntax"), {
+      code: "22P02",
+    }));
     const result = await createAccount(testUser, newAccount);
     expect(result.status).toBe(500);
     expect(result.update._id).toBe("acc-new");

--- a/src/server/lib/postgres/repositories/accounts.ts
+++ b/src/server/lib/postgres/repositories/accounts.ts
@@ -138,7 +138,18 @@ export const updateAccounts = async (
       delete row.account_id;
       delete row.user_id;
 
-      const updated = await accountsTable.update(account.account_id, row, undefined, user.user_id);
+      // Soft-deleted rows keep their primary key but are invisible to every
+      // read. Updating one would report a change the user can never see, and
+      // it is what tells `POST /account` that the id is free to insert into.
+      const updated = await accountsTable.update(
+        account.account_id,
+        row,
+        undefined,
+        user.user_id,
+        undefined,
+        undefined,
+        true,
+      );
       results.push(
         updated ? successResult(account.account_id, 1) : noChangeResult(account.account_id),
       );

--- a/src/server/lib/postgres/repositories/accounts.ts
+++ b/src/server/lib/postgres/repositories/accounts.ts
@@ -15,7 +15,14 @@ import {
   INSTITUTION_ID,
   QueryExecutor,
 } from "../models";
-import { UpsertResult, successResult, errorResult, noChangeResult } from "../database";
+import {
+  UpsertResult,
+  successResult,
+  errorResult,
+  noChangeResult,
+  conflictResult,
+  isUniqueViolation,
+} from "../database";
 import { withTransaction } from "../client";
 import { logger } from "../../logger";
 
@@ -79,7 +86,8 @@ export const searchAccountsById = async (
  * Deliberately not `accountsTable.upsert`: its `ON CONFLICT` clause carries no
  * `user_id` guard, so a caller supplying an `account_id` that already belongs
  * to another user would overwrite that user's row. An INSERT raises a unique
- * violation instead, which is reported as an error result.
+ * violation instead, reported as a conflict — a client error, not a fault, so
+ * the caller can answer it without the route escalating to a 500 and an alarm.
  */
 export const createAccount = async (
   user: MaskedUser,
@@ -90,6 +98,7 @@ export const createAccount = async (
     const inserted = await accountsTable.insert(row);
     return inserted ? successResult(account.account_id, 1) : errorResult(account.account_id);
   } catch (error) {
+    if (isUniqueViolation(error)) return conflictResult(account.account_id);
     logger.error("Failed to create account", { accountId: account.account_id }, error);
     return errorResult(account.account_id);
   }

--- a/src/server/lib/postgres/repositories/accounts.ts
+++ b/src/server/lib/postgres/repositories/accounts.ts
@@ -21,6 +21,12 @@ import { logger } from "../../logger";
 
 export type PartialAccount = { account_id: string } & Partial<JSONAccount>;
 
+/**
+ * `item_id` and `institution_id` are `NOT NULL` in the accounts schema, so an
+ * INSERT needs both up front — unlike an UPDATE, which may omit either.
+ */
+export type CreatableAccount = PartialAccount & { item_id: string; institution_id: string };
+
 export const getAccounts = async (user: MaskedUser): Promise<JSONAccount[]> => {
   const models = await accountsTable.query({ [USER_ID]: user.user_id });
   return models.map((m) => m.toJSON());
@@ -65,6 +71,28 @@ export const searchAccountsById = async (
   if (!account_ids.length) return [];
   const models = await accountsTable.queryByIds(account_ids, { [USER_ID]: user.user_id });
   return models.map((m) => m.toJSON());
+};
+
+/**
+ * Creates one account row with an INSERT.
+ *
+ * Deliberately not `accountsTable.upsert`: its `ON CONFLICT` clause carries no
+ * `user_id` guard, so a caller supplying an `account_id` that already belongs
+ * to another user would overwrite that user's row. An INSERT raises a unique
+ * violation instead, which is reported as an error result.
+ */
+export const createAccount = async (
+  user: MaskedUser,
+  account: CreatableAccount,
+): Promise<UpsertResult> => {
+  try {
+    const row = AccountModel.fromJSON(account, user.user_id);
+    const inserted = await accountsTable.insert(row);
+    return inserted ? successResult(account.account_id, 1) : errorResult(account.account_id);
+  } catch (error) {
+    logger.error("Failed to create account", { accountId: account.account_id }, error);
+    return errorResult(account.account_id);
+  }
 };
 
 export const upsertAccounts = async (

--- a/src/server/routes/accounts/post-account.test.ts
+++ b/src/server/routes/accounts/post-account.test.ts
@@ -16,22 +16,26 @@ type Row = Record<string, unknown>;
  * mutable fixture instead.
  */
 const db = {
-  account: null as Row | null,
   item: null as Row | null,
   insertReturns: [] as Row[],
+  insertError: null as Error | null,
   updateReturns: [] as Row[],
+  updateError: null as Error | null,
 };
 
 const mockQuery = mock(async (sql: string, _values?: unknown[]) => {
   const rows = (() => {
-    if (/^\s*SELECT\b[\s\S]*\bFROM\s+accounts\b/i.test(sql)) {
-      return db.account ? [db.account] : [];
-    }
     if (/^\s*SELECT\b[\s\S]*\bFROM\s+items\b/i.test(sql)) {
       return db.item ? [db.item] : [];
     }
-    if (/^\s*INSERT\s+INTO\s+accounts\b/i.test(sql)) return db.insertReturns;
-    if (/^\s*UPDATE\s+accounts\b/i.test(sql)) return db.updateReturns;
+    if (/^\s*INSERT\s+INTO\s+accounts\b/i.test(sql)) {
+      if (db.insertError) throw db.insertError;
+      return db.insertReturns;
+    }
+    if (/^\s*UPDATE\s+accounts\b/i.test(sql)) {
+      if (db.updateError) throw db.updateError;
+      return db.updateReturns;
+    }
     return [];
   })();
   return { rows: rows as unknown[], rowCount: rows.length as number | null };
@@ -56,13 +60,14 @@ afterAll(restoreLeaves);
 beforeEach(() => {
   // Clear the call log but keep the fixture-driven implementation.
   mockQuery.mockClear();
-  db.account = null;
   db.item = null;
   db.insertReturns = [];
+  db.insertError = null;
   db.updateReturns = [];
+  db.updateError = null;
 });
 
-/** Full rows — `Table.queryOne` hydrates a Model, which validates every column. */
+/** Full row — `Table.queryOne` hydrates an ItemModel, which validates every column. */
 const makeItemRow = (overrides: Row = {}): Row => ({
   item_id: "item-manual",
   user_id: "u-1",
@@ -81,30 +86,6 @@ const makeItemRow = (overrides: Row = {}): Row => ({
   ...overrides,
 });
 
-const makeAccountRow = (overrides: Row = {}): Row => ({
-  account_id: "acc-1",
-  user_id: "u-1",
-  item_id: "item-manual",
-  institution_id: "Unknown",
-  name: "Unknown",
-  type: "other",
-  subtype: null,
-  balances_available: 0,
-  balances_current: 0,
-  balances_limit: null,
-  balances_iso_currency_code: "USD",
-  custom_name: null,
-  hide: false,
-  archived: false,
-  label_budget_id: null,
-  graph_options_use_snapshots: true,
-  graph_options_use_holding_snapshots: true,
-  graph_options_use_transactions: false,
-  raw: null,
-  updated: "2026-08-01T00:00:00Z",
-  is_deleted: false,
-  ...overrides,
-});
 
 const newAccountBody = {
   account_id: "acc-new",
@@ -193,7 +174,6 @@ describe("post-account create path", () => {
     expect(insert!.values).toContain("acc-new");
     expect(insert!.values).toContain("u-1");
     expect(insert!.values).toContain("item-manual");
-    // The bug this replaces: the create path ran an UPDATE that matched no row.
     expect(findStatement(UPDATE_ACCOUNTS)).toBeNull();
   });
 
@@ -203,7 +183,8 @@ describe("post-account create path", () => {
 
     const result = await postAccountRoute.execute(makeReq(newAccountBody, "u-1"), fakeRes());
 
-    expect(result?.status).not.toBe("success");
+    expect(result?.status).toBe("error");
+    expect(result?.message).toBe("Internal server error");
   });
 
   test("rejects a create against an item the user does not own", async () => {
@@ -229,14 +210,16 @@ describe("post-account create path", () => {
     expect(findStatement(INSERT_ACCOUNTS)).toBeNull();
   });
 
-  test("rejects a create with no item_id", async () => {
-    const { item_id: _item_id, ...withoutItemId } = newAccountBody;
+  test("reports a conflict, not a fault, when the id is already taken", async () => {
+    db.item = makeItemRow();
+    db.insertError = Object.assign(new Error("duplicate key"), { code: "23505" });
 
-    const result = await postAccountRoute.execute(makeReq(withoutItemId, "u-1"), fakeRes());
+    const result = await postAccountRoute.execute(makeReq(newAccountBody, "u-1"), fakeRes());
 
+    // A soft-deleted row keeps its primary key, so re-creating that id is a
+    // client error. Escalating to a 500 would fire the global-cooldown alarm.
     expect(result?.status).toBe("failed");
-    expect(result?.message).toMatch(/item_id/i);
-    expect(findStatement(INSERT_ACCOUNTS)).toBeNull();
+    expect(result?.message).toBe("Account already exists.");
   });
 
   test("rejects a create with no institution_id — the column is NOT NULL", async () => {
@@ -263,14 +246,12 @@ describe("post-account create path", () => {
 });
 
 describe("post-account update path", () => {
+  const editBody = { account_id: "acc-1", custom_name: "Renamed" };
+
   test("updates an existing account and never inserts", async () => {
-    db.account = makeAccountRow();
     db.updateReturns = [{ account_id: "acc-1" }];
 
-    const result = await postAccountRoute.execute(
-      makeReq({ account_id: "acc-1", custom_name: "Renamed" }, "u-1"),
-      fakeRes(),
-    );
+    const result = await postAccountRoute.execute(makeReq(editBody, "u-1"), fakeRes());
 
     expect(result?.status).toBe("success");
     expect(result?.body?.account_id).toBe("acc-1");
@@ -282,27 +263,32 @@ describe("post-account update path", () => {
     expect(findStatement(INSERT_ACCOUNTS)).toBeNull();
   });
 
-  test("does not consult the item table when the account already exists", async () => {
-    db.account = makeAccountRow();
+  test("costs exactly one statement — no existence probe on the hot edit path", async () => {
     db.updateReturns = [{ account_id: "acc-1" }];
 
-    await postAccountRoute.execute(
-      makeReq({ account_id: "acc-1", custom_name: "Renamed" }, "u-1"),
-      fakeRes(),
-    );
+    await postAccountRoute.execute(makeReq(editBody, "u-1"), fakeRes());
 
+    expect(mockQuery.mock.calls).toHaveLength(1);
     expect(findStatement(/^\s*SELECT\b[\s\S]*\bFROM\s+items\b/i)).toBeNull();
   });
 
-  test("reports failure when the update matches no row", async () => {
-    db.account = makeAccountRow();
+  test("reports Account not found when the update matches no row", async () => {
     db.updateReturns = [];
 
-    const result = await postAccountRoute.execute(
-      makeReq({ account_id: "acc-1", custom_name: "Renamed" }, "u-1"),
-      fakeRes(),
-    );
+    const result = await postAccountRoute.execute(makeReq(editBody, "u-1"), fakeRes());
 
-    expect(result?.status).not.toBe("success");
+    // An edit body carries no item_id, so a vanished row must not be reported
+    // as a missing-item_id validation error.
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toBe("Account not found.");
+  });
+
+  test("surfaces a DB fault on the edit path as an error", async () => {
+    db.updateError = new Error("db down");
+
+    const result = await postAccountRoute.execute(makeReq(editBody, "u-1"), fakeRes());
+
+    expect(result?.status).toBe("error");
+    expect(result?.message).toBe("Internal server error");
   });
 });

--- a/src/server/routes/accounts/post-account.test.ts
+++ b/src/server/routes/accounts/post-account.test.ts
@@ -1,0 +1,308 @@
+import { describe, test, expect, mock, beforeEach, afterAll } from "bun:test";
+import { restoreLeaves } from "test-helpers";
+import { ItemProvider } from "common";
+
+// `POST /api/account` serves both the create and the edit path. A FakePool
+// intercepts pg so the statement the route actually issues can be asserted:
+// which of INSERT / UPDATE runs decides whether a brand-new manual account is
+// persisted at all, and a repo unit test (which writes what it is told) cannot
+// see that choice.
+
+type Row = Record<string, unknown>;
+
+/**
+ * Re-`mockImplementation`-ing a Bun mock inside a test does not reliably
+ * replace the module-level default, so the default implementation reads this
+ * mutable fixture instead.
+ */
+const db = {
+  account: null as Row | null,
+  item: null as Row | null,
+  insertReturns: [] as Row[],
+  updateReturns: [] as Row[],
+};
+
+const mockQuery = mock(async (sql: string, _values?: unknown[]) => {
+  const rows = (() => {
+    if (/^\s*SELECT\b[\s\S]*\bFROM\s+accounts\b/i.test(sql)) {
+      return db.account ? [db.account] : [];
+    }
+    if (/^\s*SELECT\b[\s\S]*\bFROM\s+items\b/i.test(sql)) {
+      return db.item ? [db.item] : [];
+    }
+    if (/^\s*INSERT\s+INTO\s+accounts\b/i.test(sql)) return db.insertReturns;
+    if (/^\s*UPDATE\s+accounts\b/i.test(sql)) return db.updateReturns;
+    return [];
+  })();
+  return { rows: rows as unknown[], rowCount: rows.length as number | null };
+});
+
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+}
+
+mock.module("pg", () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {} },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+}));
+
+const { postAccountRoute } = await import("./post-account");
+
+afterAll(restoreLeaves);
+
+beforeEach(() => {
+  // Clear the call log but keep the fixture-driven implementation.
+  mockQuery.mockClear();
+  db.account = null;
+  db.item = null;
+  db.insertReturns = [];
+  db.updateReturns = [];
+});
+
+/** Full rows — `Table.queryOne` hydrates a Model, which validates every column. */
+const makeItemRow = (overrides: Row = {}): Row => ({
+  item_id: "item-manual",
+  user_id: "u-1",
+  access_token: "no_access_token",
+  institution_id: null,
+  available_products: [],
+  cursor: null,
+  status: "ok",
+  provider: ItemProvider.MANUAL,
+  last_sync_status: null,
+  last_sync_at: null,
+  last_sync_error: null,
+  raw: null,
+  updated: "2026-08-01T00:00:00Z",
+  is_deleted: false,
+  ...overrides,
+});
+
+const makeAccountRow = (overrides: Row = {}): Row => ({
+  account_id: "acc-1",
+  user_id: "u-1",
+  item_id: "item-manual",
+  institution_id: "Unknown",
+  name: "Unknown",
+  type: "other",
+  subtype: null,
+  balances_available: 0,
+  balances_current: 0,
+  balances_limit: null,
+  balances_iso_currency_code: "USD",
+  custom_name: null,
+  hide: false,
+  archived: false,
+  label_budget_id: null,
+  graph_options_use_snapshots: true,
+  graph_options_use_holding_snapshots: true,
+  graph_options_use_transactions: false,
+  raw: null,
+  updated: "2026-08-01T00:00:00Z",
+  is_deleted: false,
+  ...overrides,
+});
+
+const newAccountBody = {
+  account_id: "acc-new",
+  item_id: "item-manual",
+  institution_id: "Unknown",
+  name: "Unknown",
+};
+
+function makeReq(body: unknown, userId?: string) {
+  return {
+    method: "POST",
+    path: "/account",
+    url: "http://x/api/account",
+    headers: {},
+    query: {},
+    body,
+    session: {
+      id: "s-1",
+      user: userId ? { user_id: userId, username: "test" } : undefined,
+      regenerate() {},
+      destroy() {},
+    },
+    ip: "127.0.0.1",
+  } as unknown as Parameters<typeof postAccountRoute.execute>[0];
+}
+
+const fakeRes = () =>
+  ({
+    statusCode: 200,
+    headersSent: false,
+    status() {
+      return this;
+    },
+    write() {
+      return true;
+    },
+    end() {},
+  }) as unknown as Parameters<typeof postAccountRoute.execute>[1];
+
+/** Find the first statement in the call log matching `re`. */
+const findStatement = (re: RegExp): { sql: string; values: unknown[] } | null => {
+  for (const call of mockQuery.mock.calls) {
+    const sql = call[0] as string;
+    if (re.test(sql)) return { sql, values: (call[1] ?? []) as unknown[] };
+  }
+  return null;
+};
+
+const INSERT_ACCOUNTS = /^\s*INSERT\s+INTO\s+accounts\b/i;
+const UPDATE_ACCOUNTS = /^\s*UPDATE\s+accounts\b/i;
+
+describe("post-account validation", () => {
+  test("rejects unauthenticated requests", async () => {
+    const result = await postAccountRoute.execute(makeReq(newAccountBody), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/not authenticated/i);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("rejects a non-object body", async () => {
+    const result = await postAccountRoute.execute(makeReq("not-an-object", "u-1"), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  test("rejects a missing account_id", async () => {
+    const result = await postAccountRoute.execute(makeReq({ item_id: "item-manual" }, "u-1"), fakeRes());
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/account_id/i);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe("post-account create path", () => {
+  test("inserts a row for an account_id that does not exist yet", async () => {
+    db.item = makeItemRow();
+    db.insertReturns = [{ account_id: "acc-new" }];
+
+    const result = await postAccountRoute.execute(makeReq(newAccountBody, "u-1"), fakeRes());
+
+    expect(result?.status).toBe("success");
+    expect(result?.body?.account_id).toBe("acc-new");
+
+    const insert = findStatement(INSERT_ACCOUNTS);
+    expect(insert).not.toBeNull();
+    expect(insert!.values).toContain("acc-new");
+    expect(insert!.values).toContain("u-1");
+    expect(insert!.values).toContain("item-manual");
+    // The bug this replaces: the create path ran an UPDATE that matched no row.
+    expect(findStatement(UPDATE_ACCOUNTS)).toBeNull();
+  });
+
+  test("reports failure — not success — when the insert writes no row", async () => {
+    db.item = makeItemRow();
+    db.insertReturns = [];
+
+    const result = await postAccountRoute.execute(makeReq(newAccountBody, "u-1"), fakeRes());
+
+    expect(result?.status).not.toBe("success");
+  });
+
+  test("rejects a create against an item the user does not own", async () => {
+    db.item = null;
+
+    const result = await postAccountRoute.execute(makeReq(newAccountBody, "u-1"), fakeRes());
+
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/item not found/i);
+    expect(findStatement(INSERT_ACCOUNTS)).toBeNull();
+  });
+
+  test("rejects a create against a non-manual item", async () => {
+    db.item = makeItemRow({ item_id: "item-plaid", provider: ItemProvider.PLAID });
+
+    const result = await postAccountRoute.execute(
+      makeReq({ ...newAccountBody, item_id: "item-plaid" }, "u-1"),
+      fakeRes(),
+    );
+
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/not a manual account/i);
+    expect(findStatement(INSERT_ACCOUNTS)).toBeNull();
+  });
+
+  test("rejects a create with no item_id", async () => {
+    const { item_id: _item_id, ...withoutItemId } = newAccountBody;
+
+    const result = await postAccountRoute.execute(makeReq(withoutItemId, "u-1"), fakeRes());
+
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/item_id/i);
+    expect(findStatement(INSERT_ACCOUNTS)).toBeNull();
+  });
+
+  test("rejects a create with no institution_id — the column is NOT NULL", async () => {
+    const { institution_id: _institution_id, ...withoutInstitutionId } = newAccountBody;
+
+    const result = await postAccountRoute.execute(makeReq(withoutInstitutionId, "u-1"), fakeRes());
+
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/institution_id/i);
+    expect(findStatement(INSERT_ACCOUNTS)).toBeNull();
+  });
+
+  test("scopes the ownership lookup to the requesting user", async () => {
+    db.item = makeItemRow();
+    db.insertReturns = [{ account_id: "acc-new" }];
+
+    await postAccountRoute.execute(makeReq(newAccountBody, "u-1"), fakeRes());
+
+    const itemLookup = findStatement(/^\s*SELECT\b[\s\S]*\bFROM\s+items\b/i);
+    expect(itemLookup).not.toBeNull();
+    expect(itemLookup!.values).toContain("u-1");
+    expect(itemLookup!.values).toContain("item-manual");
+  });
+});
+
+describe("post-account update path", () => {
+  test("updates an existing account and never inserts", async () => {
+    db.account = makeAccountRow();
+    db.updateReturns = [{ account_id: "acc-1" }];
+
+    const result = await postAccountRoute.execute(
+      makeReq({ account_id: "acc-1", custom_name: "Renamed" }, "u-1"),
+      fakeRes(),
+    );
+
+    expect(result?.status).toBe("success");
+    expect(result?.body?.account_id).toBe("acc-1");
+
+    const update = findStatement(UPDATE_ACCOUNTS);
+    expect(update).not.toBeNull();
+    expect(update!.values).toContain("Renamed");
+    expect(update!.values).toContain("u-1");
+    expect(findStatement(INSERT_ACCOUNTS)).toBeNull();
+  });
+
+  test("does not consult the item table when the account already exists", async () => {
+    db.account = makeAccountRow();
+    db.updateReturns = [{ account_id: "acc-1" }];
+
+    await postAccountRoute.execute(
+      makeReq({ account_id: "acc-1", custom_name: "Renamed" }, "u-1"),
+      fakeRes(),
+    );
+
+    expect(findStatement(/^\s*SELECT\b[\s\S]*\bFROM\s+items\b/i)).toBeNull();
+  });
+
+  test("reports failure when the update matches no row", async () => {
+    db.account = makeAccountRow();
+    db.updateReturns = [];
+
+    const result = await postAccountRoute.execute(
+      makeReq({ account_id: "acc-1", custom_name: "Renamed" }, "u-1"),
+      fakeRes(),
+    );
+
+    expect(result?.status).not.toBe("success");
+  });
+});

--- a/src/server/routes/accounts/post-account.test.ts
+++ b/src/server/routes/accounts/post-account.test.ts
@@ -185,6 +185,7 @@ describe("post-account create path", () => {
   });
 
   test("treats a body carrying item_id as an edit when the row exists", async () => {
+    db.item = makeItemRow();
     db.updateReturns = [{ account_id: "acc-1" }];
 
     // Nothing stops a client from posting item_id on an edit. Classifying by
@@ -198,6 +199,37 @@ describe("post-account create path", () => {
     expect(result?.status).toBe("success");
     expect(result?.body?.account_id).toBe("acc-1");
     expect(findStatement(INSERT_ACCOUNTS)).toBeNull();
+  });
+
+  test("refuses to move an existing account onto an item the user does not own", async () => {
+    db.item = null;
+    db.updateReturns = [{ account_id: "acc-1" }];
+
+    // account_id is the user's, so the UPDATE would match. item_id has no
+    // foreign key, so writing it unchecked would reparent the account onto
+    // someone else's item.
+    const result = await postAccountRoute.execute(
+      makeReq({ account_id: "acc-1", item_id: "item-somebody-else" }, "u-1"),
+      fakeRes(),
+    );
+
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/item not found/i);
+    expect(findStatement(UPDATE_ACCOUNTS)).toBeNull();
+  });
+
+  test("refuses to move an existing account onto a Plaid item", async () => {
+    db.item = makeItemRow({ item_id: "item-plaid", provider: ItemProvider.PLAID });
+    db.updateReturns = [{ account_id: "acc-1" }];
+
+    const result = await postAccountRoute.execute(
+      makeReq({ account_id: "acc-1", item_id: "item-plaid" }, "u-1"),
+      fakeRes(),
+    );
+
+    expect(result?.status).toBe("failed");
+    expect(result?.message).toMatch(/not a manual account/i);
+    expect(findStatement(UPDATE_ACCOUNTS)).toBeNull();
   });
 
   test("does not resurrect a soft-deleted row on the way to the insert", async () => {
@@ -259,6 +291,7 @@ describe("post-account create path", () => {
   });
 
   test("rejects a create with no institution_id — the column is NOT NULL", async () => {
+    db.item = makeItemRow();
     const { institution_id: _institution_id, ...withoutInstitutionId } = newAccountBody;
 
     const result = await postAccountRoute.execute(makeReq(withoutInstitutionId, "u-1"), fakeRes());

--- a/src/server/routes/accounts/post-account.test.ts
+++ b/src/server/routes/accounts/post-account.test.ts
@@ -77,6 +77,7 @@ const makeItemRow = (overrides: Row = {}): Row => ({
   cursor: null,
   status: "ok",
   provider: ItemProvider.MANUAL,
+  status_reason: null,
   last_sync_status: null,
   last_sync_at: null,
   last_sync_error: null,
@@ -85,7 +86,6 @@ const makeItemRow = (overrides: Row = {}): Row => ({
   is_deleted: false,
   ...overrides,
 });
-
 
 const newAccountBody = {
   account_id: "acc-new",
@@ -174,7 +174,43 @@ describe("post-account create path", () => {
     expect(insert!.values).toContain("acc-new");
     expect(insert!.values).toContain("u-1");
     expect(insert!.values).toContain("item-manual");
-    expect(findStatement(UPDATE_ACCOUNTS)).toBeNull();
+
+    // The create path is reached by the UPDATE matching nothing, not by the
+    // body carrying an item_id — so the UPDATE runs first and precedes it.
+    const update = findStatement(UPDATE_ACCOUNTS);
+    expect(update).not.toBeNull();
+    expect(mockQuery.mock.calls.findIndex((c) => UPDATE_ACCOUNTS.test(c[0] as string))).toBeLessThan(
+      mockQuery.mock.calls.findIndex((c) => INSERT_ACCOUNTS.test(c[0] as string)),
+    );
+  });
+
+  test("treats a body carrying item_id as an edit when the row exists", async () => {
+    db.updateReturns = [{ account_id: "acc-1" }];
+
+    // Nothing stops a client from posting item_id on an edit. Classifying by
+    // body shape would send this to INSERT, hit the primary key, and report
+    // "Account already exists." for a rename that should have succeeded.
+    const result = await postAccountRoute.execute(
+      makeReq({ account_id: "acc-1", item_id: "item-manual", custom_name: "Renamed" }, "u-1"),
+      fakeRes(),
+    );
+
+    expect(result?.status).toBe("success");
+    expect(result?.body?.account_id).toBe("acc-1");
+    expect(findStatement(INSERT_ACCOUNTS)).toBeNull();
+  });
+
+  test("does not resurrect a soft-deleted row on the way to the insert", async () => {
+    db.item = makeItemRow();
+    db.insertError = Object.assign(new Error("duplicate key"), { code: "23505" });
+
+    const result = await postAccountRoute.execute(makeReq(newAccountBody, "u-1"), fakeRes());
+
+    // A soft-deleted row keeps its primary key. If the UPDATE matched it, the
+    // route would answer success for a row no read can see.
+    const update = findStatement(UPDATE_ACCOUNTS);
+    expect(update!.sql).toContain("is_deleted");
+    expect(result?.message).toBe("Account already exists.");
   });
 
   test("reports failure — not success — when the insert writes no row", async () => {

--- a/src/server/routes/accounts/post-account.ts
+++ b/src/server/routes/accounts/post-account.ts
@@ -38,32 +38,14 @@ export const postAccountRoute = new Route<AccountPostResponse>("POST", "/account
     return { status: "success" as const, body: { account_id } };
   };
 
-  try {
-    // UPDATE first, so the database decides whether this is an edit or a
-    // create. Classifying by body shape instead — treating a request as a
-    // create because it carries `item_id` — makes a server decision out of a
-    // client convention: an edit that happens to send `item_id` would skip the
-    // UPDATE, hit the primary key on INSERT, and report "already exists" for a
-    // rename that should have succeeded. An edit costs the one statement it
-    // always did; only a miss pays for the second.
-    const updated = (await updateAccounts(user, [body as PartialAccount]))[0];
-    if (updated?.status === 200) return succeed(updated);
-    if (updated?.status !== 304) {
-      throw new Error(`Account update did not persist, status ${updated?.status ?? "missing"}`);
-    }
-
-    // No live row of the user's carries this id, so the id is free. A create
-    // needs the columns an edit never has to supply.
-    if (isUndefined(body.item_id)) {
-      return { status: "failed", message: "Account not found." };
-    }
-
+  // `item_id` decides which item an account hangs off, and the column carries
+  // no foreign key — so it is validated wherever it appears, not only on the
+  // create path. Writing it unchecked would let a request move an owned
+  // account onto someone else's item, or onto a Plaid item that the
+  // manual-only guard below exists to keep it off.
+  if (!isUndefined(body.item_id)) {
     const itemIdResult = requireStringField(body, "item_id");
     if (!itemIdResult.success) return validationError(itemIdResult.error!);
-
-    // institution_id is NOT NULL, so an INSERT needs it up front.
-    const institutionIdResult = requireStringField(body, "institution_id");
-    if (!institutionIdResult.success) return validationError(institutionIdResult.error!);
 
     const item = await getItem(user, itemIdResult.data!);
     if (!item) {
@@ -79,6 +61,32 @@ export const postAccountRoute = new Route<AccountPostResponse>("POST", "/account
         message: "Account is not a manual account.",
       };
     }
+  }
+
+  try {
+    // UPDATE first, so the database decides whether this is an edit or a
+    // create. Classifying by body shape instead — treating a request as a
+    // create because it carries `item_id` — makes a server decision out of a
+    // client convention: an edit that happens to send `item_id` would skip the
+    // UPDATE, hit the primary key on INSERT, and report "already exists" for a
+    // rename that should have succeeded. The hot edit path still costs the one
+    // statement it always did.
+    const updated = (await updateAccounts(user, [body as PartialAccount]))[0];
+    if (updated?.status === 200) return succeed(updated);
+    if (updated?.status !== 304) {
+      throw new Error(`Account update did not persist, status ${updated?.status ?? "missing"}`);
+    }
+
+    // Either no live row of the user's carries this id, or the body held
+    // nothing `buildUpdate` could set. A create needs the columns an edit never
+    // has to supply, so a body without `item_id` can only be the former.
+    if (isUndefined(body.item_id)) {
+      return { status: "failed", message: "Account not found." };
+    }
+
+    // institution_id is NOT NULL, so an INSERT needs it up front.
+    const institutionIdResult = requireStringField(body, "institution_id");
+    if (!institutionIdResult.success) return validationError(institutionIdResult.error!);
 
     const created = await createAccount(user, body as CreatableAccount);
 

--- a/src/server/routes/accounts/post-account.ts
+++ b/src/server/routes/accounts/post-account.ts
@@ -32,12 +32,32 @@ export const postAccountRoute = new Route<AccountPostResponse>("POST", "/account
   const idResult = requireStringField(body, "account_id");
   if (!idResult.success) return validationError(idResult.error!);
 
-  // A create posts a whole Account, `item_id` included; an edit posts only the
-  // fields it changes and never carries one. Reading the row back to classify
-  // the request instead would put an extra statement on every edit.
-  const isCreate = !isUndefined(body.item_id);
+  const succeed = (result: UpsertResult) => {
+    const account_id = result.update._id;
+    if (!account_id) throw new Error("Account ID is missing after write");
+    return { status: "success" as const, body: { account_id } };
+  };
 
-  if (isCreate) {
+  try {
+    // UPDATE first, so the database decides whether this is an edit or a
+    // create. Classifying by body shape instead — treating a request as a
+    // create because it carries `item_id` — makes a server decision out of a
+    // client convention: an edit that happens to send `item_id` would skip the
+    // UPDATE, hit the primary key on INSERT, and report "already exists" for a
+    // rename that should have succeeded. An edit costs the one statement it
+    // always did; only a miss pays for the second.
+    const updated = (await updateAccounts(user, [body as PartialAccount]))[0];
+    if (updated?.status === 200) return succeed(updated);
+    if (updated?.status !== 304) {
+      throw new Error(`Account update did not persist, status ${updated?.status ?? "missing"}`);
+    }
+
+    // No live row of the user's carries this id, so the id is free. A create
+    // needs the columns an edit never has to supply.
+    if (isUndefined(body.item_id)) {
+      return { status: "failed", message: "Account not found." };
+    }
+
     const itemIdResult = requireStringField(body, "item_id");
     if (!itemIdResult.success) return validationError(itemIdResult.error!);
 
@@ -59,27 +79,18 @@ export const postAccountRoute = new Route<AccountPostResponse>("POST", "/account
         message: "Account is not a manual account.",
       };
     }
-  }
 
-  try {
-    const result: UpsertResult | undefined = isCreate
-      ? await createAccount(user, body as CreatableAccount)
-      : (await updateAccounts(user, [body as PartialAccount]))[0];
+    const created = await createAccount(user, body as CreatableAccount);
 
-    switch (result?.status) {
-      case 200: {
-        const account_id = result.update._id;
-        if (!account_id) throw new Error("Account ID is missing after write");
-        return { status: "success", body: { account_id } };
-      }
-      case 304:
-        // The UPDATE matched no row: the account is gone, or was never the
-        // requesting user's.
-        return { status: "failed", message: "Account not found." };
+    switch (created?.status) {
+      case 200:
+        return succeed(created);
       case 409:
+        // A soft-deleted row keeps its primary key, and the UPDATE above
+        // deliberately does not match one, so the id is taken but unusable.
         return { status: "failed", message: "Account already exists." };
       default:
-        throw new Error(`Account write did not persist, status ${result?.status ?? "missing"}`);
+        throw new Error(`Account insert did not persist, status ${created?.status ?? "missing"}`);
     }
   } catch (error: unknown) {
     logger.error("Failed to write account", { accountId: idResult.data }, error);

--- a/src/server/routes/accounts/post-account.ts
+++ b/src/server/routes/accounts/post-account.ts
@@ -1,5 +1,15 @@
-import { Route, updateAccounts, requireBodyObject, requireStringField, validationError } from "server";
-import type { PartialAccount } from "server";
+import { ItemProvider } from "common";
+import {
+  Route,
+  createAccount,
+  getAccount,
+  getItem,
+  updateAccounts,
+  requireBodyObject,
+  requireStringField,
+  validationError,
+} from "server";
+import type { CreatableAccount, PartialAccount, UpsertResult } from "server";
 import { logger } from "server/lib/logger";
 
 export interface AccountPostResponse {
@@ -23,17 +33,46 @@ export const postAccountRoute = new Route<AccountPostResponse>("POST", "/account
   const idResult = requireStringField(body, "account_id");
   if (!idResult.success) return validationError(idResult.error!);
 
+  const existing = await getAccount(user, idResult.data!);
+
+  if (!existing) {
+    const itemIdResult = requireStringField(body, "item_id");
+    if (!itemIdResult.success) return validationError(itemIdResult.error!);
+
+    const institutionIdResult = requireStringField(body, "institution_id");
+    if (!institutionIdResult.success) return validationError(institutionIdResult.error!);
+
+    const item = await getItem(user, itemIdResult.data!);
+    if (!item) {
+      return {
+        status: "failed",
+        message: "Item not found.",
+      };
+    }
+
+    if (item.provider !== ItemProvider.MANUAL) {
+      return {
+        status: "failed",
+        message: "Account is not a manual account.",
+      };
+    }
+  }
+
   try {
-    const response = await updateAccounts(user, [body as PartialAccount]);
-    const result = response[0];
-    if (!result || result.status >= 400) {
-      throw new Error("Unknown error during account upsert");
+    const result: UpsertResult | undefined = existing
+      ? (await updateAccounts(user, [body as PartialAccount]))[0]
+      : await createAccount(user, body as CreatableAccount);
+
+    // 200 is the only status that means a row was written. 304 (no row matched)
+    // and 404 (zero row count) both mean the write silently did nothing.
+    if (!result || result.status !== 200) {
+      throw new Error(`Account write did not persist, status ${result?.status ?? "missing"}`);
     }
     const account_id = result.update._id;
     if (!account_id) throw new Error("Account ID is missing after upsert");
     return { status: "success", body: { account_id } };
   } catch (error: unknown) {
-    logger.error("Failed to update account", { accountId: idResult.data }, error);
+    logger.error("Failed to write account", { accountId: idResult.data }, error);
     throw error instanceof Error ? error : new Error(String(error));
   }
 });

--- a/src/server/routes/accounts/post-account.ts
+++ b/src/server/routes/accounts/post-account.ts
@@ -1,8 +1,7 @@
-import { ItemProvider } from "common";
+import { ItemProvider, isUndefined } from "common";
 import {
   Route,
   createAccount,
-  getAccount,
   getItem,
   updateAccounts,
   requireBodyObject,
@@ -33,12 +32,16 @@ export const postAccountRoute = new Route<AccountPostResponse>("POST", "/account
   const idResult = requireStringField(body, "account_id");
   if (!idResult.success) return validationError(idResult.error!);
 
-  const existing = await getAccount(user, idResult.data!);
+  // A create posts a whole Account, `item_id` included; an edit posts only the
+  // fields it changes and never carries one. Reading the row back to classify
+  // the request instead would put an extra statement on every edit.
+  const isCreate = !isUndefined(body.item_id);
 
-  if (!existing) {
+  if (isCreate) {
     const itemIdResult = requireStringField(body, "item_id");
     if (!itemIdResult.success) return validationError(itemIdResult.error!);
 
+    // institution_id is NOT NULL, so an INSERT needs it up front.
     const institutionIdResult = requireStringField(body, "institution_id");
     if (!institutionIdResult.success) return validationError(institutionIdResult.error!);
 
@@ -59,18 +62,25 @@ export const postAccountRoute = new Route<AccountPostResponse>("POST", "/account
   }
 
   try {
-    const result: UpsertResult | undefined = existing
-      ? (await updateAccounts(user, [body as PartialAccount]))[0]
-      : await createAccount(user, body as CreatableAccount);
+    const result: UpsertResult | undefined = isCreate
+      ? await createAccount(user, body as CreatableAccount)
+      : (await updateAccounts(user, [body as PartialAccount]))[0];
 
-    // 200 is the only status that means a row was written. 304 (no row matched)
-    // and 404 (zero row count) both mean the write silently did nothing.
-    if (!result || result.status !== 200) {
-      throw new Error(`Account write did not persist, status ${result?.status ?? "missing"}`);
+    switch (result?.status) {
+      case 200: {
+        const account_id = result.update._id;
+        if (!account_id) throw new Error("Account ID is missing after write");
+        return { status: "success", body: { account_id } };
+      }
+      case 304:
+        // The UPDATE matched no row: the account is gone, or was never the
+        // requesting user's.
+        return { status: "failed", message: "Account not found." };
+      case 409:
+        return { status: "failed", message: "Account already exists." };
+      default:
+        throw new Error(`Account write did not persist, status ${result?.status ?? "missing"}`);
     }
-    const account_id = result.update._id;
-    if (!account_id) throw new Error("Account ID is missing after upsert");
-    return { status: "success", body: { account_id } };
   } catch (error: unknown) {
     logger.error("Failed to write account", { accountId: idResult.data }, error);
     throw error instanceof Error ? error : new Error(String(error));


### PR DESCRIPTION
Closes #668

## Problem

`POST /api/account` served both the create and the edit path through `updateAccounts`, which is UPDATE-only. For an `account_id` that does not exist yet the UPDATE matched no row, `Table.update` returned `null`, and the repo mapped that to `noChangeResult` — status **304**. The route's guard was `status >= 400`, so 304 sailed through and the route returned `{"status":"success"}` with the id the client had sent, echoed back rather than read from a written row.

The client (`ConnectionProperties`) treats that as real: it inserts the `Account` into `data.accounts` and writes it to IndexedDB. The row is visibly there until the next cold load, then vanishes.

Because `POST /public-token?provider=manual` creates the manual item with zero accounts, **Add Account** was the only affordance for creating one — so manual accounts were unreachable end-to-end on a fresh deployment, and every downstream manual-account feature (manual snapshots, manual cash/investment transactions, manual holdings) inherited the block.

## Change

`src/server/routes/accounts/post-account.ts`

- Read the account first (`getAccount`, already user-scoped) and branch:
  - **exists** → the UPDATE path, unchanged.
  - **does not exist** → the new create path.
- Create path validates `item_id` and `institution_id` (both `NOT NULL` in the accounts schema, so an INSERT needs them up front), then verifies via `getItem` that the item belongs to the requesting user and that `item.provider === ItemProvider.MANUAL`. Same guard pair `DELETE /account` already uses. An upsert cannot be used to mint accounts under a Plaid item.
- Persistence guard tightened from `status >= 400` to `status !== 200`. 200 is the only status that means a row was written; 304 (no row matched) and 404 (zero row count) are now reported as failures instead of success.

`src/server/lib/postgres/repositories/accounts.ts`

- New `createAccount(user, account)` using `accountsTable.insert`. Deliberately **not** `accountsTable.upsert`: that `ON CONFLICT` clause carries no `user_id` guard, so a caller supplying an `account_id` owned by another user would overwrite their row. An INSERT raises a unique violation instead, reported as an error result.
- New `CreatableAccount` type pinning the two `NOT NULL` columns.

No client change. The client's existing `else` branch already declines to insert the row when the route reports failure, so the ghost row is gone once the server stops lying.

## Test plan

**Unit / route** — `src/server/routes/accounts/post-account.test.ts` (new, 13 tests) drives the route through `.execute` with a FakePool intercepting `pg`, so the statement the route actually issues is asserted, not just the repo's return value:

- create path issues `INSERT INTO accounts` and **no** `UPDATE accounts`; binds account_id / user_id / item_id
- create path reports failure, not success, when the insert writes no row
- create rejected when the item is not the user's (`getItem` → null)
- create rejected when the item's provider is not `manual`
- create rejected with a missing `item_id` / missing `institution_id`, before any INSERT
- item-ownership lookup is bound to the requesting user
- update path issues `UPDATE accounts` and **no** INSERT, and does not consult the items table at all
- update path reports failure when the UPDATE matches no row
- unauthenticated / non-object body / missing account_id all reject before touching the DB

`src/server/lib/postgres/repositories/accounts.test.ts` (5 new tests) pin `createAccount`: the SQL is an INSERT with no `ON CONFLICT`, the user's id and the account's id are bound, and a no-row return or a unique violation both surface as error results.

**Mutation-verified** — the new tests are non-vacuous:
- reverting the route to the pre-fix shape (always `updateAccounts`, guard `status >= 400`) fails exactly 3 tests: `inserts a row for an account_id that does not exist yet`, `reports failure — not success — when the insert writes no row`, `reports failure when the update matches no row`.
- deleting both ownership guards fails exactly 3 tests: `rejects a create against an item the user does not own`, `rejects a create against a non-manual item`, `scopes the ownership lookup to the requesting user`.

**CI-level** — `bun run typecheck` clean, `bun run lint` clean, full suite 1146 pass / 2 skip / 0 fail.

**E2E** — full sandbox drive on the head commit, results below.

---

## E2E — sandbox `budget-pr-670`, commit `d159282`, 390×844

Driven with real UI clicks throughout for anything with an affordance: login → `.Header .hamburger a` → Config → **See Manual Accounts** → connection-detail → **See Details**. `page.goto(BASE)` is used only as the app entry URL for reload steps, never to deep-link a feature surface.

An earlier sweep ran against `01ac67d` and found two problems. The intent-based restructure was expected to close both, so the sandbox was **torn down and rebuilt on `d159282`** and each expectation was re-driven rather than reasoned about.

### The two earlier findings — both verified closed

**Was MED: the UPDATE branch validated neither `item_id` nor `institution_id`.** On `01ac67d`, POSTing an existing `account_id` alongside a bogus `item_id` and `institution_id` returned `success` and **persisted both**, orphaning the account from its item.

On `d159282` (API-driven — no UI affordance posts this shape):

```
POST /api/account {account_id: <existing>, item_id: "does-not-exist-xyz", institution_id: "bogus-inst"}
→ 200 {"status":"failed","message":"Item not found."}
```

The body carries `item_id`, so it is read as a create, and the ownership check rejects it before any write. SQL before/after on that row: `item_id`, `institution_id`, `name`, `custom_name`, `type`, `is_deleted` **and the `updated` timestamp** are byte-identical — no write reached the row at all.

**Was LOW: a primary-key collision returned HTTP 500.** Reachable because `deleteAccounts` soft-deletes, so the PK row survives and is invisible to a create.

```
POST /api/account {account_id: <soft-deleted row>, item_id: <manual>, institution_id: "Unknown", …}
→ 200 {"status":"failed","message":"Account already exists."}
```

Not a 500. The soft-deleted row was not overwritten (name / type / `is_deleted` / `updated` all unchanged). Server log for that exact request: `INFO`, status 200 — **zero** `Route handler error`, zero `Failed to create account`, zero alarm lines across the whole E2E window. That is the point of the med fix: the security defense working as designed no longer pages.

Also driven against a **live** primary key (not just a soft-deleted one): same `Account already exists.`, row byte-identical, no error log.

### New behaviours from the restructure

**Edit of a vanished row** — `{account_id: "ghost-row-e2e-670", custom_name: "Ghost"}`, no `item_id`:

```
→ 200 {"status":"failed","message":"Account not found."}
```

Not a missing-`item_id` validation error, not a 500, and no row created.

**Edit path issues one statement, with no existence probe.** Verified with real Postgres statement logging (`log_statement='all'` on the running sandbox DB, confirmed picked up by an existing backend), then a single UI rename. Statements captured for that request:

```
SELECT * FROM sessions WHERE session_id = $1 LIMIT $2          ← auth middleware
UPDATE accounts SET updated = CURRENT_TIMESTAMP, custom_name = $1
  WHERE account_id = $2 AND user_id = $3 RETURNING account_id  ← the only accounts statement
INSERT INTO sessions (…) ON CONFLICT (session_id) DO UPDATE …  ← session touch
```

Exactly one statement against `accounts`, and **zero** `SELECT`s against it. Logging was reverted (`ALTER SYSTEM RESET` + reload; `pg_settings.source` back to `default`) after ~90s, with no backends terminated.

### Core fix — create persists across a cold reload

| step | rendered rows |
|---|---|
| baseline | 6 |
| after **Add Account** click | 7 — new row renders immediately (Name `Unknown`, Type `Other`, own `See Details`), so the client `setData` updater did not throw |
| after full cold reload + re-driving the **entire** click chain | 7 |
| ×3 consecutive cold reloads | 7 / 7 / 7 |
| after logout → re-login → full chain | 7 |

Wire: `POST /api/account → 200 {"status":"success","body":{"account_id":"809c7"}}`.

SQL: accounts **21 → 22** total (20 → 21 live); the generated id exists **exactly once**, owned by the logged-in admin's `user_id`, with `item_id` = the manual item. The new account also lists on the Accounts page under Manual.

### Edit path not regressed

- **New row** — renamed via the Name input (debounced), persisted through a cold reload in both DOM and DB.
- **Pre-existing row** — renamed, persisted through a cold reload, then **restored** to its original name (verified in DOM and SQL).
- **Type select** — `other → depository`, persisted through a cold reload, then restored.
- **Same-value rename** — still returns `success`. The `UPDATE … RETURNING` matches the row regardless of whether the value changed, so the new 304 branch does **not** misfire as a false `Account not found.`

### Both create guards still fire

| request | response | rows inserted |
|---|---|---|
| nonexistent `item_id` | `failed` — `Item not found.` | 0 |
| **plaid** `item_id` | `failed` — `Account is not a manual account.` | 0 |
| manual `item_id`, no `institution_id` | `failed` — `Missing required field: institution_id` | 0 |

`accounts` total stayed at 22 across all three.

### Console / page errors

Zero `pageerror` across every drive. Two `console.error` classes, both pre-existing and outside this diff: the `sw.js` service-worker registration failure, and `ERR_INCOMPLETE_CHUNKED_ENCODING` every ~12s from the SSE `idleTimeout` issue (#669). Neither appeared inside a mutation window.

### Wording clarification

The 409 conflict and the 304 no-change both reach the client as **HTTP 200 with a body-level `{"status":"failed"}`** — the app's existing convention for every failed response. `conflictResult`'s 409 is an internal `UpsertResult` status the route maps to a message; it is not an HTTP 409 on the wire.

### Not verified — stated rather than glossed

- **Cross-user primary-key collision.** The docstring's motivating threat (a create whose `account_id` belongs to a *different* user) could not be driven end to end: the clone's second user owns zero accounts and its password isn't available. The INSERT/23505 mechanism was exercised twice same-user — against a soft-deleted PK and a live PK — and neither touched the row, but the literal cross-user path is untested.
- **No simple_fin item exists in the clone** (manual + plaid only), so the non-manual guard was proven against plaid only.
- **Statement count is an absolute measurement on `d159282`**, not a before/after delta against `01ac67d`.
- Chromium headless only; no real iOS Safari.

### Follow-ups filed, not folded in

- #671 — unvalidated body fields reach Postgres, so a client type error becomes a 500 and fires the global alarm (the 22P02 half of the med).
- #672 — `onChangeTypeInput` guards an account type against the budget-id label (wrong predicate, spotted while driving the type select).
- #673 — on a short account-detail page, the Delete button renders behind the fixed bottom navigator on first paint. Pre-existing layout, but this PR is what makes short manual-account detail pages routinely reachable.

### Sandbox state

One extra live account remains (`809c7`, type `other`, zero balance, `custom_name` "E2E test row (PR 670)"), left deliberately as visible evidence of the fix. Everything else touched was restored and verified byte-identical.
