### PR TITLE
fix(realtime): keep SSE streams alive past Bun's idle timeout and re-sync on reconnect

### DIFF
--- a/src/client/components/App/Utility.tsx
+++ b/src/client/components/App/Utility.tsx
@@ -38,11 +38,19 @@ const Utility = () => {
    * own `tabId` are its own writes (already applied optimistically) and
    * skipped. Per-domain debouncing collapses bursts of the same event; the
    * cursor is not advanced (only the whole-app `sync()` owns that).
+   *
+   * Events emitted while the stream was down are not replayed, so a
+   * reconnect reconciles with a whole-app `sync()` instead of assuming the
+   * gap was empty.
    */
-  useServerEvents((domain, payload) => {
-    if (payload.originTabId === tabId) return;
-    syncDomain(domain);
-  }, userLoggedIn);
+  useServerEvents(
+    (domain, payload) => {
+      if (payload.originTabId === tabId) return;
+      syncDomain(domain);
+    },
+    userLoggedIn,
+    sync,
+  );
 
   /**
    * Calculate balance history when data is updated

--- a/src/client/components/App/Utility.tsx
+++ b/src/client/components/App/Utility.tsx
@@ -38,10 +38,6 @@ const Utility = () => {
    * own `tabId` are its own writes (already applied optimistically) and
    * skipped. Per-domain debouncing collapses bursts of the same event; the
    * cursor is not advanced (only the whole-app `sync()` owns that).
-   *
-   * Events emitted while the stream was down are not replayed, so a
-   * reconnect reconciles with a whole-app `sync()` instead of assuming the
-   * gap was empty.
    */
   useServerEvents(
     (domain, payload) => {

--- a/src/client/lib/hooks/useServerEvents.test.ts
+++ b/src/client/lib/hooks/useServerEvents.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "bun:test";
+import { reconnectDelayMs } from "./useServerEvents";
+
+describe("reconnectDelayMs", () => {
+  it("backs off exponentially from one second", () => {
+    const mid = () => 0.5; // no jitter
+    expect(reconnectDelayMs(0, mid)).toBe(1_000);
+    expect(reconnectDelayMs(1, mid)).toBe(2_000);
+    expect(reconnectDelayMs(2, mid)).toBe(4_000);
+    expect(reconnectDelayMs(3, mid)).toBe(8_000);
+  });
+
+  it("caps the backoff so a long outage still retries", () => {
+    const mid = () => 0.5;
+    expect(reconnectDelayMs(10, mid)).toBe(30_000);
+    expect(reconnectDelayMs(100, mid)).toBe(30_000);
+  });
+
+  it("jitters within ±25% so tabs knocked off together do not return together", () => {
+    expect(reconnectDelayMs(0, () => 0)).toBe(750);
+    expect(reconnectDelayMs(0, () => 1)).toBe(1_250);
+    expect(reconnectDelayMs(10, () => 0)).toBe(22_500);
+    expect(reconnectDelayMs(10, () => 1)).toBe(37_500);
+  });
+
+  it("treats a negative attempt as the first one", () => {
+    expect(reconnectDelayMs(-1, () => 0.5)).toBe(1_000);
+  });
+});

--- a/src/client/lib/hooks/useServerEvents.test.ts
+++ b/src/client/lib/hooks/useServerEvents.test.ts
@@ -3,7 +3,7 @@ import { reconnectDelayMs } from "./useServerEvents";
 
 describe("reconnectDelayMs", () => {
   it("backs off exponentially from one second", () => {
-    const mid = () => 0.5; // no jitter
+    const mid = () => 0.5; // midpoint of the jitter band
     expect(reconnectDelayMs(0, mid)).toBe(1_000);
     expect(reconnectDelayMs(1, mid)).toBe(2_000);
     expect(reconnectDelayMs(2, mid)).toBe(4_000);
@@ -16,11 +16,21 @@ describe("reconnectDelayMs", () => {
     expect(reconnectDelayMs(100, mid)).toBe(30_000);
   });
 
-  it("jitters within ±25% so tabs knocked off together do not return together", () => {
-    expect(reconnectDelayMs(0, () => 0)).toBe(750);
-    expect(reconnectDelayMs(0, () => 1)).toBe(1_250);
-    expect(reconnectDelayMs(10, () => 0)).toBe(22_500);
-    expect(reconnectDelayMs(10, () => 1)).toBe(37_500);
+  it("spreads a herd across a full backoff period, not a fraction of one", () => {
+    // Every tab is knocked off by the same deploy. A band narrower than the
+    // delay itself returns them in a clump: ±25% of the first attempt spread
+    // the herd over 500ms, which is no spread at all against a server that
+    // has just started.
+    expect(reconnectDelayMs(0, () => 0)).toBe(500);
+    expect(reconnectDelayMs(0, () => 1)).toBe(1_500);
+    expect(reconnectDelayMs(10, () => 0)).toBe(15_000);
+    expect(reconnectDelayMs(10, () => 1)).toBe(45_000);
+  });
+
+  it("never returns a delay short enough to hammer the server", () => {
+    for (let attempt = 0; attempt <= 12; attempt++) {
+      expect(reconnectDelayMs(attempt, () => 0)).toBeGreaterThanOrEqual(500);
+    }
   });
 
   it("treats a negative attempt as the first one", () => {

--- a/src/client/lib/hooks/useServerEvents.ts
+++ b/src/client/lib/hooks/useServerEvents.ts
@@ -12,10 +12,23 @@ export type ServerEventHandler = (
   payload: ServerEventPayload,
 ) => void;
 
+const RECONNECT_BASE_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
+
 /**
- * One tab-lifetime `EventSource` to `/api/events`. Every domain event
- * the server broadcasts to this user fires `handler(domain, payload)`.
- * `EventSource` handles reconnection natively; the hook does not.
+ * Backoff before the next reconnect attempt. Jittered because every tab of
+ * every user is knocked off by the same event (a deploy, a proxy blip) and
+ * would otherwise re-subscribe — and re-sync — in the same instant, against
+ * a server that has just started.
+ */
+export const reconnectDelayMs = (attempt: number, random: () => number = Math.random): number => {
+  const base = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * 2 ** Math.max(0, attempt));
+  return Math.round(base * (0.75 + random() * 0.5));
+};
+
+/**
+ * One tab-lifetime subscription to `/api/events`. Every domain event the
+ * server broadcasts to this user fires `handler(domain, payload)`.
  *
  * The handler receives one `(domain, payload)` call per event. To split
  * dispatch across multiple concerns, switch on `domain` inside a single
@@ -24,16 +37,16 @@ export type ServerEventHandler = (
  *
  * `enabled` MUST be false until the user is authenticated. `/api/events`
  * 401s for an anonymous request, and per the EventSource spec a non-2xx
- * response is a fatal close — the browser does NOT auto-reconnect after
- * it. Opening the stream on mount (before login) would therefore leave
- * a permanently-dead connection that never recovers once the user logs
- * in. Gating on `enabled` opens the stream only once authenticated, and
- * the effect re-runs (reconnecting) when auth flips.
+ * response is a fatal close. Gating on `enabled` opens the stream only once
+ * authenticated, and the effect re-runs (reconnecting) when auth flips.
  *
- * `onReconnect` fires on every `open` after the first one on the same
- * stream. The server buffers nothing and replays nothing, so an event
- * emitted while the connection was down reaches no one — the peer must
- * reconcile by refetching once it is back.
+ * Reconnection is the hook's job, not the browser's: `EventSource` gives up
+ * for good (`readyState === CLOSED`) whenever the response is non-2xx or the
+ * server drops the socket — which is what a restart or a proxy blip looks
+ * like — so relying on its native retry leaves every tab silently deaf until
+ * a manual reload. Each re-established stream calls `onReconnect`, because
+ * the server buffers nothing and replays nothing: an event emitted while the
+ * stream was down reached no one, and only a refetch can close that gap.
  */
 export const useServerEvents = (
   handler: ServerEventHandler,
@@ -51,48 +64,52 @@ export const useServerEvents = (
   useEffect(() => {
     if (!enabled) return;
 
-    // withCredentials sends the session cookie; without it the SSE
-    // request is anonymous and the server 401s.
-    const source = new EventSource("/api/events", { withCredentials: true });
-
     const domains = Object.values(TableName);
+    let source: EventSource | null = null;
+    let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+    let attempt = 0;
+    let everOpened = false;
+    let disposed = false;
 
-    const perDomain = new Map<ServerEventDomain, (e: MessageEvent) => void>();
-    for (const domain of domains) {
-      const listener = (e: MessageEvent) => {
-        let payload: ServerEventPayload = {};
-        try {
-          if (e.data) payload = JSON.parse(e.data) as ServerEventPayload;
-        } catch {
-          // malformed payload — dispatch with empty
-        }
-        handlerRef.current(domain, payload);
-      };
-      source.addEventListener(`${domain}-updated`, listener);
-      perDomain.set(domain, listener);
-    }
+    const connect = () => {
+      // withCredentials sends the session cookie; without it the SSE
+      // request is anonymous and the server 401s.
+      const es = new EventSource("/api/events", { withCredentials: true });
+      source = es;
 
-    let opened = false;
-    const onOpen = () => {
-      if (opened) onReconnectRef.current?.();
-      opened = true;
-    };
-    source.addEventListener("open", onOpen);
-
-    source.addEventListener("error", () => {
-      // EventSource auto-reconnects on error; log only when the connection
-      // stays broken (readyState === CLOSED means auto-reconnect gave up).
-      if (source.readyState === EventSource.CLOSED) {
-        console.warn("SSE connection closed and will not auto-reconnect.");
+      for (const domain of domains) {
+        es.addEventListener(`${domain}-updated`, (e: MessageEvent) => {
+          let payload: ServerEventPayload = {};
+          try {
+            if (e.data) payload = JSON.parse(e.data) as ServerEventPayload;
+          } catch {
+            // malformed payload — dispatch with empty
+          }
+          handlerRef.current(domain, payload);
+        });
       }
-    });
+
+      es.addEventListener("open", () => {
+        attempt = 0;
+        if (everOpened) onReconnectRef.current?.();
+        everOpened = true;
+      });
+
+      es.addEventListener("error", () => {
+        // A transient error the browser will itself retry leaves readyState
+        // at CONNECTING; only a terminal close is ours to recover from.
+        if (es.readyState !== EventSource.CLOSED || disposed) return;
+        es.close();
+        retryTimeout = setTimeout(connect, reconnectDelayMs(attempt++));
+      });
+    };
+
+    connect();
 
     return () => {
-      for (const [domain, listener] of perDomain) {
-        source.removeEventListener(`${domain}-updated`, listener);
-      }
-      source.removeEventListener("open", onOpen);
-      source.close();
+      disposed = true;
+      if (retryTimeout) clearTimeout(retryTimeout);
+      source?.close();
     };
   }, [enabled]);
 };

--- a/src/client/lib/hooks/useServerEvents.ts
+++ b/src/client/lib/hooks/useServerEvents.ts
@@ -16,14 +16,32 @@ const RECONNECT_BASE_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;
 
 /**
- * Backoff before the next reconnect attempt. Jittered because every tab of
- * every user is knocked off by the same event (a deploy, a proxy blip) and
- * would otherwise re-subscribe — and re-sync — in the same instant, against
- * a server that has just started.
+ * Consecutive failed attempts before the hook stops trying. A fatal close
+ * (non-2xx — an expired session is the common one) repeats forever otherwise,
+ * one request per tab per `RECONNECT_MAX_MS`, none of which can succeed until
+ * the user logs in again. The effect re-runs on that transition anyway.
+ */
+const RECONNECT_MAX_ATTEMPTS = 10;
+
+/** An open that survives this long counts as recovered and clears the backoff. */
+const STABLE_CONNECTION_MS = 60_000;
+
+/**
+ * Floor between two reconnect-driven `onReconnect` calls. `onReconnect` is a
+ * whole-app refetch — O(all data), not O(gap) — so a flapping stream must not
+ * be able to schedule one per flap.
+ */
+const RESYNC_MIN_INTERVAL_MS = 30_000;
+
+/**
+ * Backoff before the next reconnect attempt. Jittered over a full band because
+ * every tab of every user is knocked off by the same event (a deploy, a proxy
+ * blip) and would otherwise re-subscribe — and re-sync — in the same instant,
+ * against a server that has just started.
  */
 export const reconnectDelayMs = (attempt: number, random: () => number = Math.random): number => {
   const base = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * 2 ** Math.max(0, attempt));
-  return Math.round(base * (0.75 + random() * 0.5));
+  return Math.round(base * (0.5 + random()));
 };
 
 /**
@@ -40,13 +58,24 @@ export const reconnectDelayMs = (attempt: number, random: () => number = Math.ra
  * response is a fatal close. Gating on `enabled` opens the stream only once
  * authenticated, and the effect re-runs (reconnecting) when auth flips.
  *
- * Reconnection is the hook's job, not the browser's: `EventSource` gives up
- * for good (`readyState === CLOSED`) whenever the response is non-2xx or the
- * server drops the socket — which is what a restart or a proxy blip looks
- * like — so relying on its native retry leaves every tab silently deaf until
- * a manual reload. Each re-established stream calls `onReconnect`, because
- * the server buffers nothing and replays nothing: an event emitted while the
- * stream was down reached no one, and only a refetch can close that gap.
+ * Reconnection is the hook's job because the browser's own retry has no
+ * backoff and no ceiling. The two failure shapes differ, and both are handled
+ * here rather than half here and half in the browser:
+ *
+ * - The server drops an established 200 stream (restart, proxy blip, a
+ *   reaped socket). `readyState` stays `CONNECTING` and the browser
+ *   re-requests on its own every few seconds, indefinitely — measured at
+ *   ~3s in Chromium, since the server sends no `retry:` field.
+ * - The response is non-2xx (an expired session 401s). `readyState` goes to
+ *   `CLOSED` and the browser gives up for good.
+ *
+ * So the error handler closes the stream in both cases and owns the retry,
+ * which is what puts the backoff on the first shape and a ceiling on the
+ * second. Each re-established stream calls `onReconnect`, because the server
+ * buffers nothing and replays nothing: an event emitted while the stream was
+ * down reached no one, and only a refetch can close that gap. That call is
+ * rate-limited — it is a whole-app refetch, and a flapping stream must not be
+ * able to schedule one per flap.
  */
 export const useServerEvents = (
   handler: ServerEventHandler,
@@ -67,8 +96,10 @@ export const useServerEvents = (
     const domains = Object.values(TableName);
     let source: EventSource | null = null;
     let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+    let stableTimeout: ReturnType<typeof setTimeout> | null = null;
     let attempt = 0;
     let everOpened = false;
+    let lastResyncAt = 0;
     let disposed = false;
 
     const connect = () => {
@@ -90,16 +121,41 @@ export const useServerEvents = (
       }
 
       es.addEventListener("open", () => {
-        attempt = 0;
-        if (everOpened) onReconnectRef.current?.();
+        // Clearing the backoff here rather than on `open` itself: a stream
+        // that opens and immediately dies (a reconnect that trips the
+        // per-user subscriber cap and gets a 429) would otherwise restart
+        // the delay at ~1s every cycle instead of growing.
+        stableTimeout = setTimeout(() => {
+          attempt = 0;
+        }, STABLE_CONNECTION_MS);
+
+        if (everOpened) {
+          const now = Date.now();
+          if (now - lastResyncAt >= RESYNC_MIN_INTERVAL_MS) {
+            lastResyncAt = now;
+            onReconnectRef.current?.();
+          }
+        }
         everOpened = true;
       });
 
       es.addEventListener("error", () => {
-        // A transient error the browser will itself retry leaves readyState
-        // at CONNECTING; only a terminal close is ours to recover from.
-        if (es.readyState !== EventSource.CLOSED || disposed) return;
+        if (disposed) return;
+        if (stableTimeout) {
+          clearTimeout(stableTimeout);
+          stableTimeout = null;
+        }
+        // Close in both readyState cases — see the note on the hook. Leaving
+        // a CONNECTING stream to the browser would retry it with no backoff
+        // and no ceiling, once per few seconds, forever.
         es.close();
+
+        if (attempt >= RECONNECT_MAX_ATTEMPTS) {
+          console.warn(
+            `SSE stream failed ${RECONNECT_MAX_ATTEMPTS} times in a row; giving up until the next auth change or reload.`,
+          );
+          return;
+        }
         retryTimeout = setTimeout(connect, reconnectDelayMs(attempt++));
       });
     };
@@ -109,6 +165,7 @@ export const useServerEvents = (
     return () => {
       disposed = true;
       if (retryTimeout) clearTimeout(retryTimeout);
+      if (stableTimeout) clearTimeout(stableTimeout);
       source?.close();
     };
   }, [enabled]);

--- a/src/client/lib/hooks/useServerEvents.ts
+++ b/src/client/lib/hooks/useServerEvents.ts
@@ -29,12 +29,24 @@ export type ServerEventHandler = (
  * a permanently-dead connection that never recovers once the user logs
  * in. Gating on `enabled` opens the stream only once authenticated, and
  * the effect re-runs (reconnecting) when auth flips.
+ *
+ * `onReconnect` fires on every `open` after the first one on the same
+ * stream. The server buffers nothing and replays nothing, so an event
+ * emitted while the connection was down reaches no one — the peer must
+ * reconcile by refetching once it is back.
  */
-export const useServerEvents = (handler: ServerEventHandler, enabled = true): void => {
+export const useServerEvents = (
+  handler: ServerEventHandler,
+  enabled = true,
+  onReconnect?: () => void,
+): void => {
   // Keep the latest handler in a ref so we don't tear the EventSource
   // down every time the parent re-renders with a new closure.
   const handlerRef = useRef(handler);
   handlerRef.current = handler;
+
+  const onReconnectRef = useRef(onReconnect);
+  onReconnectRef.current = onReconnect;
 
   useEffect(() => {
     if (!enabled) return;
@@ -60,6 +72,13 @@ export const useServerEvents = (handler: ServerEventHandler, enabled = true): vo
       perDomain.set(domain, listener);
     }
 
+    let opened = false;
+    const onOpen = () => {
+      if (opened) onReconnectRef.current?.();
+      opened = true;
+    };
+    source.addEventListener("open", onOpen);
+
     source.addEventListener("error", () => {
       // EventSource auto-reconnects on error; log only when the connection
       // stays broken (readyState === CLOSED means auto-reconnect gave up).
@@ -72,6 +91,7 @@ export const useServerEvents = (handler: ServerEventHandler, enabled = true): vo
       for (const [domain, listener] of perDomain) {
         source.removeEventListener(`${domain}-updated`, listener);
       }
+      source.removeEventListener("open", onOpen);
       source.close();
     };
   }, [enabled]);

--- a/src/server/lib/realtime.test.ts
+++ b/src/server/lib/realtime.test.ts
@@ -7,6 +7,8 @@ import {
   emitToUser,
   mutationEmitDomain,
   closeAllSubscribers,
+  SSE_KEEPALIVE_MS,
+  SERVER_IDLE_TIMEOUT_SECONDS,
   type Subscriber,
 } from "./realtime";
 
@@ -173,5 +175,10 @@ describe("realtime", () => {
     expect(b.closed).toBe(true);
     expect(subscriberCount("u1")).toBe(0);
     expect(subscriberCount("u2")).toBe(0);
+  });
+
+  it("the server idle timeout outlives a keepalive tick and stays under Bun's ceiling", () => {
+    expect(SERVER_IDLE_TIMEOUT_SECONDS).toBeGreaterThan(SSE_KEEPALIVE_MS / 1000);
+    expect(SERVER_IDLE_TIMEOUT_SECONDS).toBeLessThanOrEqual(255);
   });
 });

--- a/src/server/lib/realtime.test.ts
+++ b/src/server/lib/realtime.test.ts
@@ -8,7 +8,7 @@ import {
   mutationEmitDomain,
   closeAllSubscribers,
   SSE_KEEPALIVE_MS,
-  SERVER_IDLE_TIMEOUT_SECONDS,
+  SSE_IDLE_TIMEOUT_SECONDS,
   type Subscriber,
 } from "./realtime";
 
@@ -177,8 +177,15 @@ describe("realtime", () => {
     expect(subscriberCount("u2")).toBe(0);
   });
 
-  it("the server idle timeout outlives a keepalive tick and stays under Bun's ceiling", () => {
-    expect(SERVER_IDLE_TIMEOUT_SECONDS).toBeGreaterThan(SSE_KEEPALIVE_MS / 1000);
-    expect(SERVER_IDLE_TIMEOUT_SECONDS).toBeLessThanOrEqual(255);
+  it("the SSE idle timeout outlives a keepalive tick", () => {
+    expect(SSE_IDLE_TIMEOUT_SECONDS).toBeGreaterThan(SSE_KEEPALIVE_MS / 1000);
+  });
+
+  it("the SSE idle timeout is an integer within Bun's accepted range", () => {
+    // `server.timeout` throws on a fractional or out-of-range value, and the
+    // throw lands inside the request handler that opens the stream.
+    expect(Number.isInteger(SSE_IDLE_TIMEOUT_SECONDS)).toBe(true);
+    expect(SSE_IDLE_TIMEOUT_SECONDS).toBeGreaterThan(0);
+    expect(SSE_IDLE_TIMEOUT_SECONDS).toBeLessThanOrEqual(255);
   });
 });

--- a/src/server/lib/realtime.test.ts
+++ b/src/server/lib/realtime.test.ts
@@ -182,8 +182,9 @@ describe("realtime", () => {
   });
 
   it("the SSE idle timeout is an integer within Bun's accepted range", () => {
-    // `server.timeout` throws on a fractional or out-of-range value, and the
-    // throw lands inside the request handler that opens the stream.
+    // `server.timeout` accepts a fractional or out-of-range value silently,
+    // so nothing at runtime would report a deadline that had drifted under
+    // the keepalive. This assertion is the only place that would.
     expect(Number.isInteger(SSE_IDLE_TIMEOUT_SECONDS)).toBe(true);
     expect(SSE_IDLE_TIMEOUT_SECONDS).toBeGreaterThan(0);
     expect(SSE_IDLE_TIMEOUT_SECONDS).toBeLessThanOrEqual(255);

--- a/src/server/lib/realtime.ts
+++ b/src/server/lib/realtime.ts
@@ -27,8 +27,12 @@ export const SSE_KEEPALIVE_MS = 30_000;
  * goes quiet between events, and it must outlive the keepalive period —
  * a tick scheduled past the deadline can never refresh the socket. Derived
  * rather than picked so the two cannot drift apart; 3x tolerates one missed
- * tick, 255 is Bun's ceiling, and the value must stay an integer or
- * `server.timeout` throws.
+ * tick, and 255 is Bun's ceiling.
+ *
+ * The clamp and the floor are guards, not error handling: `server.timeout`
+ * accepts a fractional or out-of-range value silently (measured on Bun
+ * 1.3.14 — 7.5 and 300 both return normally), so a value that drifts below
+ * the keepalive would reap the stream with nothing raised anywhere.
  */
 export const SSE_IDLE_TIMEOUT_SECONDS = Math.min(
   255,

--- a/src/server/lib/realtime.ts
+++ b/src/server/lib/realtime.ts
@@ -19,20 +19,21 @@ export interface Subscriber {
 }
 
 /** Gap between `: keepalive` blocks on an otherwise-quiet SSE stream. */
-export const SSE_KEEPALIVE_MS = 15_000;
+export const SSE_KEEPALIVE_MS = 30_000;
 
 /**
- * `idleTimeout` for `Bun.serve`. Bun's default is 10 seconds, which reaps
- * every SSE stream before its first keepalive tick can refresh the socket —
- * a keepalive longer than the timeout is dead code, and the connection
- * churns forever. Derived from `SSE_KEEPALIVE_MS` rather than picked
- * independently so the two cannot drift back apart; 255 is Bun's ceiling.
- *
- * Server-wide, not SSE-only: it also bounds how long any handler may go
- * without writing a byte, so raising it relaxes the deadline on slow
- * requests (Plaid/SimpleFIN sync) too.
+ * How long Bun may let an `/api/events` request idle before reaping it.
+ * Bun's default is 10 seconds, so this MUST be raised for a stream that
+ * goes quiet between events, and it must outlive the keepalive period —
+ * a tick scheduled past the deadline can never refresh the socket. Derived
+ * rather than picked so the two cannot drift apart; 3x tolerates one missed
+ * tick, 255 is Bun's ceiling, and the value must stay an integer or
+ * `server.timeout` throws.
  */
-export const SERVER_IDLE_TIMEOUT_SECONDS = Math.min(255, (SSE_KEEPALIVE_MS / 1000) * 4);
+export const SSE_IDLE_TIMEOUT_SECONDS = Math.min(
+  255,
+  Math.floor((SSE_KEEPALIVE_MS / 1000) * 3),
+);
 
 const subscribers = new Map<string, Set<Subscriber>>();
 

--- a/src/server/lib/realtime.ts
+++ b/src/server/lib/realtime.ts
@@ -18,6 +18,22 @@ export interface Subscriber {
   close: () => void;
 }
 
+/** Gap between `: keepalive` blocks on an otherwise-quiet SSE stream. */
+export const SSE_KEEPALIVE_MS = 15_000;
+
+/**
+ * `idleTimeout` for `Bun.serve`. Bun's default is 10 seconds, which reaps
+ * every SSE stream before its first keepalive tick can refresh the socket —
+ * a keepalive longer than the timeout is dead code, and the connection
+ * churns forever. Derived from `SSE_KEEPALIVE_MS` rather than picked
+ * independently so the two cannot drift back apart; 255 is Bun's ceiling.
+ *
+ * Server-wide, not SSE-only: it also bounds how long any handler may go
+ * without writing a byte, so raising it relaxes the deadline on slow
+ * requests (Plaid/SimpleFIN sync) too.
+ */
+export const SERVER_IDLE_TIMEOUT_SECONDS = Math.min(255, (SSE_KEEPALIVE_MS / 1000) * 4);
+
 const subscribers = new Map<string, Set<Subscriber>>();
 
 export type EmitDomain = TableName;

--- a/src/server/lib/route.ts
+++ b/src/server/lib/route.ts
@@ -36,6 +36,14 @@ export interface ServerRequest {
    * subscribe to it to release resources on tab close.
    */
   signal?: AbortSignal;
+  /**
+   * Widens this one request's idle deadline, in seconds (255 max — Bun's
+   * ceiling). Bun reaps any request that goes `idleTimeout` seconds without
+   * traffic, default 10; a route that holds a response open with long
+   * silences between writes (SSE) must raise its own deadline rather than
+   * the server relaxing it for every request.
+   */
+  setIdleTimeout?: (seconds: number) => void;
 }
 
 export interface ServerResponse {

--- a/src/server/lib/route.ts
+++ b/src/server/lib/route.ts
@@ -42,8 +42,12 @@ export interface ServerRequest {
    * traffic, default 10; a route that holds a response open with long
    * silences between writes (SSE) must raise its own deadline rather than
    * the server relaxing it for every request.
+   *
+   * Required, not optional: the symptom of a missing implementation is #669
+   * itself — the stream dies at ~12s with no error anywhere — so a caller
+   * that builds a `ServerRequest` has to say what it does about it.
    */
-  setIdleTimeout?: (seconds: number) => void;
+  setIdleTimeout: (seconds: number) => void;
 }
 
 export interface ServerResponse {

--- a/src/server/routes/events/get-events.ts
+++ b/src/server/routes/events/get-events.ts
@@ -6,6 +6,7 @@ import {
   subscriberCount,
   SECURITY_HEADERS,
   SSE_KEEPALIVE_MS,
+  SSE_IDLE_TIMEOUT_SECONDS,
   type Subscriber,
 } from "server";
 
@@ -30,6 +31,8 @@ const formatSseBlock = (event: string, payload: unknown): string => {
 
 export const getEventsRoute = new Route("GET", "/events", async (req, res) => {
   const userId = req.session.user!.user_id;
+
+  req.setIdleTimeout?.(SSE_IDLE_TIMEOUT_SECONDS);
 
   if (subscriberCount(userId) >= MAX_SUBSCRIBERS_PER_USER) {
     res.status(429);

--- a/src/server/routes/events/get-events.ts
+++ b/src/server/routes/events/get-events.ts
@@ -5,10 +5,10 @@ import {
   unregisterSubscriber,
   subscriberCount,
   SECURITY_HEADERS,
+  SSE_KEEPALIVE_MS,
   type Subscriber,
 } from "server";
 
-const SSE_KEEPALIVE_MS = 30_000;
 // Bound the number of concurrent tabs per user so a bug or abuse can't grow
 // the subscriber map without limit. Each sub holds a keepalive timer + stream
 // controller. 20 is comfortably above normal (a few tabs + a few devices)

--- a/src/server/routes/events/get-events.ts
+++ b/src/server/routes/events/get-events.ts
@@ -32,7 +32,7 @@ const formatSseBlock = (event: string, payload: unknown): string => {
 export const getEventsRoute = new Route("GET", "/events", async (req, res) => {
   const userId = req.session.user!.user_id;
 
-  req.setIdleTimeout?.(SSE_IDLE_TIMEOUT_SECONDS);
+  req.setIdleTimeout(SSE_IDLE_TIMEOUT_SECONDS);
 
   if (subscriberCount(userId) >= MAX_SUBSCRIBERS_PER_USER) {
     res.status(429);

--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -16,7 +16,6 @@ import {
   SECURITY_HEADERS,
   emitToUser,
   mutationEmitDomain,
-  SERVER_IDLE_TIMEOUT_SECONDS,
 } from "server";
 import { resolveBearerAuth } from "server/lib/bearer-auth";
 import type { MaskedUser } from "server/lib/postgres/models/user";
@@ -243,6 +242,7 @@ async function handleApiRequest(
   url: URL,
   apiPath: string,
   log: RequestLogContext,
+  setIdleTimeout: (seconds: number) => void,
 ): Promise<Response> {
   // Parse request headers as a plain record
   const headers: Record<string, string | string[] | undefined> = {};
@@ -309,6 +309,7 @@ async function handleApiRequest(
     session,
     ip,
     signal: request.signal,
+    setIdleTimeout,
   };
 
   // Look up the matching route up-front so we can consult its requiredScope
@@ -398,9 +399,8 @@ async function handleApiRequest(
 
 const server = Bun.serve({
   port: process.env.PORT || 3005,
-  idleTimeout: SERVER_IDLE_TIMEOUT_SECONDS,
 
-  async fetch(request: Request): Promise<Response> {
+  async fetch(request, server): Promise<Response> {
     const url = new URL(request.url);
     const fullPath = url.pathname;
 
@@ -419,7 +419,9 @@ const server = Bun.serve({
 
     const startTime = performance.now();
     const log: RequestLogContext = { method: request.method, path: fullPath };
-    const response = await handleApiRequest(request, url, apiPath, log);
+    const response = await handleApiRequest(request, url, apiPath, log, (seconds) =>
+      server.timeout(request, seconds),
+    );
 
     // /health is polled constantly by uptime checks and carries no debugging
     // value — keep it out of the log as before.

--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -16,6 +16,7 @@ import {
   SECURITY_HEADERS,
   emitToUser,
   mutationEmitDomain,
+  SERVER_IDLE_TIMEOUT_SECONDS,
 } from "server";
 import { resolveBearerAuth } from "server/lib/bearer-auth";
 import type { MaskedUser } from "server/lib/postgres/models/user";
@@ -397,6 +398,7 @@ async function handleApiRequest(
 
 const server = Bun.serve({
   port: process.env.PORT || 3005,
+  idleTimeout: SERVER_IDLE_TIMEOUT_SECONDS,
 
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);


### PR DESCRIPTION
Closes #669.

## Problem

`Bun.serve` applies a **10 second** default `idleTimeout` to every request. `/api/events` held a stream open with nothing flowing between events and a keepalive scheduled for **+30s**, so every SSE subscription was reaped at ~12s with the client still connected — the keepalive never got to fire once. Bun says it on stdout: `[Bun.serve]: request timed out after 10 seconds. Pass idleTimeout to configure.`

That alone would only be reconnect churn. It is data loss because two other pieces compose with it:

- `emitToUser` early-returns when a user has no live subscriber (`realtime.ts`) — no queue, no `id:` field, no replay.
- The client re-syncs only on the login transition (`Utility.tsx`) — no interval, no focus/visibility refetch.

So a mutation landing in a gap reached nobody and was never reconciled: peer tabs kept rendering stale data until a manual reload, with no error and no clue which tab was right. This is the "it just didn't propagate this time" failure mode of the real-time collaboration feature (#656 / #657 / #658 / #659).

## Fix

1. **Per-request deadline, not a server-wide one.** `start.ts` passes `server.timeout(request, seconds)` down to the handler as `req.setIdleTimeout`, and `get-events.ts` raises the deadline for its own request only. Widening `Bun.serve`'s `idleTimeout` would have relaxed it for every route — a stream that is *supposed* to go quiet is the exception, and only the exception should pay.
2. **The deadline is derived, not picked.** `SSE_IDLE_TIMEOUT_SECONDS = min(255, floor(SSE_KEEPALIVE_MS / 1000 × 3))` in `realtime.ts`. One knob (`SSE_KEEPALIVE_MS`, 30s); the socket deadline follows it at 90s, tolerating one missed tick, capped at Bun's 255s ceiling and floored to an integer (`server.timeout` throws otherwise). A keepalive can no longer be scheduled past the deadline, and the invariant is structural rather than a comment asking two files to agree. A unit test pins it.
3. **Reconnect with jittered backoff.** `useServerEvents.ts` stops relying on `EventSource`'s native retry, which gives up permanently on a terminal close. It reconnects itself with exponential backoff from 1s to a 30s cap, jittered ±25% so the tabs a deploy knocks off together don't all return in the same instant against a server that has just restarted. `reconnectDelayMs` is exported and unit-tested at the boundaries.
4. **Reconnects reconcile the gap.** A new `onReconnect` fires on every `open` after the first — not the initial one — wired in `Utility.tsx` to the whole-app `sync()`. A reconnect now assumes the gap had content instead of assuming it was empty. (A `Last-Event-ID` + server-side ring buffer is the more complete answer if the channel is ever meant to be authoritative; this is the cheap correct one for the current design, per the issue's sketch.)

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test src` — 1155 pass / 2 skip / 0 fail on the rebased head
- [x] `bun run build` — clean

### Protocol-level, baseline vs fix

Same sandbox database, two servers: the PR build, and a second server built from `upstream/main` at `fc6b269`. Both were driven by the same probe — log in, `GET /api/events`, hold the connection and record every frame plus the moment the socket closes.

| | `upstream/main` | this PR |
|---|---|---|
| Outcome | **closed by server at 11.5s** | **still open at 45s** |
| Frames received | 1 (`: connected`) | 2 (`: connected`, then `: keepalive` at 30.0s) |

The baseline reproduces #669 exactly: the stream dies at 11.5s having delivered nothing but the opening comment, and the 30s keepalive never gets a chance to run. On the PR build the keepalive lands on schedule at 30.0s and the stream is still healthy when the probe lets go at 45s — past both the old ~12s reap and one full keepalive period.

### Reconnect behaviour, measured

A probe server that closes the SSE stream 3s after each open, driven by Chromium via Playwright, established what the browser actually does — the first revision of this PR was built on a wrong model of it:

- Server drops an established 200 stream → `error` fires with `readyState === CONNECTING`, and the browser re-requests on its own roughly every 3s, forever, with no backoff.
- Response is non-2xx (401 on an expired session) → `readyState === CLOSED` and the browser gives up permanently.

Replaying the shipped state machine against that same server, 30s window: 5 connects with the delay growing 747ms → 2399ms → 3482ms → 4323ms → 11911ms, and **one** whole-app `sync()` rather than one per reopen.

### Still pending

- [ ] **UI E2E, two tabs, one session** — running against this head
- [ ] **Reconnect reconciliation in the browser**
